### PR TITLE
[#9] Core↔UI 이벤트 버스 (mitt) + Zustand store + 라운드트립

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { SimulationCore } from '@astro-simulator/core';
-import { useEffect, useRef, useState } from 'react';
+import { attachCoreToStore } from '@/core/core-adapter';
+import { useSimStore } from '@/store/sim-store';
+import { useEffect, useRef } from 'react';
 
 /**
  * Babylon 캔버스 래퍼.
@@ -11,38 +13,44 @@ import { useEffect, useRef, useState } from 'react';
 export function SimCanvas() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const coreRef = useRef<SimulationCore | null>(null);
-  const [renderer, setRenderer] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+
+  const renderer = useSimStore((s) => s.rendererKind);
+  const engineError = useSimStore((s) => s.engineError);
+  const pingCount = useSimStore((s) => s.pingCount);
+  const incrementPing = useSimStore((s) => s.incrementPing);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    // 이미 생성되어 있으면 재초기화 금지 (StrictMode 이중 마운트)
     if (coreRef.current && !coreRef.current.disposed) return;
 
-    let cancelled = false;
     const core = new SimulationCore(canvas);
     coreRef.current = core;
 
-    core
-      .start()
-      .then(() => {
-        if (cancelled) return;
-        setRenderer(core.rendererKind);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        console.error('[sim-canvas] 엔진 초기화 실패', err);
-        setError(err instanceof Error ? err.message : String(err));
-      });
+    const detach = attachCoreToStore(core);
+
+    let cancelled = false;
+    core.start().catch((err: unknown) => {
+      if (cancelled) return;
+      console.error('[sim-canvas] 엔진 초기화 실패', err);
+    });
 
     return () => {
       cancelled = true;
+      detach();
       core.dispose();
       coreRef.current = null;
     };
   }, []);
+
+  const handlePing = () => {
+    const core = coreRef.current;
+    if (!core) return;
+    // 라운드트립 테스트 — UI에서 store 업데이트, Core로 명령 발행
+    incrementPing();
+    core.command({ type: 'setMode', mode: 'observe' });
+  };
 
   return (
     <div className="relative w-full h-full">
@@ -51,9 +59,23 @@ export function SimCanvas() {
         className="block w-full h-full outline-none"
         style={{ touchAction: 'none' }}
       />
-      {/* 디버그 HUD — B1 검증용, D1에서 정식 HUD로 대체됨 */}
-      <div className="absolute top-2 right-2 num text-caption text-fg-secondary bg-bg-surface/80 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle">
-        {error ? `ERR · ${error}` : renderer ? `renderer · ${renderer}` : 'initializing…'}
+      {/* 개발용 HUD — D1 (#20)에서 정식 HUD로 대체 */}
+      <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
+        <div className="num text-caption text-fg-secondary bg-bg-surface/80 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle">
+          {engineError
+            ? `ERR · ${engineError}`
+            : renderer
+              ? `renderer · ${renderer}`
+              : 'initializing…'}
+        </div>
+        <button
+          type="button"
+          onClick={handlePing}
+          className="num text-caption text-fg-primary bg-primary/10 hover:bg-primary/20 border border-primary/30 px-2 py-1 rounded-sm transition-colors"
+          style={{ transitionDuration: 'var(--duration-fast)' }}
+        >
+          ping: {pingCount}
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/core/core-adapter.ts
+++ b/apps/web/src/core/core-adapter.ts
@@ -1,0 +1,53 @@
+import type { SimulationCore } from '@astro-simulator/core';
+import { useSimStore } from '@/store/sim-store';
+
+/**
+ * Core 이벤트를 Zustand store에 연결하는 어댑터.
+ * Core는 store를 직접 알지 못한다 — 이 모듈이 유일한 다리.
+ *
+ * 반환값은 cleanup 함수. 컴포넌트 언마운트 시 호출.
+ */
+export function attachCoreToStore(core: SimulationCore): () => void {
+  const store = useSimStore.getState();
+
+  const onEngineReady = ({ renderer }: { renderer: 'webgpu' | 'webgl2' }) => {
+    store.setRenderer(renderer);
+    store.setEngineError(null);
+  };
+
+  const onError = ({ message }: { message: string }) => {
+    store.setEngineError(message);
+  };
+
+  const onTimeChanged = ({ julianDate }: { julianDate: number }) => {
+    store.setTime(julianDate);
+  };
+
+  const onBodySelected = ({ id }: { id: string | null }) => {
+    store.setSelectedBody(id);
+  };
+
+  const onTimeScaleChanged = ({ scale }: { scale: number }) => {
+    store.setTimeScale(scale);
+  };
+
+  const onFps = ({ fps }: { fps: number }) => {
+    store.setFps(fps);
+  };
+
+  core.on('engineReady', onEngineReady);
+  core.on('error', onError);
+  core.on('timeChanged', onTimeChanged);
+  core.on('bodySelected', onBodySelected);
+  core.on('timeScaleChanged', onTimeScaleChanged);
+  core.on('performance', onFps);
+
+  return () => {
+    core.off('engineReady', onEngineReady);
+    core.off('error', onError);
+    core.off('timeChanged', onTimeChanged);
+    core.off('bodySelected', onBodySelected);
+    core.off('timeScaleChanged', onTimeScaleChanged);
+    core.off('performance', onFps);
+  };
+}

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -1,0 +1,60 @@
+import type { SimMode } from '@astro-simulator/shared';
+import { create } from 'zustand';
+
+/**
+ * 시뮬레이션 UI 상태 store.
+ *
+ * Core에서 방출되는 이벤트를 어댑터가 이 store에 반영한다.
+ * 컴포넌트는 이 store를 선택적으로 구독한다 (리렌더 최소화).
+ */
+export interface SimStoreState {
+  // 엔진 상태
+  rendererKind: 'webgpu' | 'webgl2' | null;
+  engineError: string | null;
+
+  // 시뮬레이션 상태
+  mode: SimMode;
+  julianDate: number | null;
+  selectedBodyId: string | null;
+  timeScale: number;
+  fps: number | null;
+
+  // 개발/디버그용 라운드트립 카운터
+  pingCount: number;
+  lastPingAt: number | null;
+
+  // actions (Core → store)
+  setRenderer: (kind: 'webgpu' | 'webgl2' | null) => void;
+  setEngineError: (message: string | null) => void;
+  setMode: (mode: SimMode) => void;
+  setTime: (julianDate: number) => void;
+  setSelectedBody: (id: string | null) => void;
+  setTimeScale: (scale: number) => void;
+  setFps: (fps: number) => void;
+  incrementPing: () => void;
+}
+
+export const useSimStore = create<SimStoreState>((set) => ({
+  rendererKind: null,
+  engineError: null,
+  mode: 'observe',
+  julianDate: null,
+  selectedBodyId: null,
+  timeScale: 1,
+  fps: null,
+  pingCount: 0,
+  lastPingAt: null,
+
+  setRenderer: (kind) => set({ rendererKind: kind }),
+  setEngineError: (message) => set({ engineError: message }),
+  setMode: (mode) => set({ mode }),
+  setTime: (julianDate) => set({ julianDate }),
+  setSelectedBody: (id) => set({ selectedBodyId: id }),
+  setTimeScale: (scale) => set({ timeScale: scale }),
+  setFps: (fps) => set({ fps }),
+  incrementPing: () =>
+    set((state) => ({
+      pingCount: state.pingCount + 1,
+      lastPingAt: Date.now(),
+    })),
+}));

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -1,14 +1,15 @@
 import { Color4, Scene } from '@babylonjs/core';
+import type { CoreCommand, CoreEvents } from '@astro-simulator/shared';
+import mitt, { type Emitter, type Handler } from 'mitt';
 import { createEngine, type CreatedEngine, type EngineKind } from './engine-factory.js';
 
 /**
- * 시뮬레이션 코어 — Babylon 엔진/씬을 소유하고 렌더 루프를 관리한다.
+ * 시뮬레이션 코어 — Babylon 엔진/씬 소유 + 이벤트 버스.
  *
  * - UI 프레임워크 의존성 없음
  * - 캔버스 엘리먼트 하나만 받아 모든 동작을 담당
  * - dispose()로 완전한 정리 가능 (React StrictMode 이중 마운트 대응)
- *
- * B2 (#9)에서 mitt 이벤트 버스를 추가한다.
+ * - 외부와의 통신은 이벤트(emit) + 명령(command) 2축으로만 노출
  */
 export class SimulationCore {
   #canvas: HTMLCanvasElement;
@@ -16,6 +17,7 @@ export class SimulationCore {
   #scene: Scene | null = null;
   #resizeObserver: ResizeObserver | null = null;
   #disposed = false;
+  #emitter: Emitter<CoreEvents> = mitt<CoreEvents>();
 
   constructor(canvas: HTMLCanvasElement) {
     this.#canvas = canvas;
@@ -37,6 +39,27 @@ export class SimulationCore {
     return this.#disposed;
   }
 
+  /** 이벤트 구독. */
+  on<K extends keyof CoreEvents>(type: K, handler: Handler<CoreEvents[K]>): void {
+    this.#emitter.on(type, handler);
+  }
+
+  /** 이벤트 구독 해제. */
+  off<K extends keyof CoreEvents>(type: K, handler: Handler<CoreEvents[K]>): void {
+    this.#emitter.off(type, handler);
+  }
+
+  /** UI → Core 명령 발행. 미지원 명령은 무시된다 (향후 확장 대비). */
+  command(cmd: CoreCommand): void {
+    if (this.#disposed) return;
+    switch (cmd.type) {
+      // P1에서는 아직 실제 명령 처리가 없다 — B2에서는 라운드트립만 검증.
+      // C5 (#17)에서 시간 명령, C6 (#18)에서 카메라 명령이 추가된다.
+      default:
+        console.warn('[SimulationCore] 미지원 명령:', cmd);
+    }
+  }
+
   /** 엔진 초기화 + 기본 씬 생성 + 렌더 루프 시작. */
   async start(): Promise<void> {
     if (this.#disposed) {
@@ -44,11 +67,19 @@ export class SimulationCore {
     }
     if (this.#created) return;
 
-    this.#created = await createEngine(this.#canvas);
-    const { engine } = this.#created;
+    try {
+      this.#created = await createEngine(this.#canvas);
+    } catch (error) {
+      this.#emitter.emit('error', {
+        message: '엔진 초기화에 실패했습니다.',
+        cause: error,
+      });
+      throw error;
+    }
 
+    const { engine, kind } = this.#created;
     const scene = new Scene(engine);
-    scene.clearColor = new Color4(0.031, 0.035, 0.051, 1); // bg-base
+    scene.clearColor = new Color4(0.031, 0.035, 0.051, 1);
     this.#scene = scene;
 
     engine.runRenderLoop(() => {
@@ -61,6 +92,8 @@ export class SimulationCore {
       engine.resize();
     });
     this.#resizeObserver.observe(this.#canvas);
+
+    this.#emitter.emit('engineReady', { renderer: kind });
   }
 
   /** 완전 정리 — 캔버스 외부 자원 모두 해제. */
@@ -76,5 +109,7 @@ export class SimulationCore {
 
     this.#created?.engine.dispose();
     this.#created = null;
+
+    this.#emitter.all.clear();
   }
 }


### PR DESCRIPTION
## Summary
- SimulationCore에 mitt emitter 내장, engineReady/error 이벤트
- Zustand useSimStore (UI 상태 전역)
- attachCoreToStore 어댑터 (Core는 store 모름)
- ping 버튼으로 라운드트립 검증

## 검증
- typecheck/build/lint 통과

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)