### PR TITLE
[#28 #29] DateTimePicker + UnitToggle + URL 상태 동기화

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { NextIntlClientProvider, hasLocale } from 'next-intl';
 import { notFound } from 'next/navigation';
 import { JetBrains_Mono, Space_Grotesk } from 'next/font/google';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { routing } from '@/i18n/routing';
 import type { ReactNode } from 'react';
 import 'pretendard/dist/web/variable/pretendardvariable.css';
@@ -47,7 +48,9 @@ export default async function LocaleLayout({
       data-mode="observe"
     >
       <body>
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <NuqsAdapter>
+          <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -8,6 +8,9 @@ import { ModeSwitcher } from './mode-switcher';
 import { SidePanels } from './side-panels';
 import { ScaleControl } from './scale-control';
 import { TimeControls } from './time-controls';
+import { DateTimePicker } from './date-time-picker';
+import { UnitToggle } from './unit-toggle';
+import { UrlSync } from '../../core/url-sync';
 import { SimCanvasDynamic } from '../sim-canvas.dynamic';
 
 /**
@@ -26,7 +29,14 @@ export function AppShell() {
               <FocusQuickButtons />
             </div>
           }
+          right={
+            <div className="flex items-center gap-2">
+              <DateTimePicker />
+              <UnitToggle />
+            </div>
+          }
         />
+        <UrlSync />
         <HudCorners />
         <SidePanels />
         <ScaleControl />

--- a/apps/web/src/components/layout/date-time-picker.tsx
+++ b/apps/web/src/components/layout/date-time-picker.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+import { useSimCommand } from '@/core/sim-context';
+
+/**
+ * DateTimePicker — 특정 UTC 시점으로 점프.
+ * 입력 형식: YYYY-MM-DDTHH:mm (datetime-local)
+ */
+export function DateTimePicker() {
+  const [value, setValue] = useState('');
+  const sendCommand = useSimCommand();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleJump = () => {
+    if (!value) return;
+    try {
+      const iso = new Date(value).toISOString();
+      sendCommand({ type: 'jumpToDate', isoUtc: iso });
+      setError(null);
+    } catch {
+      setError('잘못된 날짜');
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1" data-testid="datetime-picker">
+      <input
+        type="datetime-local"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="num text-caption bg-bg-surface/80 backdrop-blur border border-border-subtle rounded-sm px-2 py-1 text-fg-primary focus:outline-none focus:border-primary/50"
+        data-testid="datetime-input"
+      />
+      <button
+        type="button"
+        onClick={handleJump}
+        disabled={!value}
+        className="num text-caption px-2 py-1 rounded-sm border bg-bg-surface/80 text-fg-secondary border-border-subtle hover:bg-bg-elevated disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        style={{ transitionDuration: 'var(--duration-fast)' }}
+        data-testid="datetime-jump"
+      >
+        점프
+      </button>
+      {error && <span className="text-caption text-danger">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/unit-toggle.tsx
+++ b/apps/web/src/components/layout/unit-toggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useSimStore, type UnitSystem } from '@/store/sim-store';
+
+const UNITS: { id: UnitSystem; label: string; desc: string }[] = [
+  { id: 'si', label: 'SI', desc: '미터/킬로그램/초' },
+  { id: 'astro', label: 'AU', desc: '천문 단위 (AU/ly/pc)' },
+  { id: 'natural', label: 'Nat', desc: '자연 단위 (c=1, ℏ=1)' },
+];
+
+/**
+ * 단위계 토글. 표시 단위 전역 선택 (실제 포매팅은 P2에서 확장).
+ */
+export function UnitToggle() {
+  const unit = useSimStore((s) => s.unitSystem);
+  const setUnit = useSimStore((s) => s.setUnitSystem);
+
+  return (
+    <div
+      className="flex items-center gap-0.5 bg-bg-surface/80 backdrop-blur border border-border-subtle rounded-sm p-0.5"
+      data-testid="unit-toggle"
+    >
+      {UNITS.map((u) => {
+        const active = unit === u.id;
+        return (
+          <button
+            key={u.id}
+            type="button"
+            onClick={() => setUnit(u.id)}
+            title={u.desc}
+            data-testid={`unit-${u.id}`}
+            className={`num text-caption px-2 py-0.5 rounded-xs transition-colors ${
+              active ? 'bg-primary/25 text-fg-primary' : 'text-fg-secondary hover:bg-bg-elevated'
+            }`}
+            style={{ transitionDuration: 'var(--duration-fast)' }}
+          >
+            {u.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/core/url-sync.tsx
+++ b/apps/web/src/core/url-sync.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { SimMode } from '@astro-simulator/shared';
+import { parseAsFloat, parseAsString, parseAsStringEnum, useQueryState } from 'nuqs';
+import { useEffect, useRef } from 'react';
+import { useSimStore } from '@/store/sim-store';
+import { useSimCommand } from './sim-context';
+
+const MODE_VALUES: SimMode[] = ['observe', 'research', 'education', 'sandbox'];
+
+/**
+ * URL ↔ 시뮬레이션 상태 동기화.
+ *  - mode, focus, speed: store ↔ URL 양방향
+ *  - t (Julian Date): 초기 로드 시에만 URL → store (매 프레임 쓰기 하면 리렌더 폭주)
+ *
+ * 시간 공유는 향후 "스냅샷/북마크" 기능으로 분리.
+ */
+export function UrlSync() {
+  const [urlMode, setUrlMode] = useQueryState(
+    'mode',
+    parseAsStringEnum<SimMode>(MODE_VALUES).withOptions({ history: 'replace' }),
+  );
+  const [urlT] = useQueryState('t', parseAsFloat.withOptions({ history: 'replace' }));
+  const [urlFocus, setUrlFocus] = useQueryState(
+    'focus',
+    parseAsString.withOptions({ history: 'replace' }),
+  );
+  const [urlSpeed, setUrlSpeed] = useQueryState(
+    'speed',
+    parseAsFloat.withOptions({ history: 'replace' }),
+  );
+
+  const mode = useSimStore((s) => s.mode);
+  const selectedBodyId = useSimStore((s) => s.selectedBodyId);
+  const timeScale = useSimStore((s) => s.timeScale);
+  const setMode = useSimStore((s) => s.setMode);
+
+  const sendCommand = useSimCommand();
+  const initialized = useRef(false);
+
+  // 초기 URL → store (최초 1회)
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    if (urlMode) {
+      setMode(urlMode);
+      sendCommand({ type: 'setMode', mode: urlMode });
+    }
+    if (urlT !== null && urlT !== undefined && Number.isFinite(urlT)) {
+      sendCommand({ type: 'jumpToJulianDate', julianDate: urlT });
+    }
+    if (urlFocus) {
+      sendCommand({ type: 'focusOn', bodyId: urlFocus });
+    }
+    if (urlSpeed !== null && urlSpeed !== undefined && Number.isFinite(urlSpeed)) {
+      sendCommand({ type: 'setTimeScale', scale: urlSpeed });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // store → URL (mode/focus/speed만)
+  useEffect(() => {
+    if (!initialized.current) return;
+    setUrlMode(mode === 'observe' ? null : mode);
+  }, [mode, setUrlMode]);
+
+  useEffect(() => {
+    if (!initialized.current) return;
+    setUrlFocus(selectedBodyId);
+  }, [selectedBodyId, setUrlFocus]);
+
+  useEffect(() => {
+    if (!initialized.current) return;
+    setUrlSpeed(timeScale === 86_400 ? null : timeScale);
+  }, [timeScale, setUrlSpeed]);
+
+  return null;
+}

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -1,6 +1,8 @@
 import type { SimMode } from '@astro-simulator/shared';
 import { create } from 'zustand';
 
+export type UnitSystem = 'si' | 'astro' | 'natural';
+
 /**
  * 시뮬레이션 UI 상태 store.
  *
@@ -18,6 +20,7 @@ export interface SimStoreState {
   selectedBodyId: string | null;
   timeScale: number;
   fps: number | null;
+  unitSystem: UnitSystem;
 
   // 개발/디버그용 라운드트립 카운터
   pingCount: number;
@@ -31,6 +34,7 @@ export interface SimStoreState {
   setSelectedBody: (id: string | null) => void;
   setTimeScale: (scale: number) => void;
   setFps: (fps: number) => void;
+  setUnitSystem: (unit: UnitSystem) => void;
   incrementPing: () => void;
 }
 
@@ -42,6 +46,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   selectedBodyId: null,
   timeScale: 86_400,
   fps: null,
+  unitSystem: 'astro',
   pingCount: 0,
   lastPingAt: null,
 
@@ -52,6 +57,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   setSelectedBody: (id) => set({ selectedBodyId: id }),
   setTimeScale: (scale) => set({ timeScale: scale }),
   setFps: (fps) => set({ fps }),
+  setUnitSystem: (unit) => set({ unitSystem: unit }),
   incrementPing: () =>
     set((state) => ({
       pingCount: state.pingCount + 1,

--- a/scripts/browser-verify.mjs
+++ b/scripts/browser-verify.mjs
@@ -78,6 +78,19 @@ if (earthBtn) {
   check('지구 포커스 클릭 시 selected 상태 전환', false, '지구 버튼 못 찾음');
 }
 
+// DateTimePicker / UnitToggle 렌더
+check('DateTimePicker 렌더', (await page.$('[data-testid="datetime-picker"]')) !== null);
+check('UnitToggle 렌더', (await page.$('[data-testid="unit-toggle"]')) !== null);
+
+// UnitToggle 클릭
+const siUnit = await page.$('[data-testid="unit-si"]');
+if (siUnit) {
+  await siUnit.click();
+  await page.waitForTimeout(100);
+  const cls = (await siUnit.getAttribute('class')) ?? '';
+  check('SI 단위 토글 클릭 시 active', cls.includes('bg-primary/25'));
+}
+
 // 모드 전환 — research 클릭
 const researchBtn = await page.$('[data-testid="mode-research"]');
 if (researchBtn) {
@@ -155,6 +168,12 @@ check(
   'en 로케일 전환 — lang 속성',
   (await page.evaluate(() => document.documentElement.lang)) === 'en',
 );
+
+// URL 동기화 검증 — 연구 모드 상태 URL에 반영
+await page.goto(`${baseUrl}/ko?mode=research`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(800);
+const urlMode = await page.evaluate(() => document.documentElement.getAttribute('data-mode'));
+check('URL mode=research 복원', urlMode === 'research', `data-mode=${urlMode}`);
 
 // 루트 / → 리다이렉트 확인
 const resp = await page.goto(`${baseUrl}/`, { waitUntil: 'networkidle' });


### PR DESCRIPTION
## Summary
- DateTimePicker (datetime-local → jumpToDate)
- UnitToggle (SI/AU/Natural, store.unitSystem)
- URL sync (mode/focus/speed 양방향; JD는 초기 로드만)

## 검증 ✅ PASS 25건, 에러 0건

Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)