### PR TITLE
[#84] physics-wasm 스캐폴딩 — Rust 1.94.1 + wasm-pack 0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,22 @@ jobs:
           echo "Go 프로젝트 감지됨"
         # Go 설정은 프로젝트별로 추가
 
-      # Rust 프로젝트 감지
-      - name: Rust 테스트
-        if: hashFiles('Cargo.toml') != ''
-        run: |
-          echo "Rust 프로젝트 감지됨"
-        # Rust 설정은 프로젝트별로 추가
+      # Rust + WASM 툴체인 (packages/physics-wasm)
+      - name: Rust 툴체인 설정
+        if: hashFiles('rust-toolchain.toml') != ''
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - name: wasm-pack 설치
+        if: hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        run: cargo install wasm-pack --version 0.14.0 --locked
+
+      - name: Rust 테스트 (physics-wasm)
+        if: hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        run: cargo test --manifest-path packages/physics-wasm/Cargo.toml
 
       # Makefile 기반
       - name: Make 테스트

--- a/packages/physics-wasm/.gitignore
+++ b/packages/physics-wasm/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+pkg-bundler/
+target/
+Cargo.lock

--- a/packages/physics-wasm/Cargo.toml
+++ b/packages/physics-wasm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "physics-wasm"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "astro-simulator Newton N-body WASM 코어 (P2-A)"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/packages/physics-wasm/README.md
+++ b/packages/physics-wasm/README.md
@@ -1,0 +1,47 @@
+# @astro-simulator/physics-wasm
+
+Newton N-body WASM 코어. Rust + wasm-pack 기반. P2-A에서 심플렉틱 적분기(Leapfrog/Verlet)로 확장 예정.
+
+## 요구 사항
+
+- Rust 툴체인 (자동 관리: 루트 `rust-toolchain.toml` → 1.94.1 + `wasm32-unknown-unknown` target + minimal profile)
+- `wasm-pack`: `cargo install wasm-pack` (권장, 재현성 최상)
+
+## 빌드
+
+```bash
+pnpm -C packages/physics-wasm build          # Node 소비용 pkg/
+pnpm -C packages/physics-wasm build:bundler  # 웹 번들러 소비용 pkg-bundler/
+```
+
+`pkg/`, `pkg-bundler/`, `target/`는 빌드 산출물이므로 커밋하지 않는다 (`.gitignore`).
+
+## 테스트
+
+```bash
+pnpm -C packages/physics-wasm test   # Rust 측 cargo test는 별도: cd 후 cargo test
+cargo test --manifest-path packages/physics-wasm/Cargo.toml
+```
+
+`pnpm test`는 사전에 `build`(nodejs target)를 실행한 뒤 vitest로 TS ↔ WASM 왕복을 검증한다.
+
+## 구조
+
+```
+packages/physics-wasm/
+├── Cargo.toml          # 크레이트 메타
+├── src/lib.rs          # Rust 소스 (wasm-bindgen exports)
+├── package.json        # 워크스페이스 멤버
+├── vitest.config.ts    # TS 바인딩 테스트 설정
+├── tests/              # TS 테스트 (pkg/ import)
+├── pkg/                # wasm-pack 산출물 (gitignored)
+└── target/             # cargo 빌드 캐시 (gitignored)
+```
+
+## 로드맵
+
+- #84 스캐폴딩 (현재)
+- #85 Leapfrog/Verlet 적분기 + 에너지 보존 테스트
+- #86 TS 바인딩 확장 + 씬 통합
+- #87 Kepler 대비 정확도 검증
+- #88 역행 대칭성 테스트

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@astro-simulator/physics-wasm",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
+  "type": "module",
+  "main": "./pkg/physics_wasm.js",
+  "types": "./pkg/physics_wasm.d.ts",
+  "exports": {
+    ".": {
+      "types": "./pkg/physics_wasm.d.ts",
+      "default": "./pkg/physics_wasm.js"
+    }
+  },
+  "scripts": {
+    "build": "wasm-pack build --target nodejs --out-dir pkg",
+    "build:bundler": "wasm-pack build --target bundler --out-dir pkg-bundler",
+    "clean": "rm -rf pkg pkg-bundler target",
+    "prebuild-test": "pnpm build",
+    "test": "pnpm prebuild-test && vitest run",
+    "test:watch": "vitest",
+    "lint": "echo 'lint: cargo clippy 참고'",
+    "typecheck": "echo 'typecheck: TS 없음, cargo check 사용'"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/physics-wasm/src/lib.rs
+++ b/packages/physics-wasm/src/lib.rs
@@ -1,0 +1,22 @@
+//! astro-simulator Newton N-body WASM 코어.
+//!
+//! P2-A 스캐폴딩 — 현재는 TS ↔ WASM 왕복만 검증.
+//! 실제 Leapfrog/Verlet 적분기는 #85에서 구현.
+
+use wasm_bindgen::prelude::*;
+
+/// 스모크 테스트용 함수. TS 바인딩 왕복 검증 전용.
+#[wasm_bindgen]
+pub fn add(a: f64, b: f64) -> f64 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_basic() {
+        assert_eq!(add(1.5, 2.25), 3.75);
+    }
+}

--- a/packages/physics-wasm/tests/binding.test.ts
+++ b/packages/physics-wasm/tests/binding.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — pkg/는 빌드 산출물(gitignored). test 스크립트가 선빌드한다.
+import { add } from '../pkg/physics_wasm.js';
+
+describe('physics-wasm ↔ TS binding', () => {
+  it('add() — WASM 왕복 스모크', () => {
+    expect(add(1.5, 2.25)).toBe(3.75);
+    expect(add(-1, 1)).toBe(0);
+  });
+});

--- a/packages/physics-wasm/vitest.config.ts
+++ b/packages/physics-wasm/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,12 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/physics-wasm:
+    devDependencies:
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+
   packages/shared:
     devDependencies:
       '@vitest/coverage-v8':

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
## [#84] physics-wasm 스캐폴딩

P2-A Newton N-body 코어의 기반. Rust stable 1.94.1 + wasm-pack 0.14.0.

### 변경 사항

- **rust-toolchain.toml** — 1.94.1 pin + wasm32-unknown-unknown target + minimal profile (재현성)
- **packages/physics-wasm/** 신규 크레이트
  - Cargo.toml: cdylib + wasm-bindgen 0.2
  - src/lib.rs: 스모크 `add()` + cargo test
- **pnpm 워크스페이스 멤버** @astro-simulator/physics-wasm
  - vitest로 TS ↔ WASM 왕복 PASS (1/1)
  - build(nodejs) / build:bundler / clean 스크립트
- **CI** (ci.yml)
  - `dtolnay/rust-toolchain@stable` (1.94.1 + wasm target + clippy/fmt)
  - `cargo install wasm-pack --version 0.14.0 --locked`
  - `cargo test --manifest-path packages/physics-wasm/Cargo.toml`
- **.gitignore** — pkg/, pkg-bundler/, target/, Cargo.lock

### 결정

- **Node 타깃 우선**: 단위 테스트가 Node(vitest)에서 실행되므로 `--target nodejs`가 기본 build. 씬 통합(#86)에서 `--target bundler` 추가 필요 시 `build:bundler` 스크립트 준비됨
- **Rust 버전 1.94.1 stable**: 루트 `rust-toolchain.toml`로 pin하여 CI/로컬 일치 보장 (기존 1.81 → 1.94.1 업그레이드)
- **Cargo.lock gitignore**: 라이브러리 크레이트(cdylib)이며 배포 대상이 아님 — 재현성은 `rust-toolchain.toml` + `wasm-pack --version 0.14.0 --locked`로 확보

### 스프린트 계약 (#84 DoD)

- [x] Cargo.toml + wasm-pack 설정
- [x] pnpm workspace 등록 (@astro-simulator/physics-wasm)
- [x] `pnpm -C packages/physics-wasm build` → .wasm + TS 바인딩 산출
- [x] Hello-world `add(a,b)` TS ↔ WASM 왕복 vitest 검증
- [x] CI: rust toolchain + wasm-pack 설치 워크플로우
- [x] README — 빌드/테스트 방법

### 테스트

- [x] `cargo test` PASS (1/1)
- [x] `pnpm -C packages/physics-wasm test` PASS (1/1, 선빌드 포함)
- [x] 기존 테스트 영향 없음 — core 89, apps/web 37 PASS
- [x] `pnpm verify:test-coverage` PASS
- [x] 한글 U+FFFD 없음

### 브라우저 3단계 검증

- [x] N/A (사유: 런타임 UI 변경 없음, 신규 크레이트 스캐폴딩)

### 관련 이슈

Closes #84
Refs #85 #86 #87 #88 #89 (P2-A 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)