### PR TITLE
[fix] apps/web Vitest + UI 테스트 37개 + 모바일 뷰포트 검증

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astro-simulator/core": "workspace:*",

--- a/apps/web/src/components/layout/date-time-picker.test.tsx
+++ b/apps/web/src/components/layout/date-time-picker.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreCommand } from '@astro-simulator/shared';
+import { DateTimePicker } from './date-time-picker';
+
+let sentCommands: CoreCommand[] = [];
+vi.mock('@/core/sim-context', () => ({
+  useSimCommand: () => (cmd: CoreCommand) => {
+    sentCommands.push(cmd);
+  },
+}));
+
+beforeEach(() => {
+  sentCommands = [];
+});
+
+describe('DateTimePicker', () => {
+  it('datetime 입력 + 점프 버튼 렌더', () => {
+    render(<DateTimePicker />);
+    expect(screen.getByTestId('datetime-input')).toBeInTheDocument();
+    expect(screen.getByTestId('datetime-jump')).toBeInTheDocument();
+  });
+
+  it('입력 전에는 점프 버튼 disabled', () => {
+    render(<DateTimePicker />);
+    expect(screen.getByTestId('datetime-jump')).toBeDisabled();
+  });
+
+  it('유효 날짜 입력 후 점프 → jumpToDate 명령', () => {
+    render(<DateTimePicker />);
+    const input = screen.getByTestId('datetime-input');
+    fireEvent.change(input, { target: { value: '2026-04-14T00:00' } });
+    fireEvent.click(screen.getByTestId('datetime-jump'));
+    const cmd = sentCommands.find((c) => c.type === 'jumpToDate');
+    expect(cmd).toBeDefined();
+    // datetime-local은 로컬 타임존으로 파싱되므로 정확한 문자열 대신 ISO 형식만 검증
+    const iso = (cmd as { isoUtc: string }).isoUtc;
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    // 2026-04-14 (KST) = 2026-04-13 15:00 (UTC) 또는 2026-04-14 00:00 (UTC)
+    expect(iso).toMatch(/^2026-04-1[34]T/);
+  });
+});

--- a/apps/web/src/components/layout/mode-switcher.test.tsx
+++ b/apps/web/src/components/layout/mode-switcher.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreCommand } from '@astro-simulator/shared';
+import { useSimStore } from '@/store/sim-store';
+import { ModeSwitcher } from './mode-switcher';
+
+let sentCommands: CoreCommand[] = [];
+vi.mock('@/core/sim-context', () => ({
+  useSimCommand: () => (cmd: CoreCommand) => {
+    sentCommands.push(cmd);
+  },
+}));
+
+beforeEach(() => {
+  sentCommands = [];
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'observe',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('ModeSwitcher', () => {
+  it('4개 모드 버튼 렌더', () => {
+    render(<ModeSwitcher />);
+    expect(screen.getByTestId('mode-observe')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-research')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-education')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-sandbox')).toBeInTheDocument();
+  });
+
+  it('observe가 초기 active 상태', () => {
+    render(<ModeSwitcher />);
+    expect(screen.getByTestId('mode-observe')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('mode-research')).toHaveAttribute('data-active', 'false');
+  });
+
+  it('research 클릭 시 store 모드 갱신 + setMode 명령', () => {
+    render(<ModeSwitcher />);
+    fireEvent.click(screen.getByTestId('mode-research'));
+    expect(useSimStore.getState().mode).toBe('research');
+    expect(sentCommands).toContainEqual({ type: 'setMode', mode: 'research' });
+  });
+
+  it('education 모드는 disabled 상태', () => {
+    render(<ModeSwitcher />);
+    const btn = screen.getByTestId('mode-education') as HTMLButtonElement;
+    expect(btn).toBeDisabled();
+    // P2+ 툴팁 존재
+    expect(btn).toHaveAttribute('title');
+  });
+
+  it('disabled 모드 클릭은 setMode 명령 발행 안 함', () => {
+    render(<ModeSwitcher />);
+    fireEvent.click(screen.getByTestId('mode-sandbox'));
+    expect(sentCommands).not.toContainEqual(
+      expect.objectContaining({ type: 'setMode', mode: 'sandbox' }),
+    );
+  });
+
+  it('모드 변경 시 html[data-mode] 속성 동기화', () => {
+    render(<ModeSwitcher />);
+    fireEvent.click(screen.getByTestId('mode-research'));
+    expect(document.documentElement.getAttribute('data-mode')).toBe('research');
+  });
+});

--- a/apps/web/src/components/layout/time-controls.test.tsx
+++ b/apps/web/src/components/layout/time-controls.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreCommand } from '@astro-simulator/shared';
+import { useSimStore } from '@/store/sim-store';
+import { TimeControls } from './time-controls';
+
+// next-intl 의존성 없고, SimCommandContext만 필요 — 단순 provider mock
+let sentCommands: CoreCommand[] = [];
+vi.mock('@/core/sim-context', () => ({
+  useSimCommand: () => (cmd: CoreCommand) => {
+    sentCommands.push(cmd);
+  },
+}));
+
+beforeEach(() => {
+  sentCommands = [];
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'observe',
+    julianDate: 2_451_545.5,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('TimeControls', () => {
+  it('정지 아닌 상태 — pause 버튼 렌더', () => {
+    render(<TimeControls />);
+    expect(screen.getByTestId('time-pause')).toBeInTheDocument();
+  });
+
+  it('pause 클릭 시 setTimeScale 0 명령 발행', () => {
+    render(<TimeControls />);
+    fireEvent.click(screen.getByTestId('time-pause'));
+    expect(sentCommands).toContainEqual({ type: 'setTimeScale', scale: 0 });
+  });
+
+  it('scale=0일 때 play 버튼 렌더 + 클릭 시 이전 배율 복원', () => {
+    useSimStore.setState({ timeScale: 0 });
+    render(<TimeControls />);
+    fireEvent.click(screen.getByTestId('time-play'));
+    // scale 0에서 play — 기본 DAY_PER_SEC 86400으로 복원
+    expect(sentCommands).toContainEqual({
+      type: 'setTimeScale',
+      scale: 86_400,
+    });
+  });
+
+  it('1y 프리셋 클릭 시 YEAR_PER_SEC 명령', () => {
+    render(<TimeControls />);
+    fireEvent.click(screen.getByTestId('time-preset-1y'));
+    expect(sentCommands).toContainEqual({
+      type: 'setTimeScale',
+      scale: 31_557_600,
+    });
+  });
+
+  it('역행 버튼 → 음수 배율', () => {
+    render(<TimeControls />);
+    fireEvent.click(screen.getByTestId('time-reverse'));
+    const cmd = sentCommands.find((c) => c.type === 'setTimeScale') as
+      | { type: 'setTimeScale'; scale: number }
+      | undefined;
+    expect(cmd?.scale).toBeLessThan(0);
+  });
+
+  it('UTC 문자열 렌더', () => {
+    render(<TimeControls />);
+    // JD 2451545.5 → 2000-01-02 00:00 (약)
+    const utc = screen.getByTestId('time-utc');
+    expect(utc.textContent).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/web/src/components/layout/unit-toggle.test.tsx
+++ b/apps/web/src/components/layout/unit-toggle.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { UnitToggle } from './unit-toggle';
+
+beforeEach(() => {
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'observe',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('UnitToggle', () => {
+  it('3개 단위계 버튼 렌더', () => {
+    render(<UnitToggle />);
+    expect(screen.getByTestId('unit-si')).toBeInTheDocument();
+    expect(screen.getByTestId('unit-astro')).toBeInTheDocument();
+    expect(screen.getByTestId('unit-natural')).toBeInTheDocument();
+  });
+
+  it('astro가 초기 active', () => {
+    render(<UnitToggle />);
+    expect(screen.getByTestId('unit-astro').className).toContain('bg-primary/25');
+  });
+
+  it('SI 클릭 시 store 업데이트 + active 전환', () => {
+    render(<UnitToggle />);
+    fireEvent.click(screen.getByTestId('unit-si'));
+    expect(useSimStore.getState().unitSystem).toBe('si');
+  });
+
+  it('Natural 클릭 시 store natural로 변경', () => {
+    render(<UnitToggle />);
+    fireEvent.click(screen.getByTestId('unit-natural'));
+    expect(useSimStore.getState().unitSystem).toBe('natural');
+  });
+
+  it('각 버튼에 tooltip(title) 존재', () => {
+    render(<UnitToggle />);
+    expect(screen.getByTestId('unit-si')).toHaveAttribute('title');
+    expect(screen.getByTestId('unit-astro')).toHaveAttribute('title');
+    expect(screen.getByTestId('unit-natural')).toHaveAttribute('title');
+  });
+});

--- a/apps/web/src/components/ui/tier-badge.test.tsx
+++ b/apps/web/src/components/ui/tier-badge.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TierBadge } from './tier-badge';
+
+describe('TierBadge', () => {
+  it('Tier 1 배지 — 라벨 T1 + teal 색', () => {
+    render(<TierBadge tier={1} />);
+    const badge = screen.getByTestId('tier-badge-1');
+    expect(badge).toHaveTextContent('T1');
+    expect(badge).toHaveAttribute('title', expect.stringContaining('관측'));
+  });
+
+  it('Tier 2~4 각각 라벨', () => {
+    const { rerender } = render(<TierBadge tier={2} />);
+    expect(screen.getByTestId('tier-badge-2')).toHaveTextContent('T2');
+    rerender(<TierBadge tier={3} />);
+    expect(screen.getByTestId('tier-badge-3')).toHaveTextContent('T3');
+    rerender(<TierBadge tier={4} />);
+    expect(screen.getByTestId('tier-badge-4')).toHaveTextContent('T4');
+  });
+
+  it('각 tier의 tooltip 설명 존재', () => {
+    const tiers: Array<{ t: 1 | 2 | 3 | 4; keyword: string }> = [
+      { t: 1, keyword: '관측' },
+      { t: 2, keyword: '통계' },
+      { t: 3, keyword: '이론' },
+      { t: 4, keyword: '예술' },
+    ];
+    for (const { t, keyword } of tiers) {
+      const { unmount } = render(<TierBadge tier={t} />);
+      expect(screen.getByTestId(`tier-badge-${t}`)).toHaveAttribute(
+        'title',
+        expect.stringContaining(keyword),
+      );
+      unmount();
+    }
+  });
+});

--- a/apps/web/src/hooks/use-mouse-inactivity.test.tsx
+++ b/apps/web/src/hooks/use-mouse-inactivity.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMouseInactivity } from './use-mouse-inactivity';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useMouseInactivity', () => {
+  it('초기값은 false (활성 상태)', () => {
+    const { result } = renderHook(() => useMouseInactivity(1000));
+    expect(result.current).toBe(false);
+  });
+
+  it('timeout 경과 시 true로 전환', () => {
+    const { result } = renderHook(() => useMouseInactivity(1000));
+    expect(result.current).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('mousemove 발생 시 타이머 리셋', () => {
+    const { result } = renderHook(() => useMouseInactivity(1000));
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(900);
+    });
+    expect(result.current).toBe(false); // 재시작되어 아직 inactive 아님
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('keydown / wheel 이벤트로도 리셋', () => {
+    const { result } = renderHook(() => useMouseInactivity(500));
+    act(() => {
+      vi.advanceTimersByTime(400);
+      window.dispatchEvent(new KeyboardEvent('keydown'));
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new WheelEvent('wheel'));
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('unmount 시 타이머/리스너 정리', () => {
+    const { unmount } = renderHook(() => useMouseInactivity(1000));
+    const before = window.setTimeout.length; // smoke
+    expect(before).toBeGreaterThanOrEqual(0);
+    unmount();
+    // 이벤트 dispatch 해도 에러 없이 지나가야 함
+    expect(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/store/sim-store.test.ts
+++ b/apps/web/src/store/sim-store.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from './sim-store';
+
+// 각 테스트 간 상태 격리
+beforeEach(() => {
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'observe',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('useSimStore', () => {
+  it('초기 상태 — observe 모드, 1일/초 스케일', () => {
+    const s = useSimStore.getState();
+    expect(s.mode).toBe('observe');
+    expect(s.timeScale).toBe(86_400);
+    expect(s.rendererKind).toBeNull();
+    expect(s.unitSystem).toBe('astro');
+  });
+
+  it('setRenderer', () => {
+    useSimStore.getState().setRenderer('webgpu');
+    expect(useSimStore.getState().rendererKind).toBe('webgpu');
+  });
+
+  it('setMode', () => {
+    useSimStore.getState().setMode('research');
+    expect(useSimStore.getState().mode).toBe('research');
+  });
+
+  it('setTime', () => {
+    useSimStore.getState().setTime(2_460_000);
+    expect(useSimStore.getState().julianDate).toBe(2_460_000);
+  });
+
+  it('setSelectedBody — null 허용', () => {
+    useSimStore.getState().setSelectedBody('jupiter');
+    expect(useSimStore.getState().selectedBodyId).toBe('jupiter');
+    useSimStore.getState().setSelectedBody(null);
+    expect(useSimStore.getState().selectedBodyId).toBeNull();
+  });
+
+  it('setTimeScale — 음수 허용 (역행)', () => {
+    useSimStore.getState().setTimeScale(-86_400);
+    expect(useSimStore.getState().timeScale).toBe(-86_400);
+  });
+
+  it('setUnitSystem — 3가지 단위계', () => {
+    const { setUnitSystem } = useSimStore.getState();
+    setUnitSystem('si');
+    expect(useSimStore.getState().unitSystem).toBe('si');
+    setUnitSystem('natural');
+    expect(useSimStore.getState().unitSystem).toBe('natural');
+  });
+
+  it('incrementPing — 카운터 증가 + 타임스탬프 기록', () => {
+    const before = Date.now();
+    useSimStore.getState().incrementPing();
+    const s = useSimStore.getState();
+    expect(s.pingCount).toBe(1);
+    expect(s.lastPingAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('engineError — 에러 문자열 설정/클리어', () => {
+    useSimStore.getState().setEngineError('WebGPU 실패');
+    expect(useSimStore.getState().engineError).toBe('WebGPU 실패');
+    useSimStore.getState().setEngineError(null);
+    expect(useSimStore.getState().engineError).toBeNull();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    passWithNoTests: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.{test,spec}.{ts,tsx}', 'src/i18n/**'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "lint:shared": "eslint packages/shared/src",
     "check-encoding": "bash scripts/check-encoding.sh",
     "verify:browser": "node scripts/browser-verify.mjs",
-    "verify:scale": "node scripts/browser-verify-scale.mjs"
+    "verify:scale": "node scripts/browser-verify-scale.mjs",
+    "verify:mobile": "node scripts/browser-verify-mobile.mjs",
+    "verify:all": "pnpm verify:browser && pnpm verify:mobile && pnpm verify:scale"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/scripts/browser-verify-mobile.mjs
+++ b/scripts/browser-verify-mobile.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * 모바일 뷰포트 검증 (run-tests 스킬 "듀얼 뷰포트" 규칙 준수).
+ * 480×900 기준 반응형 레이아웃 + 핵심 렌더.
+ *
+ * 규율: sm(640px) 미만은 "라이트 뷰 모드" (기획 결정 — design-tokens.md §8).
+ * 480×900은 이 라이트 뷰 경로 검증.
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotDir = join(__dirname, '..', '.verify-screenshots', 'mobile');
+mkdirSync(screenshotDir, { recursive: true });
+
+const results = { pass: [], fail: [] };
+const check = (name, condition, detail = '') => {
+  if (condition) results.pass.push(`${name}${detail ? ' — ' + detail : ''}`);
+  else results.fail.push(`${name}${detail ? ' — ' + detail : ''}`);
+};
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 480, height: 900 },
+  deviceScaleFactor: 2,
+  isMobile: true,
+  hasTouch: true,
+});
+const page = await context.newPage();
+
+const consoleErrors = [];
+const pageErrors = [];
+page.on('console', (m) => {
+  if (m.type() === 'error') consoleErrors.push(m.text());
+});
+page.on('pageerror', (e) => pageErrors.push(e.message));
+
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+
+// 기본 요소 렌더
+check('모바일 canvas 렌더', (await page.$('canvas')) !== null);
+check('TopBar 렌더 (로고)', (await page.$('header[data-testid="topbar"]')) !== null);
+check('모드 스위처 렌더', (await page.$('[data-testid="mode-switcher"]')) !== null);
+
+// 가로 스크롤 발생 여부 (반응형 깨짐 검출)
+const hScroll = await page.evaluate(() => {
+  return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+});
+check('가로 스크롤 미발생 (반응형)', !hScroll);
+
+// 뷰포트 치수 확인
+const vp = await page.evaluate(() => ({
+  w: window.innerWidth,
+  h: window.innerHeight,
+}));
+check('뷰포트 480×900', vp.w === 480 && vp.h === 900, `${vp.w}x${vp.h}`);
+
+await page.screenshot({ path: join(screenshotDir, '01-mobile-ko.png'), fullPage: false });
+
+// 터치 포커스 — 지구 버튼 탭
+const earthBtn = await page.$('[data-testid="focus-earth"]');
+if (earthBtn) {
+  await earthBtn.tap();
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: join(screenshotDir, '02-mobile-focus-earth.png') });
+  check('모바일 지구 포커스 탭 동작', true);
+}
+
+// 연구 모드 탭 → 패널 슬라이드 (모바일에서 풀스크린 차지할 수 있음)
+const researchBtn = await page.$('[data-testid="mode-research"]');
+if (researchBtn) {
+  await researchBtn.tap();
+  await page.waitForTimeout(600);
+  await page.screenshot({ path: join(screenshotDir, '03-mobile-research.png') });
+  check('모바일 연구 모드 전환', true);
+}
+
+await browser.close();
+
+console.log('\n========================================');
+console.log(`모바일 뷰포트 검증 (480×900)`);
+console.log(`PASS: ${results.pass.length}건`);
+results.pass.forEach((p) => console.log(`  ✓ ${p}`));
+if (results.fail.length > 0) {
+  console.log(`\nFAIL: ${results.fail.length}건`);
+  results.fail.forEach((f) => console.log(`  ✗ ${f}`));
+  process.exit(1);
+}
+if (consoleErrors.length > 0 || pageErrors.length > 0) {
+  console.log(`\n콘솔 에러 ${consoleErrors.length}, 런타임 에러 ${pageErrors.length}`);
+  consoleErrors.forEach((e) => console.log('  console:', e));
+  pageErrors.forEach((e) => console.log('  runtime:', e));
+  process.exit(1);
+}
+console.log(`스크린샷: ${screenshotDir}`);
+console.log('모바일 검증 통과 ✓');


### PR DESCRIPTION
## 배경
CLAUDE.md '테스트 없이 PR 생성 금지' + run-tests 스킬 '듀얼 뷰포트' 규칙 위반 교정.

## 변경
- apps/web Vitest 설정 (jsdom, @/ alias)
- UI 단위 테스트 37개 (sim-store, use-mouse-inactivity, tier-badge, time-controls, mode-switcher, unit-toggle, date-time-picker)
- 모바일 480×900 뷰포트 검증 스크립트
- verify:all 집계 스크립트

## 검증
- pnpm test: 95 tests (54+4+37) 전부 통과
- pnpm verify:browser: 25 PASS
- pnpm verify:mobile: 7 PASS
- pnpm verify:scale: 9 PASS
- 콘솔/런타임 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)