### PR TITLE
[#10] 태양 + 지구 프록시 구체 렌더

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SimulationCore } from '@astro-simulator/core';
+import { SimulationCore, scene as sceneApi } from '@astro-simulator/core';
 import { attachCoreToStore } from '@/core/core-adapter';
 import { useSimStore } from '@/store/sim-store';
 import { useEffect, useRef } from 'react';
@@ -31,10 +31,18 @@ export function SimCanvas() {
     const detach = attachCoreToStore(core);
 
     let cancelled = false;
-    core.start().catch((err: unknown) => {
-      if (cancelled) return;
-      console.error('[sim-canvas] 엔진 초기화 실패', err);
-    });
+    core
+      .start()
+      .then(() => {
+        if (cancelled || !core.scene) return;
+        // B3 데모 씬 — C3 (#15)에서 실제 태양계로 교체
+        sceneApi.setupArcRotateCamera(core.scene, { radius: 35 });
+        sceneApi.createSunEarthDemo(core.scene);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        console.error('[sim-canvas] 엔진 초기화 실패', err);
+      });
 
     return () => {
       cancelled = true;

--- a/packages/core/src/scene/camera.ts
+++ b/packages/core/src/scene/camera.ts
@@ -1,0 +1,50 @@
+import { ArcRotateCamera, Vector3, type Scene } from '@babylonjs/core';
+
+export interface ArcCameraOptions {
+  /** 수평 회전각 (rad) */
+  alpha?: number;
+  /** 수직 회전각 (rad) */
+  beta?: number;
+  /** 타겟까지 거리 (씬 단위) */
+  radius?: number;
+  /** 타겟 위치 */
+  target?: Vector3;
+  /** 최소 거리 */
+  lowerRadiusLimit?: number;
+  /** 최대 거리 */
+  upperRadiusLimit?: number;
+}
+
+/**
+ * 기본 ArcRotate 카메라를 씬에 설치한다.
+ * Floating Origin 기반의 본격 카메라 시스템은 C6 (#18)에서 구현.
+ */
+export function setupArcRotateCamera(
+  scene: Scene,
+  options: ArcCameraOptions = {},
+): ArcRotateCamera {
+  const {
+    alpha = -Math.PI / 2,
+    beta = Math.PI / 2.5,
+    radius = 30,
+    target = Vector3.Zero(),
+    lowerRadiusLimit = 2,
+    upperRadiusLimit = 1_000_000,
+  } = options;
+
+  const camera = new ArcRotateCamera('camera', alpha, beta, radius, target, scene);
+  camera.lowerRadiusLimit = lowerRadiusLimit;
+  camera.upperRadiusLimit = upperRadiusLimit;
+  camera.wheelPrecision = 3;
+  camera.pinchPrecision = 50;
+  camera.panningSensibility = 0;
+  camera.minZ = 0.01;
+  camera.maxZ = 1e9;
+
+  const canvas = scene.getEngine().getRenderingCanvas();
+  if (canvas) {
+    camera.attachControl(canvas, true);
+  }
+
+  return camera;
+}

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -1,10 +1,11 @@
 /**
  * Scene 모듈.
  *
- * Babylon 씬 관리, 카메라 컨트롤러, 천체 메쉬 생성/업데이트,
- * 계층 Scene Graph를 담당한다.
- *
- * 구현은 B1/B3/C3/C6 (#8, #10, #15, #18)에서 수행.
+ * Babylon 씬 관리, 카메라 컨트롤러, 천체 메쉬 생성/업데이트.
+ * 본격 Scene Graph는 C3/C6 (#15, #18)에서 구현.
  */
 
-export {};
+export { setupArcRotateCamera } from './camera.js';
+export type { ArcCameraOptions } from './camera.js';
+export { createSunEarthDemo } from './sun-earth-demo.js';
+export type { SunEarthDemoHandles } from './sun-earth-demo.js';

--- a/packages/core/src/scene/sun-earth-demo.ts
+++ b/packages/core/src/scene/sun-earth-demo.ts
@@ -1,0 +1,61 @@
+import {
+  Color3,
+  HemisphericLight,
+  MeshBuilder,
+  PointLight,
+  StandardMaterial,
+  Vector3,
+  type Mesh,
+  type Scene,
+} from '@babylonjs/core';
+
+export interface SunEarthDemoHandles {
+  sun: Mesh;
+  earth: Mesh;
+  dispose: () => void;
+}
+
+/**
+ * B3 (#10) 검증용 임시 씬 — 태양 + 지구 프록시 구체.
+ *
+ * C3 (#15)에서 실제 행성 8개 + 달로 교체된다.
+ * 좌표 단위는 데모용 임의 단위 (씬 단위 = AU/10 수준).
+ */
+export function createSunEarthDemo(scene: Scene): SunEarthDemoHandles {
+  // 약한 전역 조명 + 태양 중심 포인트 라이트
+  const ambient = new HemisphericLight('hemi', new Vector3(0, 1, 0), scene);
+  ambient.intensity = 0.15;
+  ambient.groundColor = new Color3(0.02, 0.02, 0.05);
+
+  const sunLight = new PointLight('sun-light', new Vector3(0, 0, 0), scene);
+  sunLight.intensity = 2.5;
+  sunLight.diffuse = new Color3(1, 0.95, 0.8);
+
+  // 태양 — 자체 발광 구체
+  const sun = MeshBuilder.CreateSphere('sun', { diameter: 4, segments: 48 }, scene);
+  const sunMat = new StandardMaterial('sun-mat', scene);
+  sunMat.emissiveColor = new Color3(1, 0.91, 0.66); // star-g 계열
+  sunMat.disableLighting = true;
+  sun.material = sunMat;
+
+  // 지구 프록시 — 태양에서 임의 거리 배치
+  const earth = MeshBuilder.CreateSphere('earth', { diameter: 1.2, segments: 32 }, scene);
+  earth.position = new Vector3(20, 0, 0);
+  const earthMat = new StandardMaterial('earth-mat', scene);
+  earthMat.diffuseColor = new Color3(0.25, 0.45, 0.78); // star-o 계열 약화
+  earthMat.specularColor = new Color3(0.1, 0.1, 0.1);
+  earth.material = earthMat;
+
+  return {
+    sun,
+    earth,
+    dispose: () => {
+      ambient.dispose();
+      sunLight.dispose();
+      sunMat.dispose();
+      earthMat.dispose();
+      sun.dispose();
+      earth.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- scene/camera.ts: setupArcRotateCamera 유틸
- scene/sun-earth-demo.ts: 태양 + 지구 프록시 + 조명
- SimCanvas에서 start 후 데모 씬 설치

## 검증
- typecheck/build/lint 통과
- 데모 씬은 C3 (#15)에서 실제 태양계로 교체 예정

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)