### PR TITLE
[#77] orbit 라인 LineSystem 통합 — draw call 9→1

### DIFF
--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -61,7 +61,6 @@ export function createSolarSystemScene(
   const system = getSolarSystem();
   const bodiesById = new Map(system.bodies.map((b) => [b.id, b]));
   const meshes = new Map<string, Mesh>();
-  const orbitLines: Mesh[] = [];
   const disposables: { dispose: () => void }[] = [];
 
   // 배경 톤
@@ -83,15 +82,22 @@ export function createSolarSystemScene(
     meshes.set(body.id, mesh);
   }
 
-  // 궤도선 생성 (부모 중심)
+  // 궤도선 — 개별 Mesh 대신 LineSystem 하나로 통합해 draw call 감소 (#77).
+  // P1은 모든 궤도가 동일 색상이라 색 배열 불필요.
+  const orbitLineBatches: Vector3[][] = [];
   for (const body of system.bodies) {
     if (!body.orbit) continue;
-    const line = createOrbitLine(body, scene);
-    if (line) {
-      line.isVisible = showOrbitLines;
-      orbitLines.push(line);
-      disposables.push({ dispose: () => line.dispose() });
-    }
+    const pts = sampleOrbitPoints(body);
+    if (pts) orbitLineBatches.push(pts);
+  }
+  const orbitLines =
+    orbitLineBatches.length > 0
+      ? MeshBuilder.CreateLineSystem('orbit-lines', { lines: orbitLineBatches }, scene)
+      : null;
+  if (orbitLines) {
+    orbitLines.color = new Color3(0.25, 0.28, 0.4);
+    orbitLines.isVisible = showOrbitLines;
+    disposables.push({ dispose: () => orbitLines.dispose() });
   }
 
   // 재사용 버퍼 — 프레임당 Map/Vec3 재할당을 피한다 (#76).
@@ -170,7 +176,7 @@ export function createSolarSystemScene(
   };
 
   const setOrbitLinesVisible = (visible: boolean) => {
-    for (const line of orbitLines) line.isVisible = visible;
+    if (orbitLines) orbitLines.isVisible = visible;
   };
 
   // 초기 시점 적용
@@ -218,7 +224,7 @@ function createBodyMesh(body: LoadedCelestialBody, scene: Scene): Mesh {
   return mesh;
 }
 
-function createOrbitLine(body: LoadedCelestialBody, scene: Scene): Mesh | null {
+function sampleOrbitPoints(body: LoadedCelestialBody): Vector3[] | null {
   if (!body.orbit || !body.parentId) return null;
   const orbit = body.orbit;
   // 궤도 한 바퀴 샘플링 (진근점각 기준 등간격)
@@ -250,9 +256,7 @@ function createOrbitLine(body: LoadedCelestialBody, scene: Scene): Mesh | null {
     );
   }
 
-  const line = MeshBuilder.CreateLines(`${body.id}-orbit`, { points }, scene);
-  line.color = new Color3(0.25, 0.28, 0.4);
-  return line;
+  return points;
 }
 
 function hexToColor3(hex: string): Color3 {


### PR DESCRIPTION
## [#77] orbit 라인 LineSystem 통합

### 변경 사항

`packages/core/src/scene/solar-system-scene.ts`:

- 궤도선을 `MeshBuilder.CreateLines` 9개 → `CreateLineSystem` 단일 mesh로 통합
- `createOrbitLine` 함수를 `sampleOrbitPoints`(점 샘플링만)로 분리
- `orbitLines: Mesh[]` → `orbitLines: LinesMesh | null` 단일 참조
- 가시성 토글은 단일 mesh의 `isVisible`로 일괄 제어

### 배경

P1 회고 기술 부채. P2-B에서 소천체/혜성/소행성대(N=100~1000) 추가 예정. 개별 Mesh 방식은 N에 비례해 draw call이 선형 증가 → LineSystem으로 단일 호출 상쇄.

### 스프린트 계약 (#77 DoD)

- [x] InstancedMesh 또는 LineSystem으로 통합 → **LineSystem 채택** (동일 색상이라 InstancedMesh보다 단순)
- [x] draw call before/after 기록 — **9 → 1** (9개 LinesMesh → 1 LineSystem with 9 batches)
- [ ] 시각적 회귀 없음 — 스크린샷 비교는 사용자 환경에서 `pnpm dev` 실행 후 확인 권장. 코드 레벨: 점 생성 로직 동일, 색상·가시성 동일

### 테스트

- [x] 89 단위 테스트 PASS
- [x] typecheck PASS
- [x] 한글 U+FFFD 없음

### 브라우저 3단계 검증

> 내부 렌더링 파이프라인 변경이라 3단계 모두 해당됨. 리뷰어/머지 전 로컬 확인 권장.

- [ ] **정적**: `pnpm dev` 후 8행성 궤도선 표시 확인 (색상 0.25,0.28,0.4 유지)
- [ ] **인터랙션**: 궤도선 토글 체크박스 (HUD 컨트롤) 동작 — 단일 mesh가 일괄 on/off
- [ ] **흐름**: 시간 재생/포커스 전환 시 궤도선 위치 유지

*CI 머지 후 로컬 검증 1회 권장. 의심 사항 있으면 이 PR에서 롤백 가능.*

### 관련 이슈

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)