### PR TITLE
[#75] verify:test-coverage — 워크스페이스 Vitest 설정 누락 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           echo "Node.js ${node_version} 사용"
         # Node 설정은 프로젝트별로 추가
 
+      # verify:test-coverage — 모든 워크스페이스에 Vitest 설정 존재 강제
+      - name: verify:test-coverage
+        if: hashFiles('scripts/verify-test-coverage.mjs') != ''
+        run: node scripts/verify-test-coverage.mjs
+
       # Python 프로젝트 감지
       - name: Python 테스트
         if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != ''

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "verify:browser": "node scripts/browser-verify.mjs",
     "verify:scale": "node scripts/browser-verify-scale.mjs",
     "verify:mobile": "node scripts/browser-verify-mobile.mjs",
-    "verify:all": "pnpm verify:browser && pnpm verify:mobile && pnpm verify:scale && pnpm verify:perf && pnpm verify:a11y",
+    "verify:all": "pnpm verify:test-coverage && pnpm verify:browser && pnpm verify:mobile && pnpm verify:scale && pnpm verify:perf && pnpm verify:a11y",
     "verify:perf": "node scripts/browser-verify-perf.mjs",
-    "verify:a11y": "node scripts/browser-verify-a11y.mjs"
+    "verify:a11y": "node scripts/browser-verify-a11y.mjs",
+    "verify:test-coverage": "node scripts/verify-test-coverage.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/scripts/verify-test-coverage.mjs
+++ b/scripts/verify-test-coverage.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * verify:test-coverage
+ *
+ * P1 회고에서 apps/web Vitest 설정 누락으로 D그룹 9개 PR이 단위 테스트 없이
+ * 머지된 사고가 발생. 모든 워크스페이스에 vitest.config 존재를 CI에서 강제한다.
+ */
+import { readdirSync, statSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const WORKSPACES = ['apps', 'packages'];
+const CONFIG_CANDIDATES = [
+  'vitest.config.ts',
+  'vitest.config.js',
+  'vitest.config.mjs',
+  'vite.config.ts',
+];
+
+function listPackages(dir) {
+  const abs = join(ROOT, dir);
+  if (!existsSync(abs)) return [];
+  return readdirSync(abs)
+    .map((name) => join(dir, name))
+    .filter((rel) => {
+      const full = join(ROOT, rel);
+      return statSync(full).isDirectory() && existsSync(join(full, 'package.json'));
+    });
+}
+
+function hasVitestConfig(rel) {
+  const full = join(ROOT, rel);
+  if (CONFIG_CANDIDATES.some((c) => existsSync(join(full, c)))) return true;
+  // vite.config.ts 에 test: {} 블록이 있는 경우도 허용
+  const vite = join(full, 'vite.config.ts');
+  if (existsSync(vite)) {
+    const src = readFileSync(vite, 'utf8');
+    if (/\btest\s*:\s*\{/.test(src)) return true;
+  }
+  return false;
+}
+
+function hasTestScript(rel) {
+  const pkgPath = join(ROOT, rel, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  if (pkg.private === true && pkg.name?.endsWith('-config')) return true; // 설정 전용 패키지 면제
+  return typeof pkg.scripts?.test === 'string' && pkg.scripts.test.length > 0;
+}
+
+const missing = [];
+for (const ws of WORKSPACES) {
+  for (const pkg of listPackages(ws)) {
+    const cfg = hasVitestConfig(pkg);
+    const script = hasTestScript(pkg);
+    if (!cfg || !script) {
+      missing.push({ pkg, cfg, script });
+    }
+  }
+}
+
+if (missing.length > 0) {
+  console.error('❌ verify:test-coverage — 다음 워크스페이스에 테스트 설정이 누락되었습니다:');
+  for (const m of missing) {
+    const reasons = [];
+    if (!m.cfg) reasons.push('vitest.config 없음');
+    if (!m.script) reasons.push('package.json scripts.test 없음');
+    console.error(`  - ${m.pkg}: ${reasons.join(', ')}`);
+  }
+  console.error(
+    '\nP1 회고 교훈: 신규 패키지 추가 시 Vitest 설정 누락은 후속 PR에서 검증 공백을 만듭니다.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  '✅ verify:test-coverage — 모든 워크스페이스에 Vitest 설정과 test 스크립트가 존재합니다.',
+);


### PR DESCRIPTION
## [#75] verify:test-coverage

### 변경 사항

- `scripts/verify-test-coverage.mjs` 신규 — apps/*, packages/* 각 워크스페이스의 vitest.config + package.json scripts.test 존재 검사
- `package.json`: `verify:test-coverage` 스크립트 추가, `verify:all` 체인 맨 앞에 연결
- `.github/workflows/ci.yml`: CI에서 스크립트 실행 (누락 시 exit 1)

### 배경

P1 회고에서 apps/web Vitest 설정 누락으로 D그룹 9개 PR이 단위 테스트 없이 머지됨 (fix #68로 수습). P2에서 신규 패키지(Rust WASM, 벤치 등) 추가 예정이라 재발 방지 가드가 선행되어야 함.

### 스프린트 계약 (#75 DoD)

- [x] 루트 `verify:test-coverage` 스크립트 — vitest.config 및 scripts.test 존재 검사
- [x] 누락 시 exit 1
- [x] `verify:all` 파이프라인에 포함
- [x] CI에서 실행

### 테스트

- [x] 로컬 실행: `✅ 모든 워크스페이스에 Vitest 설정과 test 스크립트가 존재` 확인
- [x] 기존 단위 테스트 영향 없음 (스크립트 추가일 뿐)

### 브라우저 3단계 검증

- [x] N/A (사유: 런타임 UI 변경 없음, CI 스크립트)

### 관련 이슈

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)