### PR TITLE
[#78] bench:scene — 성능 벤치 자동화 + baseline diff

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,31 @@
+# Benchmarks
+
+`bench:scene` 자동 벤치 리포트 저장소. P2에서 N-body 전환 시 성능 회귀 감지용.
+
+## 실행
+
+```bash
+# 별도 터미널: 앱 서버 기동 (3001 포트)
+pnpm dev
+
+# 벤치 실행 → docs/benchmarks/{timestamp}.json 생성
+BENCH_PHASE=p1-end pnpm bench:scene
+
+# 첫 실행 시 baseline 설정
+pnpm bench:scene:set-baseline
+```
+
+## 파일 규칙
+
+- `{ISO-timestamp}.json` — 개별 측정 리포트 (타임스탬프 슬러그)
+- `baseline.json` — 비교 기준선. 의미 있는 성능 기준점(예: P1 종료, P2-0 완료) 갱신 시 업데이트
+- 각 리포트 JSON은 `{ timestamp, phase, scenarios: [{ name, fps }] }` 스키마
+
+## 회귀 판정
+
+bench 실행 시 baseline 대비 각 시나리오의 fps 변화율을 출력한다.
+`Δ < -2 fps` 인 시나리오는 `⚠` 마크. PR에 그 출력을 첨부하거나 값 악화 원인을 분석 후 PR 본문에 기록한다.
+
+## P2-A 이후
+
+Newton N-body 전환 후 `nBody: [{ n, fps }]` 필드가 추가된다. N=[10, 100, 200, 1000] 샘플.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "verify:all": "pnpm verify:test-coverage && pnpm verify:browser && pnpm verify:mobile && pnpm verify:scale && pnpm verify:perf && pnpm verify:a11y",
     "verify:perf": "node scripts/browser-verify-perf.mjs",
     "verify:a11y": "node scripts/browser-verify-a11y.mjs",
-    "verify:test-coverage": "node scripts/verify-test-coverage.mjs"
+    "verify:test-coverage": "node scripts/verify-test-coverage.mjs",
+    "bench:scene": "node scripts/bench-scene.mjs",
+    "bench:scene:set-baseline": "node scripts/bench-set-baseline.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/scripts/bench-scene.mjs
+++ b/scripts/bench-scene.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * bench:scene — P2 성능 회귀 감지용 자동 벤치.
+ *
+ * 배경
+ * ----
+ * P2에서 Newton N-body 전환 시 성능 회귀 위험이 크다. PR마다 시나리오별 FPS를
+ * JSON으로 기록해두고 baseline과 diff를 표기한다. P1 E3(browser-verify-perf)는
+ * PASS/FAIL 게이트 용도, bench:scene은 시계열 수치 아카이브 용도.
+ *
+ * 현재 지원
+ * --------
+ * - 시나리오별 FPS (정지/재생/포커스) — browser-verify-perf 시나리오 재사용
+ * - JSON 리포트 docs/benchmarks/{timestamp}.json 저장
+ * - docs/benchmarks/baseline.json 대비 diff 콘솔 출력
+ *
+ * P2-A 이후 확장 예정
+ * -----------------
+ * - N = [10, 100, 200, 1000] 소천체 개수 파라미터화 (씬에 N-body 주입 후)
+ */
+import { chromium } from 'playwright';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const SCENARIO_DURATION_MS = 3_000;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const benchDir = join(__dirname, '..', 'docs', 'benchmarks');
+mkdirSync(benchDir, { recursive: true });
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const measureFps = (durationMs) =>
+  page.evaluate(
+    (d) =>
+      new Promise((resolve) => {
+        let count = 0;
+        const start = performance.now();
+        const loop = () => {
+          count += 1;
+          if (performance.now() - start < d) requestAnimationFrame(loop);
+          else resolve((count * 1000) / (performance.now() - start));
+        };
+        requestAnimationFrame(loop);
+      }),
+    durationMs,
+  );
+
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000);
+
+const steps = [
+  { name: 'idle', prep: async () => page.click('[data-testid="time-pause"]').catch(() => {}) },
+  {
+    name: 'play-1d',
+    prep: async () => {
+      await page.click('[data-testid="time-play"]').catch(() => {});
+      await page.click('[data-testid="time-preset-1d"]').catch(() => {});
+    },
+  },
+  { name: 'play-1y', prep: () => page.click('[data-testid="time-preset-1y"]').catch(() => {}) },
+  { name: 'focus-earth', prep: () => page.click('[data-testid="focus-earth"]').catch(() => {}) },
+  {
+    name: 'focus-neptune',
+    prep: () => page.click('[data-testid="focus-neptune"]').catch(() => {}),
+  },
+];
+
+const scenarios = [];
+for (const s of steps) {
+  await s.prep();
+  await page.waitForTimeout(500);
+  const fps = await measureFps(SCENARIO_DURATION_MS);
+  scenarios.push({ name: s.name, fps: Number(fps.toFixed(2)) });
+}
+
+await browser.close();
+
+const timestamp = new Date().toISOString();
+const report = {
+  timestamp,
+  phase: process.env.BENCH_PHASE ?? 'unlabeled',
+  durationMs: SCENARIO_DURATION_MS,
+  environment: 'playwright-chromium-headless',
+  viewport: '1280x800',
+  scenarios,
+  // P2-A 이후: nBody: [{ n: 10, fps: ... }, ...]
+};
+
+const slug = timestamp.replace(/[:.]/g, '-');
+const outPath = join(benchDir, `${slug}.json`);
+writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n');
+
+// baseline diff
+const baselinePath = join(benchDir, 'baseline.json');
+let diffLines = [];
+if (existsSync(baselinePath)) {
+  const base = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const byName = new Map(base.scenarios.map((s) => [s.name, s.fps]));
+  for (const s of scenarios) {
+    const b = byName.get(s.name);
+    if (b == null) {
+      diffLines.push(`  ${s.name}: ${s.fps} fps (신규)`);
+    } else {
+      const delta = s.fps - b;
+      const pct = ((delta / b) * 100).toFixed(1);
+      const mark = delta >= -2 ? '✓' : '⚠';
+      diffLines.push(
+        `  ${mark} ${s.name}: ${s.fps} fps (baseline ${b} → Δ ${delta >= 0 ? '+' : ''}${delta.toFixed(2)}, ${pct}%)`,
+      );
+    }
+  }
+} else {
+  diffLines.push(
+    '  (baseline.json 없음 — 이 리포트를 baseline으로 복사하려면: `pnpm bench:scene:set-baseline`)',
+  );
+}
+
+console.log('\n========================================');
+console.log(`bench:scene — ${timestamp}`);
+console.log(`리포트: ${outPath}`);
+console.log('----------------------------------------');
+for (const s of scenarios) console.log(`  ${s.name}: ${s.fps} fps`);
+console.log('----------------------------------------');
+console.log('baseline diff:');
+diffLines.forEach((l) => console.log(l));

--- a/scripts/bench-set-baseline.mjs
+++ b/scripts/bench-set-baseline.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/**
+ * 가장 최근 bench:scene 리포트를 baseline.json으로 복사.
+ * 의미 있는 기준점(예: P1 종료, P2-0 완료) 갱신 시 호출.
+ */
+import { copyFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = join('docs', 'benchmarks');
+const files = readdirSync(dir)
+  .filter((f) => f.endsWith('.json') && f !== 'baseline.json')
+  .sort();
+
+if (!files.length) {
+  console.error('리포트 없음. 먼저 `pnpm bench:scene`을 실행하세요.');
+  process.exit(1);
+}
+
+const latest = files.at(-1);
+copyFileSync(join(dir, latest), join(dir, 'baseline.json'));
+console.log(`baseline ← ${latest}`);


### PR DESCRIPTION
## [#78] bench:scene 성능 벤치 자동화

### 변경 사항

- `scripts/bench-scene.mjs` — 시나리오별 FPS 측정 → `docs/benchmarks/{timestamp}.json` 저장
- `scripts/bench-set-baseline.mjs` — 최근 리포트를 baseline.json으로 승격
- `docs/benchmarks/README.md` — 실행 방법 + JSON 스키마
- `package.json`: `bench:scene`, `bench:scene:set-baseline` 스크립트 등록

### 배경

P2 Newton N-body 전환 시 성능 회귀 위험이 큼. P1의 `verify:perf`는 PASS/FAIL 게이트, `bench:scene`은 시계열 수치 아카이브 + baseline 대비 Δfps 출력으로 역할 분담.

### 스프린트 계약 (#78 DoD)

- [x] 시나리오별 FPS 리포트 생성 (현재 5개: idle/play-1d/play-1y/focus-earth/focus-neptune)
- [x] JSON 리포트 `docs/benchmarks/` 타임스탬프별 저장
- [x] baseline 대비 diff 콘솔 출력
- [ ] **N=[10,100,200,1000] 파라미터화** — P2-A에서 N-body 씬 확장 시 추가 (현재 씬은 천체 수 고정). 스키마 필드만 예약 (`nBody: []`)
- [ ] **P1 종료 baseline 캡처** — 사용자 환경에서 `pnpm dev` 기동 후 `pnpm bench:scene && pnpm bench:scene:set-baseline` 실행 필요. 헤드리스 환경 편차 때문에 측정자 머신에서 1회 실행 권장

### 테스트

- [x] Node 구문 체크 PASS
- [x] 한글 U+FFFD 없음
- [ ] 실측은 dev server 필요 — 이 PR 머지 후 로컬에서 baseline 1회 캡처 예정

### 브라우저 3단계 검증

- [x] N/A (사유: 벤치 스크립트, 런타임 UI 변경 없음)

### 관련 이슈

Refs #78 (N-body 확장은 P2-A 이슈와 함께 종결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)