### PR TITLE
[#4] packages/shared 공용 타입/상수/이벤트 패키지

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from 'next-intl';
+import { AU, SOLAR_MASS } from '@astro-simulator/shared';
 
 export default function HomePage() {
   const t = useTranslations('app');
@@ -20,6 +21,16 @@ export default function HomePage() {
       <h1 style={{ fontSize: '2.25rem', margin: 0 }}>{t('title')}</h1>
       <p style={{ color: '#9BA3B8', margin: 0 }}>{t('subtitle')}</p>
       <p style={{ color: '#626978', fontSize: '0.875rem', margin: 0 }}>{t('scaffold')}</p>
+      <p
+        style={{
+          color: '#626978',
+          fontSize: '0.75rem',
+          margin: 0,
+          fontFamily: 'ui-monospace, monospace',
+        }}
+      >
+        AU = {AU.toExponential(3)} m · M☉ = {SOLAR_MASS.toExponential(3)} kg
+      </p>
     </main>
   );
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@astro-simulator/shared": "workspace:*",
     "next": "^16.2.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,11 @@
       "import": "./dist/ephemeris/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
@@ -47,5 +51,8 @@
   "devDependencies": {
     "typescript": "^6.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "@astro-simulator/shared": "workspace:*"
+  }
 }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,17 @@
+# @astro-simulator/shared
+
+core와 web 양쪽에서 공유하는 타입/상수/이벤트 정의.
+
+## 모듈
+
+| 서브패스 | 내용 |
+|---|---|
+| `@astro-simulator/shared/types` | DataTier, CelestialKind, CelestialBody, OrbitalElements, SimMode |
+| `@astro-simulator/shared/constants` | 물리 상수(G, c), 천문 단위(AU, ly, pc), 태양계 기본값 |
+| `@astro-simulator/shared/events` | CoreEvents 타입 맵, CoreCommand 판별식 유니온 |
+
+## 원칙
+
+- 런타임 동작 없음 — 타입과 상수만 (sideEffects: false)
+- 외부 의존성 없음
+- core/web 순환 참조 방지를 위한 중립 패키지

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@astro-simulator/shared",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared types, constants, and event definitions for astro-simulator",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./events": {
+      "types": "./dist/events/index.d.ts",
+      "import": "./dist/events/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.js"
+    },
+    "./constants": {
+      "types": "./dist/constants/index.d.ts",
+      "import": "./dist/constants/index.js"
+    }
+  },
+  "files": ["dist", "src", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "clean": "rm -rf dist .tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.0"
+  },
+  "sideEffects": false
+}

--- a/packages/shared/src/constants/astronomy.ts
+++ b/packages/shared/src/constants/astronomy.ts
@@ -1,0 +1,27 @@
+/**
+ * 천문학 거리/시간 단위 (SI 환산).
+ */
+
+/** 천문단위 [m] — IAU 2012 정의 */
+export const AU = 149_597_870_700;
+
+/** 광년 [m] */
+export const LIGHT_YEAR = 9_460_730_472_580_800;
+
+/** 파섹 [m] */
+export const PARSEC = 3.085_677_581_491_367e16;
+
+/** 킬로파섹 [m] */
+export const KILOPARSEC = 1000 * PARSEC;
+
+/** 메가파섹 [m] */
+export const MEGAPARSEC = 1_000_000 * PARSEC;
+
+/** 율리우스 년 [s] (365.25일) */
+export const JULIAN_YEAR_SECONDS = 365.25 * 86_400;
+
+/** J2000.0 epoch — Julian Date 2451545.0 (2000-01-01 12:00 TT) */
+export const J2000_JD = 2_451_545.0;
+
+/** 율리우스 세기 [일] — 36525일 */
+export const JULIAN_CENTURY_DAYS = 36_525;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,0 +1,3 @@
+export * from './physics.js';
+export * from './astronomy.js';
+export * from './solar-system.js';

--- a/packages/shared/src/constants/physics.ts
+++ b/packages/shared/src/constants/physics.ts
@@ -1,0 +1,19 @@
+/**
+ * 기본 물리 상수 (SI 단위).
+ * 출처: CODATA 2018 권장값.
+ */
+
+/** 중력 상수 G [m^3 kg^-1 s^-2] */
+export const GRAVITATIONAL_CONSTANT = 6.674_30e-11;
+
+/** 진공에서의 광속 [m/s] */
+export const SPEED_OF_LIGHT = 299_792_458;
+
+/** 플랑크 상수 [J·s] */
+export const PLANCK_CONSTANT = 6.626_070_15e-34;
+
+/** 볼츠만 상수 [J/K] */
+export const BOLTZMANN_CONSTANT = 1.380_649e-23;
+
+/** 슈테판-볼츠만 상수 [W·m^-2·K^-4] */
+export const STEFAN_BOLTZMANN_CONSTANT = 5.670_374_419e-8;

--- a/packages/shared/src/constants/solar-system.ts
+++ b/packages/shared/src/constants/solar-system.ts
@@ -1,0 +1,22 @@
+/**
+ * 태양계 기본 질량/반경 (참고용 상수).
+ * 정밀한 궤도 요소는 JPL Horizons 스냅샷 (C1, #13)에서 로드한다.
+ */
+
+/** 태양 질량 [kg] */
+export const SOLAR_MASS = 1.988_47e30;
+
+/** 태양 반경 [m] */
+export const SOLAR_RADIUS = 6.957e8;
+
+/** 지구 질량 [kg] */
+export const EARTH_MASS = 5.972_2e24;
+
+/** 지구 반경 [m] — 적도 반경 */
+export const EARTH_RADIUS = 6.378_137e6;
+
+/** 목성 질량 [kg] */
+export const JUPITER_MASS = 1.898_13e27;
+
+/** 목성 반경 [m] */
+export const JUPITER_RADIUS = 6.991_1e7;

--- a/packages/shared/src/events/core-events.ts
+++ b/packages/shared/src/events/core-events.ts
@@ -1,0 +1,45 @@
+import type { SimMode } from '../types/mode.js';
+
+/**
+ * Core → UI 이벤트 타입 맵.
+ * SimulationCore가 mitt emitter로 방출하며, UI 어댑터가 구독하여
+ * Zustand store에 전달한다.
+ */
+export type CoreEvents = {
+  /** 현재 시각이 변경됨 (Julian Date 기준) */
+  timeChanged: { julianDate: number };
+
+  /** 천체가 선택됨 */
+  bodySelected: { id: string | null };
+
+  /** 시뮬레이터 모드가 변경됨 */
+  modeChanged: { mode: SimMode };
+
+  /** 시간 속도 배율이 변경됨 (초당 시뮬 시간[s]) */
+  timeScaleChanged: { scale: number };
+
+  /** 카메라 위치 변경 (월드 좌표 [m]) */
+  cameraMoved: { position: [number, number, number]; target: [number, number, number] };
+
+  /** 프레임 성능 메트릭 (1초 단위 등) */
+  performance: { fps: number };
+
+  /** 엔진 초기화 상태 */
+  engineReady: { renderer: 'webgpu' | 'webgl2' };
+
+  /** 에러 발생 */
+  error: { message: string; cause?: unknown };
+};
+
+/**
+ * UI → Core 명령 판별식 유니온.
+ */
+export type CoreCommand =
+  | { type: 'setTimeScale'; scale: number }
+  | { type: 'play' }
+  | { type: 'pause' }
+  | { type: 'jumpToDate'; isoUtc: string }
+  | { type: 'jumpToJulianDate'; julianDate: number }
+  | { type: 'focusOn'; bodyId: string }
+  | { type: 'resetCamera' }
+  | { type: 'setMode'; mode: SimMode };

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -1,0 +1,1 @@
+export * from './core-events.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @astro-simulator/shared
+ *
+ * core와 web 양쪽에서 공유하는 타입, 상수, 이벤트 정의.
+ */
+
+export * from './types/index.js';
+export * from './constants/index.js';
+export * from './events/index.js';

--- a/packages/shared/src/types/celestial.ts
+++ b/packages/shared/src/types/celestial.ts
@@ -1,0 +1,67 @@
+import type { DataTier } from './tier.js';
+
+/**
+ * 천체 카테고리.
+ */
+export const CelestialKind = {
+  Star: 'star',
+  Planet: 'planet',
+  DwarfPlanet: 'dwarf-planet',
+  Moon: 'moon',
+  Asteroid: 'asteroid',
+  Comet: 'comet',
+  Spacecraft: 'spacecraft',
+  BlackHole: 'black-hole',
+  Nebula: 'nebula',
+  Galaxy: 'galaxy',
+  StarCluster: 'star-cluster',
+} as const;
+
+export type CelestialKind = (typeof CelestialKind)[keyof typeof CelestialKind];
+
+/**
+ * Kepler 궤도 6요소 (J2000.0 기준).
+ * 모든 각도는 라디안, 거리는 미터.
+ */
+export interface OrbitalElements {
+  /** 궤도 장반경 a [m] */
+  semiMajorAxis: number;
+  /** 이심률 e [dimensionless] */
+  eccentricity: number;
+  /** 궤도 경사각 i [rad] */
+  inclination: number;
+  /** 승교점 경도 Ω [rad] */
+  longitudeOfAscendingNode: number;
+  /** 근일점 편각 ω [rad] */
+  argumentOfPeriapsis: number;
+  /** epoch 시점의 평균 이상 M₀ [rad] */
+  meanAnomalyAtEpoch: number;
+  /** epoch (Julian Date) */
+  epoch: number;
+}
+
+/**
+ * 천체 단일 레코드.
+ */
+export interface CelestialBody {
+  /** 고유 ID (예: 'earth', 'jupiter') */
+  id: string;
+  /** 분류 */
+  kind: CelestialKind;
+  /** 한국어 이름 */
+  nameKo: string;
+  /** 영문 이름 */
+  nameEn: string;
+  /** 질량 [kg] */
+  mass: number;
+  /** 반경 [m] */
+  radius: number;
+  /** 데이터 신뢰성 티어 */
+  tier: DataTier;
+  /** 부모 천체 ID (예: 달의 부모는 지구) — 없으면 null (태양 등) */
+  parentId: string | null;
+  /** 궤도 요소 — 태양/최상위 천체는 없을 수 있음 */
+  orbit?: OrbitalElements;
+  /** 색상 표시용 힌트 (흑체복사 온도[K] 또는 명시 색) */
+  colorHint?: { temperatureK?: number; hex?: string };
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './tier.js';
+export * from './celestial.js';
+export * from './mode.js';

--- a/packages/shared/src/types/mode.ts
+++ b/packages/shared/src/types/mode.ts
@@ -1,0 +1,13 @@
+/**
+ * 시뮬레이터 인터랙션 모드.
+ * P1에서는 observe, research만 활성화.
+ * education, sandbox는 P2+ 예정.
+ */
+export const SimMode = {
+  Observe: 'observe',
+  Research: 'research',
+  Education: 'education',
+  Sandbox: 'sandbox',
+} as const;
+
+export type SimMode = (typeof SimMode)[keyof typeof SimMode];

--- a/packages/shared/src/types/tier.ts
+++ b/packages/shared/src/types/tier.ts
@@ -1,0 +1,16 @@
+/**
+ * 데이터 신뢰성 티어.
+ * UI에서 모든 수치 표시 시 티어 배지를 병기하여 교육적 정직성을 유지한다.
+ */
+export const DataTier = {
+  /** Tier 1 — 관측 정확 (JPL Horizons, Gaia, Hipparcos) */
+  Observed: 1,
+  /** Tier 2 — 통계/경험 모델 (항성 진화 트랙, IMF) */
+  Model: 2,
+  /** Tier 3 — 이론 모델 (블랙홀 강착원반) */
+  Theory: 3,
+  /** Tier 4 — 예술적 근사 (성운 시각화) */
+  Artistic: 4,
+} as const;
+
+export type DataTier = (typeof DataTier)[keyof typeof DataTier];

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@astro-simulator/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       next:
         specifier: ^16.2.3
         version: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -38,9 +41,18 @@ importers:
 
   packages/core:
     dependencies:
+      '@astro-simulator/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@babylonjs/core':
         specifier: ^8.0.0
         version: 8.56.2
+    devDependencies:
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.2
+
+  packages/shared:
     devDependencies:
       typescript:
         specifier: ^6.0.0


### PR DESCRIPTION
## Summary
- `@astro-simulator/shared` 패키지 신규 생성
- 물리 상수, 천문 단위, 태양계 기본값
- CelestialBody, OrbitalElements, DataTier, SimMode 타입
- CoreEvents 타입 맵, CoreCommand 유니온

## 검증
- [x] shared build 성공
- [x] core, web 양쪽에 workspace dep 연결
- [x] web 홈 페이지에서 AU/SOLAR_MASS import → 빌드 성공 (end-to-end 통합 검증)
- [x] U+FFFD 없음

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)