### PR TITLE
[fix] WebGPU adapter 사전 체크 + 브라우저 3단계 검증 스크립트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 # TypeScript 빌드 캐시
 *.tsbuildinfo
 
+.verify-screenshots/

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "format:check": "prettier --check .",
     "lint:core": "eslint packages/core/src",
     "lint:shared": "eslint packages/shared/src",
-    "check-encoding": "bash scripts/check-encoding.sh"
+    "check-encoding": "bash scripts/check-encoding.sh",
+    "verify:browser": "node scripts/browser-verify.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -39,6 +40,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "playwright": "^1.59.1",
     "prettier": "^3.8.2",
     "typescript": "^6.0.2"
   },

--- a/packages/core/src/engine/engine-factory.ts
+++ b/packages/core/src/engine/engine-factory.ts
@@ -10,13 +10,14 @@ export interface CreatedEngine {
 /**
  * WebGPU 우선 시도 후 실패 시 WebGL2로 폴백한다.
  * ADR: docs/phases/architecture.md §6 "WebGPU-first + WebGL2 폴백"
+ *
+ * WebGPUEngine 생성 전에 navigator.gpu.requestAdapter()를 먼저 시도하여
+ * 실제 사용 가능한 adapter가 있는 경우에만 진행한다.
+ * 이렇게 하지 않으면 Babylon 내부에서 console.error로 실패 로그가 먼저 찍힌다
+ * (try/catch로 잡히지 않음).
  */
 export async function createEngine(canvas: HTMLCanvasElement): Promise<CreatedEngine> {
-  // WebGPU 지원 확인
-  const webgpuSupported =
-    typeof navigator !== 'undefined' && 'gpu' in navigator && Boolean(navigator.gpu);
-
-  if (webgpuSupported) {
+  if (await isWebGpuUsable()) {
     try {
       const engine = new WebGPUEngine(canvas, {
         antialias: true,
@@ -26,7 +27,7 @@ export async function createEngine(canvas: HTMLCanvasElement): Promise<CreatedEn
       await engine.initAsync();
       return { engine, kind: 'webgpu' };
     } catch (error) {
-      // WebGPU 초기화 실패 — WebGL2로 폴백
+      // adapter는 있었으나 초기화 중 실패 — WebGL2로 폴백
       console.warn('[engine-factory] WebGPU 초기화 실패, WebGL2로 폴백합니다.', error);
     }
   }
@@ -37,4 +38,24 @@ export async function createEngine(canvas: HTMLCanvasElement): Promise<CreatedEn
     adaptToDeviceRatio: true,
   });
   return { engine, kind: 'webgl2' };
+}
+
+/**
+ * 현재 환경에서 WebGPU 사용이 가능한지 사전 판별.
+ * - navigator.gpu 존재
+ * - requestAdapter() 가 null이 아닌 adapter 반환
+ *
+ * 헤드리스 브라우저(Playwright Chromium 등)는 gpu 객체는 있으나 adapter가 null이므로
+ * 여기서 즉시 false로 판별되어 WebGL2 경로로 이동.
+ */
+async function isWebGpuUsable(): Promise<boolean> {
+  if (typeof navigator === 'undefined') return false;
+  const gpu = (navigator as Navigator & { gpu?: GPU }).gpu;
+  if (!gpu) return false;
+  try {
+    const adapter = await gpu.requestAdapter();
+    return adapter !== null;
+  } catch {
+    return false;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       prettier:
         specifier: ^3.8.2
         version: 3.8.2

--- a/scripts/browser-verify.mjs
+++ b/scripts/browser-verify.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * UI 브라우저 3단계 검증 (CRITICAL #3 준수).
+ *
+ * 사용: node scripts/browser-verify.mjs [baseUrl]
+ * 기본 URL: http://localhost:3001
+ *
+ * Level 1 정적:    콘솔 에러 없음, canvas/HUD 렌더
+ * Level 2 인터랙션: ping 버튼 동작
+ * Level 3 흐름:    ko/en 전환, URL 동작
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotDir = join(__dirname, '..', '.verify-screenshots');
+mkdirSync(screenshotDir, { recursive: true });
+
+const results = { pass: [], fail: [], warn: [] };
+const check = (name, condition, detail = '') => {
+  if (condition) results.pass.push(`${name}${detail ? ' — ' + detail : ''}`);
+  else results.fail.push(`${name}${detail ? ' — ' + detail : ''}`);
+};
+const warn = (msg) => results.warn.push(msg);
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const consoleErrors = [];
+const pageErrors = [];
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text());
+});
+page.on('pageerror', (err) => pageErrors.push(err.message));
+
+// ===== Level 1: 정적 =====
+console.log('\n[Level 1] 정적 검증');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500); // Babylon 초기화 대기
+
+// HUD 텍스트 확인
+const hudText = await page.textContent('body');
+check('canvas 엘리먼트 존재', (await page.$('canvas')) !== null);
+check(
+  'HUD renderer 표시',
+  /renderer\s*·\s*(webgpu|webgl2)/.test(hudText ?? ''),
+  (hudText ?? '').match(/renderer\s*·\s*\w+/)?.[0] ?? '없음',
+);
+check('ping 버튼 존재', (await page.$('button:has-text("ping:")')) !== null);
+check('언어 ko 설정', (await page.evaluate(() => document.documentElement.lang)) === 'ko');
+check(
+  'data-mode=observe',
+  (await page.evaluate(() => document.documentElement.getAttribute('data-mode'))) === 'observe',
+);
+
+await page.screenshot({ path: join(screenshotDir, '01-static-ko.png'), fullPage: false });
+
+// ===== Level 2: 인터랙션 =====
+console.log('\n[Level 2] 인터랙션 검증');
+const pingBtn = await page.$('button:has-text("ping:")');
+if (pingBtn) {
+  const before = await pingBtn.textContent();
+  await pingBtn.click();
+  await page.waitForTimeout(200);
+  const after = await pingBtn.textContent();
+  const beforeN = parseInt((before ?? '').match(/\d+/)?.[0] ?? '0', 10);
+  const afterN = parseInt((after ?? '').match(/\d+/)?.[0] ?? '0', 10);
+  check('ping 버튼 클릭 시 카운터 증가', afterN === beforeN + 1, `${beforeN} → ${afterN}`);
+} else {
+  check('ping 버튼 클릭 시 카운터 증가', false, 'ping 버튼 못 찾음');
+}
+
+await page.screenshot({ path: join(screenshotDir, '02-interaction.png') });
+
+// 마우스 드래그 — 카메라 움직임 (콘솔 에러 없이 수행되는지만 확인)
+const canvas = await page.$('canvas');
+if (canvas) {
+  const box = await canvas.boundingBox();
+  if (box) {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 100, box.y + box.height / 2 + 50, { steps: 10 });
+    await page.mouse.up();
+  }
+}
+check('캔버스 드래그 후 런타임 에러 없음', pageErrors.length === 0);
+
+// ===== Level 3: 흐름 =====
+console.log('\n[Level 3] 흐름 검증');
+await page.goto(`${baseUrl}/en`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1000);
+check(
+  'en 로케일 전환 — lang 속성',
+  (await page.evaluate(() => document.documentElement.lang)) === 'en',
+);
+
+// 루트 / → 리다이렉트 확인
+const resp = await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle' });
+check('/ → 로케일 리다이렉트', resp !== null && resp.status() < 400);
+const urlAfter = page.url();
+check('기본 로케일 경로 (/ko 또는 /en)', /\/(ko|en)(\/|$)/.test(urlAfter), `URL = ${urlAfter}`);
+
+await page.screenshot({ path: join(screenshotDir, '03-flow-en.png') });
+
+// ===== 콘솔/에러 요약 =====
+console.log('\n[콘솔/에러]');
+if (consoleErrors.length > 0) {
+  // next/dynamic BailoutToCSR 은 정상 (SSR → CSR 폴백 메시지)
+  const filtered = consoleErrors.filter(
+    (e) => !/BailoutToCSR|Switched to client rendering/.test(e),
+  );
+  if (filtered.length === 0) {
+    warn(`console.error ${consoleErrors.length}건 (모두 SSR→CSR 폴백, 정상)`);
+  } else {
+    console.log('실제 콘솔 에러:');
+    filtered.forEach((e) => console.log('  -', e));
+    check('콘솔 에러 없음', false, `${filtered.length}건`);
+  }
+}
+if (pageErrors.length > 0) {
+  console.log('페이지 런타임 에러:');
+  pageErrors.forEach((e) => console.log('  -', e));
+  check('런타임 에러 없음', false, `${pageErrors.length}건`);
+} else {
+  check('런타임 에러 없음', true);
+}
+
+await browser.close();
+
+// ===== 결과 =====
+console.log('\n========================================');
+console.log(`PASS: ${results.pass.length}건`);
+results.pass.forEach((p) => console.log(`  ✓ ${p}`));
+if (results.warn.length > 0) {
+  console.log(`\nWARN: ${results.warn.length}건`);
+  results.warn.forEach((w) => console.log(`  ⚠ ${w}`));
+}
+if (results.fail.length > 0) {
+  console.log(`\nFAIL: ${results.fail.length}건`);
+  results.fail.forEach((f) => console.log(`  ✗ ${f}`));
+  process.exit(1);
+}
+console.log(`\n스크린샷: ${screenshotDir}`);
+console.log('모든 검증 통과 ✓');


### PR DESCRIPTION
## 배경
CRITICAL #3(UI 작업 브라우저 3단계 검증) 위반 자인 후 교정.

## 변경
### engine-factory
WebGPUEngine 생성 전 navigator.gpu.requestAdapter() 사전 판별.
헤드리스/미지원 환경에서 Babylon 내부 console.error 오염 제거.

### scripts/browser-verify.mjs
Playwright 기반 3단계 자동 검증:
- Level 1 정적: canvas/HUD/lang/mode
- Level 2 인터랙션: ping 클릭 라운드트립 + 드래그
- Level 3 흐름: 로케일 전환, 리다이렉트
- 스크린샷 3장

## 검증 결과
- PASS 11건, 콘솔 에러 0건
- 태양(노랑) + 지구(파랑) 구체 확인 — 스크린샷 첨부됨

## 이후
UI 포함 PR마다 pnpm verify:browser 실행 워크플로우 정립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)