### PR TITLE
[#14] Kepler 궤도 해석해 + 단위 테스트

### DIFF
--- a/packages/core/src/physics/index.ts
+++ b/packages/core/src/physics/index.ts
@@ -1,12 +1,16 @@
 /**
  * 물리 모듈.
  *
- * P1: Kepler 궤도 해석해
+ * P1: Kepler 궤도 해석해 (이 파일)
  * P2: Leapfrog/Verlet 심플렉틱 N-body 적분기
  * P3: WebGPU Compute 기반 대규모 N-body
  * P4: 일반상대론 효과 (수성 근일점, 중력렌즈)
- *
- * P1 Kepler 구현은 C2 (#14)에서 수행.
  */
 
-export {};
+export {
+  solveKeplerEquation,
+  trueAnomalyFromEccentric,
+  meanAnomalyAt,
+  positionAt,
+  orbitalPeriod,
+} from './kepler.js';

--- a/packages/core/src/physics/kepler.test.ts
+++ b/packages/core/src/physics/kepler.test.ts
@@ -1,0 +1,136 @@
+import {
+  AU,
+  GRAVITATIONAL_CONSTANT,
+  J2000_JD,
+  JULIAN_YEAR_SECONDS,
+  SOLAR_MASS,
+} from '@astro-simulator/shared';
+import { describe, expect, it } from 'vitest';
+import { length } from '../coords/vec3.js';
+import { getSolarSystem } from '../ephemeris/solar-system-loader.js';
+import {
+  meanAnomalyAt,
+  orbitalPeriod,
+  positionAt,
+  solveKeplerEquation,
+  trueAnomalyFromEccentric,
+} from './kepler.js';
+
+const MU_SUN = GRAVITATIONAL_CONSTANT * SOLAR_MASS;
+
+describe('solveKeplerEquation', () => {
+  it('e=0 (원형) 은 E = M', () => {
+    expect(solveKeplerEquation(0.5, 0)).toBeCloseTo(0.5, 10);
+    expect(solveKeplerEquation(-1, 0)).toBeCloseTo(-1, 10);
+  });
+
+  it('M=0 이면 E=0', () => {
+    expect(solveKeplerEquation(0, 0.5)).toBeCloseTo(0, 10);
+  });
+
+  it('Kepler 방정식 항등식 만족 — M = E - e·sin E', () => {
+    const cases = [
+      { M: 1.2, e: 0.1 },
+      { M: -0.8, e: 0.3 },
+      { M: 2.5, e: 0.5 },
+      { M: 3.0, e: 0.8 },
+      { M: 0.1, e: 0.95 },
+    ];
+    for (const c of cases) {
+      const E = solveKeplerEquation(c.M, c.e);
+      const reconstructed = E - c.e * Math.sin(E);
+      // M은 [-π, π]로 정규화되어 비교
+      let Mnorm = c.M % (2 * Math.PI);
+      if (Mnorm > Math.PI) Mnorm -= 2 * Math.PI;
+      if (Mnorm < -Math.PI) Mnorm += 2 * Math.PI;
+      expect(reconstructed).toBeCloseTo(Mnorm, 8);
+    }
+  });
+
+  it('e ≥ 1 은 에러', () => {
+    expect(() => solveKeplerEquation(1, 1)).toThrow();
+    expect(() => solveKeplerEquation(1, 1.5)).toThrow();
+    expect(() => solveKeplerEquation(1, -0.1)).toThrow();
+  });
+});
+
+describe('trueAnomalyFromEccentric', () => {
+  it('E=0 이면 ν=0', () => {
+    expect(trueAnomalyFromEccentric(0, 0.1)).toBeCloseTo(0, 10);
+  });
+
+  it('e=0 이면 ν=E', () => {
+    expect(trueAnomalyFromEccentric(0.7, 0)).toBeCloseTo(0.7, 10);
+  });
+});
+
+describe('orbitalPeriod', () => {
+  it('지구 공전주기 ≈ 365.25일 (±0.1% 이내)', () => {
+    const periodSec = orbitalPeriod(AU, MU_SUN);
+    const periodDays = periodSec / 86400;
+    expect(periodDays).toBeGreaterThan(365.25 * 0.999);
+    expect(periodDays).toBeLessThan(365.25 * 1.001);
+  });
+
+  it('수성 공전주기 ≈ 87.97일', () => {
+    const periodSec = orbitalPeriod(0.38709927 * AU, MU_SUN);
+    const periodDays = periodSec / 86400;
+    expect(periodDays).toBeCloseTo(87.97, 0);
+  });
+});
+
+describe('positionAt — 태양계 실제 궤도 요소 검증', () => {
+  const system = getSolarSystem();
+  const planets = system.bodies.filter((b) => b.orbit && b.parentId === 'sun');
+
+  it('J2000.0 epoch에서 지구 거리 ∈ [근일점, 원일점] (~0.98~1.02 AU)', () => {
+    // 지구 e=0.0167 → 거리는 AU × (1 ± e) 범위
+    const earth = planets.find((b) => b.id === 'earth');
+    if (!earth?.orbit) throw new Error('earth not found');
+    const pos = positionAt(earth.orbit, J2000_JD, MU_SUN);
+    const r = length(pos);
+    expect(r).toBeGreaterThan(AU * 0.98);
+    expect(r).toBeLessThan(AU * 1.02);
+  });
+
+  it('모든 행성 J2000.0 거리가 근일점~원일점 범위 내', () => {
+    for (const p of planets) {
+      if (!p.orbit) continue;
+      const { semiMajorAxis: a, eccentricity: e } = p.orbit;
+      const periapsis = a * (1 - e);
+      const apoapsis = a * (1 + e);
+      const pos = positionAt(p.orbit, J2000_JD, MU_SUN);
+      const r = length(pos);
+      expect(r).toBeGreaterThanOrEqual(periapsis * 0.999);
+      expect(r).toBeLessThanOrEqual(apoapsis * 1.001);
+    }
+  });
+
+  it('지구 1년 후 위치는 초기 위치 근처로 복귀 (±1% 이내, Kepler 주기성)', () => {
+    const earth = planets.find((b) => b.id === 'earth');
+    if (!earth?.orbit) throw new Error('earth not found');
+    const p0 = positionAt(earth.orbit, J2000_JD, MU_SUN);
+    const p1 = positionAt(earth.orbit, J2000_JD + 365.25636, MU_SUN); // 항성년
+    const diff = Math.hypot(p0[0] - p1[0], p0[1] - p1[1], p0[2] - p1[2]);
+    const scale = length(p0);
+    expect(diff / scale).toBeLessThan(0.01);
+  });
+
+  it('수성 88일 주기', () => {
+    const mercury = planets.find((b) => b.id === 'mercury');
+    if (!mercury?.orbit) throw new Error('mercury not found');
+    const period = orbitalPeriod(mercury.orbit.semiMajorAxis, MU_SUN) / 86400;
+    expect(period).toBeCloseTo(87.97, 0);
+  });
+
+  it('meanAnomalyAt — 1년 후 약 2π 증가 (지구)', () => {
+    const earth = planets.find((b) => b.id === 'earth');
+    if (!earth?.orbit) throw new Error('earth not found');
+    const M0 = meanAnomalyAt(earth.orbit, J2000_JD, MU_SUN);
+    const M1 = meanAnomalyAt(earth.orbit, J2000_JD + 365.25636, MU_SUN);
+    const delta = M1 - M0;
+    expect(delta).toBeCloseTo(2 * Math.PI, 2);
+    // JULIAN_YEAR_SECONDS 사용 smoke check
+    expect(JULIAN_YEAR_SECONDS).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/physics/kepler.ts
+++ b/packages/core/src/physics/kepler.ts
@@ -1,0 +1,134 @@
+import type { Vec3Double } from '../coords/vec3.js';
+import type { LoadedOrbitalElements } from '../ephemeris/solar-system-loader.js';
+
+/**
+ * Kepler 2-body 해석해.
+ *
+ * ADR: docs/phases/architecture.md §5
+ * P1: 해석해로 충분 (행성간 섭동 무시, 태양계 단기간 정확도 ±1%)
+ * P2+: 심플렉틱 N-body로 교체
+ */
+
+const TWO_PI = Math.PI * 2;
+
+/**
+ * Kepler 방정식 M = E - e·sin E 를 Newton-Raphson으로 풀어 이심이상 E를 구한다.
+ *
+ * @param meanAnomaly 평균이상 M [rad]
+ * @param eccentricity 이심률 e (0 ≤ e < 1)
+ * @param tolerance 수렴 임계 (rad)
+ * @param maxIter 최대 반복 횟수
+ * @returns 이심이상 E [rad]
+ */
+export function solveKeplerEquation(
+  meanAnomaly: number,
+  eccentricity: number,
+  tolerance = 1e-10,
+  maxIter = 50,
+): number {
+  if (!(eccentricity >= 0) || eccentricity >= 1) {
+    throw new Error(`Kepler 해석해는 타원 궤도 전용 (0 ≤ e < 1), 입력: e=${eccentricity}`);
+  }
+
+  // M을 [-π, π]로 정규화 후 초기 추정값
+  let M = meanAnomaly % TWO_PI;
+  if (M > Math.PI) M -= TWO_PI;
+  if (M < -Math.PI) M += TWO_PI;
+
+  // 초기 추정: 낮은 e는 M, 높은 e는 π 근처
+  let E = eccentricity < 0.8 ? M : Math.PI * Math.sign(M || 1);
+
+  for (let i = 0; i < maxIter; i += 1) {
+    const f = E - eccentricity * Math.sin(E) - M;
+    const fp = 1 - eccentricity * Math.cos(E);
+    const dE = f / fp;
+    E -= dE;
+    if (Math.abs(dE) < tolerance) return E;
+  }
+
+  throw new Error(
+    `Kepler 방정식 수렴 실패 (M=${meanAnomaly}, e=${eccentricity}, maxIter=${maxIter})`,
+  );
+}
+
+/**
+ * 이심이상 E → 진근점각 ν.
+ */
+export function trueAnomalyFromEccentric(eccentricAnomaly: number, eccentricity: number): number {
+  const cosE = Math.cos(eccentricAnomaly);
+  const sinE = Math.sin(eccentricAnomaly);
+  const e = eccentricity;
+  // 표준 공식. atan2로 분기 처리
+  return Math.atan2(Math.sqrt(1 - e * e) * sinE, cosE - e);
+}
+
+/**
+ * 현 시점 평균이상 M(t) — 주어진 궤도와 중심 중력파라미터 μ 하에서.
+ *
+ * @param elements 궤도 요소
+ * @param julianDate 현재 시각 (JD)
+ * @param mu 중심 질량체의 중력 파라미터 μ = G·M_central [m^3/s^2]
+ */
+export function meanAnomalyAt(
+  elements: LoadedOrbitalElements,
+  julianDate: number,
+  mu: number,
+): number {
+  const a = elements.semiMajorAxis;
+  const n = Math.sqrt(mu / (a * a * a)); // 평균 운동 [rad/s]
+  const dtSeconds = (julianDate - elements.epoch) * 86_400;
+  return elements.meanAnomalyAtEpoch + n * dtSeconds;
+}
+
+/**
+ * 3D 위치 계산 — 중심 천체(부모) 기준 좌표.
+ *
+ * 좌표계: 부모 천체의 적도/황도 기준 평면(행성=황도, 달=지구 적도 or 황도).
+ * P1에서는 모든 궤도를 같은 기준 평면으로 간주한다 (J2000 ecliptic).
+ */
+export function positionAt(
+  elements: LoadedOrbitalElements,
+  julianDate: number,
+  mu: number,
+): Vec3Double {
+  const M = meanAnomalyAt(elements, julianDate, mu);
+  const E = solveKeplerEquation(M, elements.eccentricity);
+  const nu = trueAnomalyFromEccentric(E, elements.eccentricity);
+
+  const a = elements.semiMajorAxis;
+  const e = elements.eccentricity;
+  const r = a * (1 - e * Math.cos(E));
+
+  // 궤도면 좌표 (근일점 방향 = +x)
+  const xOrb = r * Math.cos(nu);
+  const yOrb = r * Math.sin(nu);
+
+  // 3D 회전: Rz(Ω) · Rx(i) · Rz(ω) · (xOrb, yOrb, 0)
+  const cosO = Math.cos(elements.longitudeOfAscendingNode);
+  const sinO = Math.sin(elements.longitudeOfAscendingNode);
+  const cosI = Math.cos(elements.inclination);
+  const sinI = Math.sin(elements.inclination);
+  const cosW = Math.cos(elements.argumentOfPeriapsis);
+  const sinW = Math.sin(elements.argumentOfPeriapsis);
+
+  // Rz(ω) · (xOrb, yOrb, 0)
+  const x1 = cosW * xOrb - sinW * yOrb;
+  const y1 = sinW * xOrb + cosW * yOrb;
+  // Rx(i): y, z 회전
+  const x2 = x1;
+  const y2 = cosI * y1;
+  const z2 = sinI * y1;
+  // Rz(Ω)
+  const x = cosO * x2 - sinO * y2;
+  const y = sinO * x2 + cosO * y2;
+  const z = z2;
+
+  return [x, y, z];
+}
+
+/**
+ * 궤도 공전주기 T = 2π √(a³/μ) [s]
+ */
+export function orbitalPeriod(semiMajorAxis: number, mu: number): number {
+  return TWO_PI * Math.sqrt((semiMajorAxis * semiMajorAxis * semiMajorAxis) / mu);
+}


### PR DESCRIPTION
## Summary
- Newton-Raphson Kepler 방정식 해법
- 궤도면 → 3D 공간 회전 (Rz·Rx·Rz)
- positionAt / orbitalPeriod / meanAnomalyAt

## 검증
- 테스트 35개 통과 (+13)
- 실제 행성 궤도 요소로 검증
  - 지구 365.25일, 수성 87.97일
  - 거리 [근일점, 원일점] 범위
- typecheck/build/lint 통과

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)