### PR TITLE
[#11] RTE 좌표계 + Floating Origin 단위 테스트

### DIFF
--- a/packages/core/src/coords/floating-origin.test.ts
+++ b/packages/core/src/coords/floating-origin.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { FloatingOrigin } from './floating-origin.js';
+import { vec3 } from './vec3.js';
+
+describe('FloatingOrigin', () => {
+  it('임계 거리 미만에서는 shift 없음', () => {
+    const fo = new FloatingOrigin(10_000);
+    const shift = fo.update(vec3(5_000, 0, 0));
+    expect(shift).toBeNull();
+    expect(fo.originOffset).toEqual([0, 0, 0]);
+  });
+
+  it('임계 거리 초과 시 원점을 카메라로 이동시킨다', () => {
+    const fo = new FloatingOrigin(10_000);
+    const shift = fo.update(vec3(15_000, 0, 0));
+    expect(shift).toEqual([15_000, 0, 0]);
+    expect(fo.originOffset).toEqual([15_000, 0, 0]);
+  });
+
+  it('연속 shift 누적', () => {
+    const fo = new FloatingOrigin(10_000);
+    fo.update(vec3(12_000, 0, 0)); // 1차 shift: origin = [12000, 0, 0]
+    // 이제 카메라가 absolute 25_000 — local 13_000 — 다시 shift
+    fo.update(vec3(25_000, 0, 0));
+    expect(fo.originOffset).toEqual([25_000, 0, 0]);
+  });
+
+  it('toLocal / toWorld 라운드트립', () => {
+    const fo = new FloatingOrigin(10_000);
+    fo.update(vec3(50_000, 0, 0));
+
+    const world = vec3(60_000, 0, 0);
+    const local = fo.toLocal(world);
+    expect(local).toEqual([10_000, 0, 0]);
+    expect(fo.toWorld(local)).toEqual(world);
+  });
+
+  it('shift 후에도 천체 상대 위치는 보존된다', () => {
+    const fo = new FloatingOrigin(10_000);
+
+    // 두 천체의 월드 절대 좌표
+    const bodyA = vec3(1_000_000_000, 0, 0);
+    const bodyB = vec3(1_000_000_050, 0, 0);
+
+    const cameraWorld = vec3(1_000_000_000, 0, 0);
+    fo.update(cameraWorld);
+
+    const localA = fo.toLocal(bodyA);
+    const localB = fo.toLocal(bodyB);
+
+    // 상대 거리는 shift와 무관하게 유지
+    expect(localB[0] - localA[0]).toBe(50);
+    // 로컬 좌표가 0 근처로 축소됨
+    expect(Math.abs(localA[0])).toBeLessThan(100);
+  });
+
+  it('reset', () => {
+    const fo = new FloatingOrigin(10_000);
+    fo.update(vec3(50_000, 0, 0));
+    fo.reset();
+    expect(fo.originOffset).toEqual([0, 0, 0]);
+  });
+
+  it('잘못된 threshold 거부', () => {
+    expect(() => new FloatingOrigin(0)).toThrow();
+    expect(() => new FloatingOrigin(-100)).toThrow();
+    expect(() => new FloatingOrigin(Number.NaN)).toThrow();
+    expect(() => new FloatingOrigin(Number.POSITIVE_INFINITY)).toThrow();
+  });
+});

--- a/packages/core/src/coords/floating-origin.ts
+++ b/packages/core/src/coords/floating-origin.ts
@@ -1,0 +1,63 @@
+import { length, subtract, type Vec3Double } from './vec3.js';
+
+/**
+ * Floating Origin 관리자.
+ *
+ * 카메라(또는 기준점)가 월드 원점에서 일정 거리 이상 멀어지면 월드 전체 좌표계를 평행이동하여
+ * 카메라를 다시 원점 근처로 되돌린다. 씬 그래프는 이 shift만큼 반대로 이동한 것으로 해석된다.
+ *
+ * ADR: docs/phases/architecture.md §4 "RTE + Floating Origin"
+ *
+ * 이 클래스는 좌표 계산만 담당한다. 실제 씬 노드 이동은 호출 측(카메라 시스템 C6)에서 수행.
+ */
+export class FloatingOrigin {
+  /** 누적 원점 오프셋 (월드 절대좌표 누산) */
+  #originOffset: Vec3Double = [0, 0, 0];
+  /** shift 트리거 임계 거리 */
+  readonly threshold: number;
+
+  constructor(threshold = 10_000) {
+    if (!(threshold > 0) || !Number.isFinite(threshold)) {
+      throw new Error('FloatingOrigin threshold는 양의 유한수여야 합니다.');
+    }
+    this.threshold = threshold;
+  }
+
+  /** 현재 누적 원점 (절대 월드 좌표) */
+  get originOffset(): Vec3Double {
+    return this.#originOffset;
+  }
+
+  /** 씬 로컬 좌표 → 절대 월드 좌표 */
+  toWorld(local: Vec3Double): Vec3Double {
+    const o = this.#originOffset;
+    return [local[0] + o[0], local[1] + o[1], local[2] + o[2]];
+  }
+
+  /** 절대 월드 좌표 → 씬 로컬 좌표 */
+  toLocal(world: Vec3Double): Vec3Double {
+    return subtract(world, this.#originOffset);
+  }
+
+  /**
+   * 카메라(월드 절대좌표)를 받아 필요 시 shift를 수행한다.
+   *
+   * @returns 이번 호출에서 발생한 shift 델타 (원점 이동량). shift가 없으면 null.
+   */
+  update(cameraWorld: Vec3Double): Vec3Double | null {
+    const local = this.toLocal(cameraWorld);
+    if (length(local) < this.threshold) {
+      return null;
+    }
+
+    // 카메라 로컬 좌표만큼 원점을 이동시켜 카메라를 다시 (0,0,0) 근처로 되돌림
+    const o = this.#originOffset;
+    this.#originOffset = [o[0] + local[0], o[1] + local[1], o[2] + local[2]];
+    return local;
+  }
+
+  /** 원점 리셋 (테스트/전환용) */
+  reset(): void {
+    this.#originOffset = [0, 0, 0];
+  }
+}

--- a/packages/core/src/coords/index.ts
+++ b/packages/core/src/coords/index.ts
@@ -4,7 +4,9 @@
  * CPU float64 월드 좌표와 GPU float32 RTE(Relative-to-Eye) 렌더 좌표 변환,
  * Floating Origin 관리를 담당한다.
  *
- * 구현은 B4 (#11)에서 수행.
+ * ADR: docs/phases/architecture.md §4
  */
 
-export {};
+export * from './vec3.js';
+export * from './rte.js';
+export * from './floating-origin.js';

--- a/packages/core/src/coords/rte.test.ts
+++ b/packages/core/src/coords/rte.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { manyToRelativeToEye, toRelativeToEye } from './rte.js';
+import { vec3 } from './vec3.js';
+
+describe('toRelativeToEye', () => {
+  it('원점에서 단순 변환', () => {
+    const out = toRelativeToEye(vec3(10, 20, 30), vec3(0, 0, 0));
+    expect(Array.from(out)).toEqual([10, 20, 30]);
+  });
+
+  it('큰 월드 좌표에서도 카메라 근처는 소수점 정밀도 유지 (RTE 핵심)', () => {
+    // 월드 좌표: 1 AU(~1.496e11m) 근처의 인접 두 점
+    const cameraWorld = vec3(149_597_870_700, 0, 0); // 1 AU
+    const bodyWorld = vec3(149_597_870_700 + 6_378_137, 0, 0); // 1 AU + 지구 반경
+    const out = toRelativeToEye(bodyWorld, cameraWorld);
+
+    // float32로 캐스팅되었지만 ~6.3e6m 범위라 수 m 단위 정밀도 유지
+    expect(out[0]).toBeCloseTo(6_378_137, -1); // 10m 이내
+    expect(out[1]).toBe(0);
+    expect(out[2]).toBe(0);
+  });
+
+  it('10^13m 스케일에서 직접 float32 대입 대비 우위', () => {
+    // Anti-pattern 검증: 월드 좌표를 float32로 바로 넘기면 정밀도 대량 손실
+    const naive = new Float32Array([4_500_000_000_001]);
+    expect(naive[0]).not.toBe(4_500_000_000_001); // float32는 표현 불가 — 가까운 값으로 반올림
+
+    // RTE는 뺄셈을 double로 수행 → 결과만 float32화
+    const cameraWorld = vec3(4_500_000_000_000, 0, 0);
+    const bodyWorld = vec3(4_500_000_000_001, 0, 0);
+    const out = toRelativeToEye(bodyWorld, cameraWorld);
+    expect(out[0]).toBe(1); // 정확히 1m 재현
+  });
+
+  it('out 버퍼 재사용', () => {
+    const buf = new Float32Array(3);
+    const result = toRelativeToEye(vec3(1, 2, 3), vec3(0, 0, 0), buf);
+    expect(result).toBe(buf);
+    expect(Array.from(buf)).toEqual([1, 2, 3]);
+  });
+
+  it('manyToRelativeToEye — 복수 천체 일괄 변환', () => {
+    const positions = [vec3(10, 0, 0), vec3(0, 20, 0), vec3(0, 0, 30)];
+    const out = manyToRelativeToEye(positions, vec3(5, 5, 5));
+    expect(Array.from(out)).toEqual([5, -5, -5, -5, 15, -5, -5, -5, 25]);
+  });
+});

--- a/packages/core/src/coords/rte.ts
+++ b/packages/core/src/coords/rte.ts
@@ -1,0 +1,42 @@
+import { subtract, type Vec3Double } from './vec3.js';
+
+/**
+ * Relative-to-Eye (RTE) 좌표 변환.
+ *
+ * CPU float64 월드 좌표를 카메라 상대 좌표로 변환하여 float32 GPU 전달용 배열을 만든다.
+ *
+ * ADR: docs/phases/architecture.md §4
+ * - 큰 수 - 큰 수 = 작은 수의 뺄셈은 double 정밀도에서 수행
+ * - 결과만 float32로 다운캐스팅 → 지터/뱅딩 방지
+ * - 1 AU(~1.5e11m)처럼 큰 월드 좌표여도 카메라 근처 천체는 소수점 m 정밀도 유지
+ */
+export function toRelativeToEye(
+  worldPos: Vec3Double,
+  cameraPos: Vec3Double,
+  out?: Float32Array,
+): Float32Array {
+  const [dx, dy, dz] = subtract(worldPos, cameraPos);
+  const target = out ?? new Float32Array(3);
+  target[0] = dx;
+  target[1] = dy;
+  target[2] = dz;
+  return target;
+}
+
+/** 여러 천체를 한 번에 RTE 변환 (flat Float32Array, 길이 3N) */
+export function manyToRelativeToEye(
+  worldPositions: readonly Vec3Double[],
+  cameraPos: Vec3Double,
+  out?: Float32Array,
+): Float32Array {
+  const n = worldPositions.length;
+  const target = out ?? new Float32Array(n * 3);
+  for (let i = 0; i < n; i += 1) {
+    const p = worldPositions[i];
+    if (!p) continue;
+    target[i * 3] = p[0] - cameraPos[0];
+    target[i * 3 + 1] = p[1] - cameraPos[1];
+    target[i * 3 + 2] = p[2] - cameraPos[2];
+  }
+  return target;
+}

--- a/packages/core/src/coords/vec3.test.ts
+++ b/packages/core/src/coords/vec3.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { add, distance, length, scale, subtract, vec3 } from './vec3.js';
+
+describe('Vec3Double', () => {
+  it('add/subtract 기본', () => {
+    expect(add(vec3(1, 2, 3), vec3(4, 5, 6))).toEqual([5, 7, 9]);
+    expect(subtract(vec3(10, 10, 10), vec3(3, 2, 1))).toEqual([7, 8, 9]);
+  });
+
+  it('scale', () => {
+    expect(scale(vec3(1, 2, 3), 2)).toEqual([2, 4, 6]);
+  });
+
+  it('length / distance', () => {
+    expect(length(vec3(3, 4, 0))).toBe(5);
+    expect(distance(vec3(0, 0, 0), vec3(0, 3, 4))).toBe(5);
+  });
+
+  it('double 정밀도 유지 — 10^13m 스케일에서 소수점 m 단위 보존', () => {
+    // 해왕성 궤도(~4.5e12m) 수준 거리에서 1m 차이 검출 가능
+    const a = vec3(4_500_000_000_000, 0, 0);
+    const b = vec3(4_500_000_000_001, 0, 0);
+    expect(distance(a, b)).toBe(1);
+  });
+});

--- a/packages/core/src/coords/vec3.ts
+++ b/packages/core/src/coords/vec3.ts
@@ -1,0 +1,40 @@
+/**
+ * 3D double-precision 벡터.
+ *
+ * JS `number`는 IEEE 754 64비트 double이므로 CPU 월드 좌표에 그대로 사용한다.
+ * Float32Array/Babylon Vector3로 변환되는 지점은 RTE 파이프라인(`toRelativeToEye`) 뿐.
+ */
+export type Vec3Double = readonly [number, number, number];
+
+/** 새 Vec3Double 생성 (가독성용 factory) */
+export const vec3 = (x: number, y: number, z: number): Vec3Double => [x, y, z];
+
+export const ZERO_VEC3: Vec3Double = [0, 0, 0];
+
+/** a - b */
+export function subtract(a: Vec3Double, b: Vec3Double): Vec3Double {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+/** a + b */
+export function add(a: Vec3Double, b: Vec3Double): Vec3Double {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+/** 스칼라 배 */
+export function scale(v: Vec3Double, s: number): Vec3Double {
+  return [v[0] * s, v[1] * s, v[2] * s];
+}
+
+/** 유클리드 거리 (double 정밀도 유지) */
+export function distance(a: Vec3Double, b: Vec3Double): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/** 크기 */
+export function length(v: Vec3Double): number {
+  return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+}


### PR DESCRIPTION
## Summary
- Vec3Double tuple + 기본 연산
- RTE 변환 (toRelativeToEye, manyToRelativeToEye)
- FloatingOrigin 클래스

## 테스트 16개 통과
- double 정밀도 검증 (10^13m에서 1m 분해능)
- RTE anti-pattern 비교
- Floating Origin shift/누적/리셋

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)