### PR TITLE
[#12] Logarithmic depth buffer + 근/원 동시 렌더 검증

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -35,7 +35,9 @@ export function SimCanvas() {
       .start()
       .then(() => {
         if (cancelled || !core.scene) return;
-        // B3 데모 씬 — C3 (#15)에서 실제 태양계로 교체
+        // B5: 로그 뎁스 버퍼 활성화 — 극단 near/far 동시 렌더 지원
+        sceneApi.enableLogarithmicDepth(core.scene);
+        // C3 (#15)에서 실제 태양계로 교체
         sceneApi.setupArcRotateCamera(core.scene, { radius: 35 });
         sceneApi.createSunEarthDemo(core.scene);
       })

--- a/packages/core/src/scene/camera.ts
+++ b/packages/core/src/scene/camera.ts
@@ -28,8 +28,8 @@ export function setupArcRotateCamera(
     beta = Math.PI / 2.5,
     radius = 30,
     target = Vector3.Zero(),
-    lowerRadiusLimit = 2,
-    upperRadiusLimit = 1_000_000,
+    lowerRadiusLimit = 0.5,
+    upperRadiusLimit = 1e14,
   } = options;
 
   const camera = new ArcRotateCamera('camera', alpha, beta, radius, target, scene);
@@ -38,8 +38,9 @@ export function setupArcRotateCamera(
   camera.wheelPrecision = 3;
   camera.pinchPrecision = 50;
   camera.panningSensibility = 0;
+  // 로그 뎁스 버퍼 전제 — 극단 near/far (행성 표면 ~ 태양계 외곽 이상)
   camera.minZ = 0.01;
-  camera.maxZ = 1e9;
+  camera.maxZ = 1e14;
 
   const canvas = scene.getEngine().getRenderingCanvas();
   if (canvas) {

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -9,3 +9,6 @@ export { setupArcRotateCamera } from './camera.js';
 export type { ArcCameraOptions } from './camera.js';
 export { createSunEarthDemo } from './sun-earth-demo.js';
 export type { SunEarthDemoHandles } from './sun-earth-demo.js';
+export { enableLogarithmicDepth } from './log-depth.js';
+export { createNearFarProbe } from './near-far-probe.js';
+export type { NearFarProbeHandles } from './near-far-probe.js';

--- a/packages/core/src/scene/log-depth.ts
+++ b/packages/core/src/scene/log-depth.ts
@@ -1,0 +1,20 @@
+import type { Material, Scene } from '@babylonjs/core';
+
+/**
+ * 로그 뎁스 버퍼 활성화.
+ *
+ * 태양계 규모(~10^13m)부터 행성 표면(~10m)까지 동시 렌더 시 선형 depth buffer는
+ * Z-fighting 및 정밀도 부족을 유발한다. 로그 뎁스는 원거리까지 정밀도를 유지한다.
+ *
+ * Babylon은 material 단위 플래그 — 씬 전체 적용과 향후 생성될 머티리얼도 자동 적용한다.
+ */
+export function enableLogarithmicDepth(scene: Scene): void {
+  for (const m of scene.materials) {
+    m.useLogarithmicDepth = true;
+  }
+
+  // 이후 추가되는 머티리얼에도 자동 적용
+  scene.onNewMaterialAddedObservable.add((m: Material) => {
+    m.useLogarithmicDepth = true;
+  });
+}

--- a/packages/core/src/scene/near-far-probe.ts
+++ b/packages/core/src/scene/near-far-probe.ts
@@ -1,0 +1,51 @@
+import {
+  Color3,
+  MeshBuilder,
+  StandardMaterial,
+  Vector3,
+  type Mesh,
+  type Scene,
+} from '@babylonjs/core';
+
+export interface NearFarProbeHandles {
+  near: Mesh;
+  far: Mesh;
+  dispose: () => void;
+}
+
+/**
+ * B5 (#12) 검증용 — 근거리 1m + 원거리 10^12m 구체 동시 배치.
+ *
+ * 로그 뎁스 버퍼 작동 여부를 육안으로 확인하는 디버그 씬.
+ * 두 구체 모두 선명하게 그려지고 Z-fighting이 없어야 한다.
+ *
+ * E2 (#31) 브라우저 3단계 검증에서 시각 확인.
+ */
+export function createNearFarProbe(scene: Scene): NearFarProbeHandles {
+  // 근거리 — 카메라 앞 1m 지점
+  const near = MeshBuilder.CreateSphere('probe-near', { diameter: 0.5, segments: 24 }, scene);
+  near.position = new Vector3(1, 0, 0);
+  const nearMat = new StandardMaterial('probe-near-mat', scene);
+  nearMat.emissiveColor = new Color3(0.44, 0.87, 0.7); // nebula-teal
+  nearMat.disableLighting = true;
+  near.material = nearMat;
+
+  // 원거리 — 10^12m (천왕성 궤도 수준)
+  const far = MeshBuilder.CreateSphere('probe-far', { diameter: 1e10, segments: 24 }, scene);
+  far.position = new Vector3(1e12, 0, 0);
+  const farMat = new StandardMaterial('probe-far-mat', scene);
+  farMat.emissiveColor = new Color3(1, 0.72, 0.47); // star-k
+  farMat.disableLighting = true;
+  far.material = farMat;
+
+  return {
+    near,
+    far,
+    dispose: () => {
+      nearMat.dispose();
+      farMat.dispose();
+      near.dispose();
+      far.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- enableLogarithmicDepth 유틸 (씬 전체 + 미래 머티리얼 자동)
- createNearFarProbe 검증 씬
- 카메라 near/far 극단 범위 확장

## 검증
- typecheck/build/lint/test(16개) 통과
- 브라우저 시각 검증은 E2 (#31)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)