### PR TITLE
[#8] Babylon 엔진 초기화 + SSR 우회 캔버스 마운트

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,45 +1,9 @@
-import { useTranslations } from 'next-intl';
-import { AU, SOLAR_MASS } from '@astro-simulator/shared';
+import { SimCanvasDynamic } from '@/components/sim-canvas.dynamic';
 
 export default function HomePage() {
-  const t = useTranslations('app');
-
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center gap-4 p-8 bg-bg-base text-fg-primary">
-      <h1 className="text-h1 font-display tracking-tight">{t('title')}</h1>
-      <p className="text-body text-fg-secondary">{t('subtitle')}</p>
-      <p className="text-body-sm text-fg-tertiary">{t('scaffold')}</p>
-
-      {/* 토큰 시각 검증 섹션 */}
-      <section className="mt-8 grid grid-cols-2 md:grid-cols-4 gap-3 text-caption">
-        <TokenChip color="var(--star-o)" label="O · 30,000K+" />
-        <TokenChip color="var(--star-b)" label="B · 10,000K" />
-        <TokenChip color="var(--star-a)" label="A · 7,500K" />
-        <TokenChip color="var(--star-g)" label="G · 5,800K" />
-        <TokenChip color="var(--star-k)" label="K · 4,500K" />
-        <TokenChip color="var(--star-m)" label="M · 3,200K" />
-        <TokenChip color="var(--nebula-teal)" label="Tier 1 관측" />
-        <TokenChip color="var(--nebula-violet)" label="Tier 4 예술" />
-      </section>
-
-      <p className="mt-4 num text-fg-tertiary text-body-sm">
-        AU = {AU.toExponential(3)} m · M☉ = {SOLAR_MASS.toExponential(3)} kg
-      </p>
+    <main className="fixed inset-0 bg-bg-base text-fg-primary">
+      <SimCanvasDynamic />
     </main>
-  );
-}
-
-function TokenChip({ color, label }: { color: string; label: string }) {
-  return (
-    <div
-      className="flex items-center gap-2 px-3 py-2 rounded-sm border"
-      style={{ borderColor: 'var(--border-subtle)', background: 'var(--bg-surface)' }}
-    >
-      <span
-        className="w-3 h-3 rounded-full"
-        style={{ background: color, boxShadow: `0 0 8px ${color}` }}
-      />
-      <span className="num text-fg-secondary">{label}</span>
-    </div>
   );
 }

--- a/apps/web/src/components/sim-canvas.dynamic.tsx
+++ b/apps/web/src/components/sim-canvas.dynamic.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+/**
+ * SimCanvas의 SSR 우회 래퍼.
+ * Babylon.js는 window/WebGPU에 의존하므로 서버에서 로드 금지.
+ */
+export const SimCanvasDynamic = dynamic(() => import('./sim-canvas').then((m) => m.SimCanvas), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center text-fg-tertiary text-body-sm">
+      엔진 로딩 중…
+    </div>
+  ),
+});

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { SimulationCore } from '@astro-simulator/core';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Babylon 캔버스 래퍼.
+ * - SSR 우회는 `SimCanvasDynamic` (sim-canvas.dynamic.tsx) 사용
+ * - StrictMode 이중 마운트 대응: 초기화 가드 + dispose
+ */
+export function SimCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const coreRef = useRef<SimulationCore | null>(null);
+  const [renderer, setRenderer] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    // 이미 생성되어 있으면 재초기화 금지 (StrictMode 이중 마운트)
+    if (coreRef.current && !coreRef.current.disposed) return;
+
+    let cancelled = false;
+    const core = new SimulationCore(canvas);
+    coreRef.current = core;
+
+    core
+      .start()
+      .then(() => {
+        if (cancelled) return;
+        setRenderer(core.rendererKind);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        console.error('[sim-canvas] 엔진 초기화 실패', err);
+        setError(err instanceof Error ? err.message : String(err));
+      });
+
+    return () => {
+      cancelled = true;
+      core.dispose();
+      coreRef.current = null;
+    };
+  }, []);
+
+  return (
+    <div className="relative w-full h-full">
+      <canvas
+        ref={canvasRef}
+        className="block w-full h-full outline-none"
+        style={{ touchAction: 'none' }}
+      />
+      {/* 디버그 HUD — B1 검증용, D1에서 정식 HUD로 대체됨 */}
+      <div className="absolute top-2 right-2 num text-caption text-fg-secondary bg-bg-surface/80 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle">
+        {error ? `ERR · ${error}` : renderer ? `renderer · ${renderer}` : 'initializing…'}
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/engine/engine-factory.ts
+++ b/packages/core/src/engine/engine-factory.ts
@@ -1,0 +1,40 @@
+import { Engine, WebGPUEngine } from '@babylonjs/core';
+
+export type EngineKind = 'webgpu' | 'webgl2';
+
+export interface CreatedEngine {
+  engine: Engine | WebGPUEngine;
+  kind: EngineKind;
+}
+
+/**
+ * WebGPU 우선 시도 후 실패 시 WebGL2로 폴백한다.
+ * ADR: docs/phases/architecture.md §6 "WebGPU-first + WebGL2 폴백"
+ */
+export async function createEngine(canvas: HTMLCanvasElement): Promise<CreatedEngine> {
+  // WebGPU 지원 확인
+  const webgpuSupported =
+    typeof navigator !== 'undefined' && 'gpu' in navigator && Boolean(navigator.gpu);
+
+  if (webgpuSupported) {
+    try {
+      const engine = new WebGPUEngine(canvas, {
+        antialias: true,
+        stencil: true,
+        adaptToDeviceRatio: true,
+      });
+      await engine.initAsync();
+      return { engine, kind: 'webgpu' };
+    } catch (error) {
+      // WebGPU 초기화 실패 — WebGL2로 폴백
+      console.warn('[engine-factory] WebGPU 초기화 실패, WebGL2로 폴백합니다.', error);
+    }
+  }
+
+  const engine = new Engine(canvas, true, {
+    preserveDrawingBuffer: true,
+    stencil: true,
+    adaptToDeviceRatio: true,
+  });
+  return { engine, kind: 'webgl2' };
+}

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -1,0 +1,3 @@
+export { createEngine } from './engine-factory.js';
+export type { CreatedEngine, EngineKind } from './engine-factory.js';
+export { SimulationCore } from './simulation-core.js';

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -1,0 +1,80 @@
+import { Color4, Scene } from '@babylonjs/core';
+import { createEngine, type CreatedEngine, type EngineKind } from './engine-factory.js';
+
+/**
+ * 시뮬레이션 코어 — Babylon 엔진/씬을 소유하고 렌더 루프를 관리한다.
+ *
+ * - UI 프레임워크 의존성 없음
+ * - 캔버스 엘리먼트 하나만 받아 모든 동작을 담당
+ * - dispose()로 완전한 정리 가능 (React StrictMode 이중 마운트 대응)
+ *
+ * B2 (#9)에서 mitt 이벤트 버스를 추가한다.
+ */
+export class SimulationCore {
+  #canvas: HTMLCanvasElement;
+  #created: CreatedEngine | null = null;
+  #scene: Scene | null = null;
+  #resizeObserver: ResizeObserver | null = null;
+  #disposed = false;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.#canvas = canvas;
+  }
+
+  get engine(): CreatedEngine['engine'] | null {
+    return this.#created?.engine ?? null;
+  }
+
+  get scene(): Scene | null {
+    return this.#scene;
+  }
+
+  get rendererKind(): EngineKind | null {
+    return this.#created?.kind ?? null;
+  }
+
+  get disposed(): boolean {
+    return this.#disposed;
+  }
+
+  /** 엔진 초기화 + 기본 씬 생성 + 렌더 루프 시작. */
+  async start(): Promise<void> {
+    if (this.#disposed) {
+      throw new Error('SimulationCore가 이미 dispose되었습니다.');
+    }
+    if (this.#created) return;
+
+    this.#created = await createEngine(this.#canvas);
+    const { engine } = this.#created;
+
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.031, 0.035, 0.051, 1); // bg-base
+    this.#scene = scene;
+
+    engine.runRenderLoop(() => {
+      if (this.#disposed) return;
+      scene.render();
+    });
+
+    this.#resizeObserver = new ResizeObserver(() => {
+      if (this.#disposed) return;
+      engine.resize();
+    });
+    this.#resizeObserver.observe(this.#canvas);
+  }
+
+  /** 완전 정리 — 캔버스 외부 자원 모두 해제. */
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+
+    this.#scene?.dispose();
+    this.#scene = null;
+
+    this.#created?.engine.dispose();
+    this.#created = null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@
  * Babylon.js는 peer dependency.
  */
 
+export * from './engine/index.js';
+
 export * as coords from './coords/index.js';
 export * as physics from './physics/index.js';
 export * as scene from './scene/index.js';


### PR DESCRIPTION
## Summary
- SimulationCore 클래스 (engine/scene 소유, dispose 가능)
- WebGPU 시도 → WebGL2 폴백
- SimCanvas + dynamic SSR 우회
- StrictMode 이중 마운트 대응

## 검증
- typecheck/build/lint 통과

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)