### PR TITLE
[#86] WASM Newton 엔진 + TS 래퍼 + 씬 통합

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@astro-simulator/physics-wasm": "workspace:*",
     "@astro-simulator/shared": "workspace:*",
     "mitt": "^3.0.1",
     "zod": "^4.3.6"

--- a/packages/core/src/physics/index.ts
+++ b/packages/core/src/physics/index.ts
@@ -14,3 +14,10 @@ export {
   positionAt,
   orbitalPeriod,
 } from './kepler.js';
+export { orbitalStateAt, type StateVector } from './state-vector.js';
+export {
+  NBodyEngine,
+  buildInitialState,
+  type NBodyEngineOptions,
+  type NBodyState,
+} from './nbody-engine.js';

--- a/packages/core/src/physics/nbody-engine.test.ts
+++ b/packages/core/src/physics/nbody-engine.test.ts
@@ -1,0 +1,66 @@
+/**
+ * NBodyEngine (TS) ↔ WASM 코어 왕복 검증 + Kepler state vector 테스트.
+ *
+ * cargo test는 Rust 측 에너지 보존 검증 (#85). 이 파일은 TS 래퍼 층에서
+ * 초기 상태 빌더·서브스텝 분할·역행이 정상 동작하는지 확인한다.
+ */
+import { describe, expect, it } from 'vitest';
+import { GRAVITATIONAL_CONSTANT } from '@astro-simulator/shared';
+import { NBodyEngine, buildInitialState, orbitalStateAt } from './index.js';
+import { getSolarSystem } from '../ephemeris/solar-system-loader.js';
+
+const AU = 1.495_978_707e11;
+
+describe('orbitalStateAt', () => {
+  it('태양 중력장의 지구 궤도 — 속도 크기가 원속도 ~29.78 km/s 근방', () => {
+    const system = getSolarSystem();
+    const earth = system.bodies.find((b) => b.id === 'earth')!;
+    const mu = GRAVITATIONAL_CONSTANT * system.bodies.find((b) => b.id === 'sun')!.mass;
+    const { position, velocity } = orbitalStateAt(earth.orbit!, system.epoch, mu);
+    const r = Math.hypot(position[0], position[1], position[2]);
+    const v = Math.hypot(velocity[0], velocity[1], velocity[2]);
+    expect(r / AU).toBeGreaterThan(0.98);
+    expect(r / AU).toBeLessThan(1.02);
+    expect(v).toBeGreaterThan(29_000);
+    expect(v).toBeLessThan(31_000);
+  });
+});
+
+describe('NBodyEngine (WASM 왕복)', () => {
+  it('buildInitialState + step 1회 — 위치가 의미 있게 이동', () => {
+    const system = getSolarSystem();
+    const state = buildInitialState(system, system.epoch);
+    const earthIdx = state.ids.indexOf('earth');
+    expect(earthIdx).toBeGreaterThanOrEqual(0);
+    const x0 = state.positions[3 * earthIdx]!;
+    const y0 = state.positions[3 * earthIdx + 1]!;
+
+    const eng = new NBodyEngine(state);
+    eng.advance(86_400); // 1 일
+    const p1 = eng.positions();
+    const x1 = p1[3 * earthIdx]!;
+    const y1 = p1[3 * earthIdx + 1]!;
+    const moved = Math.hypot(x1 - x0, y1 - y0);
+    // 하루 이동 거리 ≈ v·dt ≈ 29.78 km/s · 86400s ≈ 2.57e9 m
+    expect(moved).toBeGreaterThan(2e9);
+    expect(moved).toBeLessThan(3e9);
+    eng.dispose();
+  });
+
+  it('역행(심플렉틱 대칭) — +dt 후 −dt 복귀 오차 < 1e-6 상대', () => {
+    const system = getSolarSystem();
+    const state = buildInitialState(system, system.epoch);
+    const eng = new NBodyEngine(state, { maxSubstepSeconds: 3600 });
+    const earthIdx = state.ids.indexOf('earth');
+    const p0 = eng.positions();
+    eng.advance(86_400 * 10);
+    eng.advance(-86_400 * 10);
+    const p1 = eng.positions();
+    const dx = p1[3 * earthIdx]! - p0[3 * earthIdx]!;
+    const dy = p1[3 * earthIdx + 1]! - p0[3 * earthIdx + 1]!;
+    const err = Math.hypot(dx, dy);
+    const r = Math.hypot(p0[3 * earthIdx]!, p0[3 * earthIdx + 1]!);
+    expect(err / r).toBeLessThan(1e-6);
+    eng.dispose();
+  });
+});

--- a/packages/core/src/physics/nbody-engine.ts
+++ b/packages/core/src/physics/nbody-engine.ts
@@ -1,0 +1,120 @@
+/**
+ * Newton N-body 엔진 — WASM 코어(#85)를 TS에서 사용하기 위한 얇은 래퍼.
+ *
+ * - 월드 좌표(태양 원점, SI m·s) 기준으로 초기화
+ * - `advance(dtSeconds)`로 전/역행 가능 (Velocity-Verlet 대칭성)
+ * - 긴 dt는 내부 서브스텝으로 쪼개어 안정성 확보 (기본 1일)
+ */
+import { NBodyEngine as WasmEngine } from '@astro-simulator/physics-wasm';
+import { GRAVITATIONAL_CONSTANT } from '@astro-simulator/shared';
+import type { LoadedSolarSystem } from '../ephemeris/solar-system-loader.js';
+import { orbitalStateAt } from './state-vector.js';
+
+const DEFAULT_MAX_SUB_DT_SECONDS = 86_400; // 1 일
+
+export interface NBodyEngineOptions {
+  /** 서브스텝 최대 dt(초). 기본 1일. */
+  maxSubstepSeconds?: number;
+}
+
+export interface NBodyState {
+  ids: string[];
+  masses: Float64Array;
+  positions: Float64Array; // 길이 3N, 월드 좌표
+  velocities: Float64Array;
+}
+
+/**
+ * 태양계 로드 결과에서 Newton 초기 상태를 빌드한다.
+ * 태양은 원점·정지로 고정. 자식 바디는 orbitalStateAt로 부모 기준 좌표를 구한 뒤
+ * 부모 월드 좌표에 더해 태양 중심 좌표로 변환.
+ *
+ * P1은 모든 행성이 태양을 부모로 하므로 단순 누적. 달은 지구 기준.
+ */
+export function buildInitialState(system: LoadedSolarSystem, julianDate: number): NBodyState {
+  const byId = new Map(system.bodies.map((b) => [b.id, b]));
+  const worldPos = new Map<string, [number, number, number]>();
+  const worldVel = new Map<string, [number, number, number]>();
+
+  const resolve = (id: string): void => {
+    if (worldPos.has(id)) return;
+    const body = byId.get(id);
+    if (!body) return;
+    if (!body.orbit || !body.parentId) {
+      worldPos.set(id, [0, 0, 0]);
+      worldVel.set(id, [0, 0, 0]);
+      return;
+    }
+    const parent = byId.get(body.parentId);
+    if (!parent) return;
+    resolve(parent.id);
+    const parentP = worldPos.get(parent.id)!;
+    const parentV = worldVel.get(parent.id)!;
+    const mu = GRAVITATIONAL_CONSTANT * parent.mass;
+    const { position, velocity } = orbitalStateAt(body.orbit, julianDate, mu);
+    worldPos.set(id, [
+      parentP[0] + position[0],
+      parentP[1] + position[1],
+      parentP[2] + position[2],
+    ]);
+    worldVel.set(id, [
+      parentV[0] + velocity[0],
+      parentV[1] + velocity[1],
+      parentV[2] + velocity[2],
+    ]);
+  };
+  for (const b of system.bodies) resolve(b.id);
+
+  const n = system.bodies.length;
+  const ids = system.bodies.map((b) => b.id);
+  const masses = new Float64Array(n);
+  const positions = new Float64Array(3 * n);
+  const velocities = new Float64Array(3 * n);
+  system.bodies.forEach((b, i) => {
+    masses[i] = b.mass;
+    const p = worldPos.get(b.id) ?? [0, 0, 0];
+    const v = worldVel.get(b.id) ?? [0, 0, 0];
+    positions[3 * i] = p[0];
+    positions[3 * i + 1] = p[1];
+    positions[3 * i + 2] = p[2];
+    velocities[3 * i] = v[0];
+    velocities[3 * i + 1] = v[1];
+    velocities[3 * i + 2] = v[2];
+  });
+
+  return { ids, masses, positions, velocities };
+}
+
+export class NBodyEngine {
+  private wasm: WasmEngine;
+  private readonly maxSubDt: number;
+  readonly ids: readonly string[];
+
+  constructor(state: NBodyState, options: NBodyEngineOptions = {}) {
+    this.wasm = new WasmEngine(state.masses, state.positions, state.velocities);
+    this.maxSubDt = options.maxSubstepSeconds ?? DEFAULT_MAX_SUB_DT_SECONDS;
+    this.ids = state.ids;
+  }
+
+  /** dtSeconds만큼 적분. 음수 값은 역행(심플렉틱 대칭). */
+  advance(dtSeconds: number): void {
+    if (dtSeconds === 0) return;
+    this.wasm.step_chunked(dtSeconds, this.maxSubDt);
+  }
+
+  positions(): Float64Array {
+    return this.wasm.positions();
+  }
+
+  velocities(): Float64Array {
+    return this.wasm.velocities();
+  }
+
+  totalEnergy(): number {
+    return this.wasm.total_energy();
+  }
+
+  dispose(): void {
+    this.wasm.free();
+  }
+}

--- a/packages/core/src/physics/state-vector.ts
+++ b/packages/core/src/physics/state-vector.ts
@@ -1,0 +1,72 @@
+/**
+ * Kepler 궤도 요소 → 위치·속도 state vector (SI 단위).
+ *
+ * Newton N-body 적분기(#85)는 초기 상태로 위치·속도를 요구하므로,
+ * JPL 궤도 요소에서 수치미분 없이 해석적으로 계산한다.
+ *
+ * 공식 출처: 표준 천체역학 교과서(Vallado 등) — 궤도면 좌표에서
+ *   r = a(1-e²)/(1+e·cos ν)
+ *   ṙ   = √(μ/p) · e · sin ν
+ *   rν̇  = √(μ/p) · (1 + e·cos ν)
+ * 를 3D로 회전한다(Rz(Ω) Rx(i) Rz(ω)).
+ */
+import type { Vec3Double } from '../coords/vec3.js';
+import type { LoadedOrbitalElements } from '../ephemeris/solar-system-loader.js';
+import { solveKeplerEquation, meanAnomalyAt, trueAnomalyFromEccentric } from './kepler.js';
+
+export interface StateVector {
+  position: Vec3Double;
+  velocity: Vec3Double;
+}
+
+/**
+ * julianDate 시점의 부모 기준 위치(m)·속도(m/s)를 계산한다.
+ * mu = G * M_parent.
+ */
+export function orbitalStateAt(
+  elements: LoadedOrbitalElements,
+  julianDate: number,
+  mu: number,
+): StateVector {
+  const M = meanAnomalyAt(elements, julianDate, mu);
+  const E = solveKeplerEquation(M, elements.eccentricity);
+  const nu = trueAnomalyFromEccentric(E, elements.eccentricity);
+
+  const a = elements.semiMajorAxis;
+  const e = elements.eccentricity;
+  const p = a * (1 - e * e);
+  const r = p / (1 + e * Math.cos(nu));
+
+  const cosNu = Math.cos(nu);
+  const sinNu = Math.sin(nu);
+
+  // 궤도면(perifocal) 좌표: x = 근일점 방향
+  const xOrb = r * cosNu;
+  const yOrb = r * sinNu;
+  const sqrtMuOverP = Math.sqrt(mu / p);
+  const vxOrb = -sqrtMuOverP * sinNu;
+  const vyOrb = sqrtMuOverP * (e + cosNu);
+
+  // 회전: Rz(Ω) Rx(i) Rz(ω)
+  const cosO = Math.cos(elements.longitudeOfAscendingNode);
+  const sinO = Math.sin(elements.longitudeOfAscendingNode);
+  const cosI = Math.cos(elements.inclination);
+  const sinI = Math.sin(elements.inclination);
+  const cosW = Math.cos(elements.argumentOfPeriapsis);
+  const sinW = Math.sin(elements.argumentOfPeriapsis);
+
+  const rotate = (x: number, y: number): Vec3Double => {
+    const x1 = cosW * x - sinW * y;
+    const y1 = sinW * x + cosW * y;
+    const y2 = cosI * y1;
+    const z2 = sinI * y1;
+    const xWorld = cosO * x1 - sinO * y2;
+    const yWorld = sinO * x1 + cosO * y2;
+    return [xWorld, yWorld, z2];
+  };
+
+  return {
+    position: rotate(xOrb, yOrb),
+    velocity: rotate(vxOrb, vyOrb),
+  };
+}

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -13,6 +13,7 @@ import { AU, GRAVITATIONAL_CONSTANT, J2000_JD } from '@astro-simulator/shared';
 import { getSolarSystem, type LoadedCelestialBody } from '../ephemeris/solar-system-loader.js';
 import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
+import { NBodyEngine, buildInitialState } from '../physics/nbody-engine.js';
 
 /**
  * 씬 단위: 1 scene unit = 1 AU.
@@ -39,11 +40,15 @@ export interface SolarSystemSceneHandles {
   dispose: () => void;
 }
 
+export type PhysicsEngineKind = 'kepler' | 'newton';
+
 export interface SolarSystemSceneOptions {
   /** 초기 시각 (Julian Date). 기본: J2000.0 */
   initialJulianDate?: number;
   /** 궤도선 초기 가시성. 기본: true */
   showOrbitLines?: boolean;
+  /** 물리 엔진 선택. 기본: 'kepler' (해석해). 'newton'은 #86에서 추가. */
+  physicsEngine?: PhysicsEngineKind;
 }
 
 /**
@@ -56,7 +61,8 @@ export function createSolarSystemScene(
   scene: Scene,
   options: SolarSystemSceneOptions = {},
 ): SolarSystemSceneHandles {
-  const { initialJulianDate = J2000_JD, showOrbitLines = true } = options;
+  const { initialJulianDate = J2000_JD, showOrbitLines = true, physicsEngine = 'kepler' } = options;
+  const SECONDS_PER_DAY = 86_400;
 
   const system = getSolarSystem();
   const bodiesById = new Map(system.bodies.map((b) => [b.id, b]));
@@ -112,7 +118,62 @@ export function createSolarSystemScene(
   }
   const resolved = new Set<string>();
 
+  // Newton 경로 — 호출 시 초기 상태 빌드 후 updateAt(jd)에서 Δt만큼 적분.
+  let newtonEngine: NBodyEngine | null = null;
+  let newtonLastJd = initialJulianDate;
+  let newtonIdIndex: Map<string, number> | null = null;
+  if (physicsEngine === 'newton') {
+    const initial = buildInitialState(system, initialJulianDate);
+    newtonEngine = new NBodyEngine(initial);
+    newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
+    disposables.push({ dispose: () => newtonEngine?.dispose() });
+  }
+
   const updateAt = (jd: number) => {
+    if (newtonEngine && newtonIdIndex) {
+      const dtSec = (jd - newtonLastJd) * SECONDS_PER_DAY;
+      if (dtSec !== 0) {
+        newtonEngine.advance(dtSec);
+        newtonLastJd = jd;
+      }
+      const flat = newtonEngine.positions();
+      for (const body of system.bodies) {
+        const idx = newtonIdIndex.get(body.id);
+        const world = worldPositions.get(body.id)!;
+        if (idx == null) {
+          world[0] = 0;
+          world[1] = 0;
+          world[2] = 0;
+          continue;
+        }
+        world[0] = flat[3 * idx] ?? 0;
+        world[1] = flat[3 * idx + 1] ?? 0;
+        world[2] = flat[3 * idx + 2] ?? 0;
+      }
+    } else {
+      updateAtKepler(jd);
+    }
+
+    // 메쉬 위치 갱신 (미터 → 씬 단위)
+    for (const [id, world] of worldPositions) {
+      const mesh = meshes.get(id);
+      if (!mesh) continue;
+      mesh.position.set(
+        world[0] * SCENE_UNIT_PER_METER,
+        world[1] * SCENE_UNIT_PER_METER,
+        world[2] * SCENE_UNIT_PER_METER,
+      );
+    }
+
+    const sunWorld = worldPositions.get('sun') ?? [0, 0, 0];
+    sunLight.position.set(
+      sunWorld[0] * SCENE_UNIT_PER_METER,
+      sunWorld[1] * SCENE_UNIT_PER_METER,
+      sunWorld[2] * SCENE_UNIT_PER_METER,
+    );
+  };
+
+  const updateAtKepler = (jd: number) => {
     // 1) 각 바디의 부모-로컬 좌표 계산 (부모가 없으면 (0,0,0))
     for (const body of system.bodies) {
       const buf = localPositions.get(body.id)!;
@@ -154,25 +215,7 @@ export function createSolarSystemScene(
       return world;
     };
     for (const body of system.bodies) resolveWorld(body.id);
-
-    // 3) 메쉬 위치 갱신 (미터 → 씬 단위)
-    for (const [id, world] of worldPositions) {
-      const mesh = meshes.get(id);
-      if (!mesh) continue;
-      mesh.position.set(
-        world[0] * SCENE_UNIT_PER_METER,
-        world[1] * SCENE_UNIT_PER_METER,
-        world[2] * SCENE_UNIT_PER_METER,
-      );
-    }
-
-    // 4) 태양 포인트 라이트를 태양 위치로 이동 (태양 이동은 없지만 안전장치)
-    const sunWorld = worldPositions.get('sun') ?? [0, 0, 0];
-    sunLight.position.set(
-      sunWorld[0] * SCENE_UNIT_PER_METER,
-      sunWorld[1] * SCENE_UNIT_PER_METER,
-      sunWorld[2] * SCENE_UNIT_PER_METER,
-    );
+    // 메쉬 위치·광원 업데이트는 호출자(updateAt)가 worldPositions에서 공통 수행.
   };
 
   const setOrbitLinesVisible = (visible: boolean) => {

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -8,15 +8,20 @@
   "types": "./pkg/physics_wasm.d.ts",
   "exports": {
     ".": {
-      "types": "./pkg/physics_wasm.d.ts",
-      "default": "./pkg/physics_wasm.js"
+      "node": {
+        "types": "./pkg/physics_wasm.d.ts",
+        "default": "./pkg/physics_wasm.js"
+      },
+      "types": "./pkg-bundler/physics_wasm.d.ts",
+      "default": "./pkg-bundler/physics_wasm.js"
     }
   },
   "scripts": {
-    "build": "wasm-pack build --target nodejs --out-dir pkg",
+    "build": "pnpm build:node && pnpm build:bundler",
+    "build:node": "wasm-pack build --target nodejs --out-dir pkg",
     "build:bundler": "wasm-pack build --target bundler --out-dir pkg-bundler",
     "clean": "rm -rf pkg pkg-bundler target",
-    "prebuild-test": "pnpm build",
+    "prebuild-test": "pnpm build:node",
     "test": "pnpm prebuild-test && vitest run",
     "test:watch": "vitest",
     "lint": "echo 'lint: cargo clippy 참고'",

--- a/packages/physics-wasm/src/lib.rs
+++ b/packages/physics-wasm/src/lib.rs
@@ -2,18 +2,74 @@
 //!
 //! - `add`: TS ↔ WASM 왕복 스모크 (#84)
 //! - `nbody`: Velocity-Verlet 적분기 + O(N²) 중력 합 (#85)
+//! - `NBodyEngine`: WASM export 래퍼 — TS에서 직접 사용 (#86)
 //!
-//! 좌표계: SI 단위 (m, kg, s). 위치/속도는 3N-flat `Vec<f64>` (SoA 아닌 AoS-flat).
+//! 좌표계: SI 단위 (m, kg, s). 위치/속도는 3N-flat `Vec<f64>` (AoS-flat).
 //! 심플렉틱 특성상 고정 dt에서 에너지 오차가 장기적으로 bounded oscillation.
 
 use wasm_bindgen::prelude::*;
 
 pub mod nbody;
 
+use nbody::NBodySystem;
+
 /// 스모크 테스트용 함수. #84.
 #[wasm_bindgen]
 pub fn add(a: f64, b: f64) -> f64 {
     a + b
+}
+
+/// NBodySystem을 WASM으로 노출하는 래퍼. TS는 Float64Array를 그대로 주고받는다.
+#[wasm_bindgen]
+pub struct NBodyEngine {
+    inner: NBodySystem,
+}
+
+#[wasm_bindgen]
+impl NBodyEngine {
+    /// masses(N) · pos(3N) · vel(3N) 로 초기화. 길이 불일치 시 panic.
+    #[wasm_bindgen(constructor)]
+    pub fn new(masses: Vec<f64>, pos: Vec<f64>, vel: Vec<f64>) -> NBodyEngine {
+        NBodyEngine {
+            inner: NBodySystem::new(masses, pos, vel),
+        }
+    }
+
+    pub fn n(&self) -> usize {
+        self.inner.n()
+    }
+
+    /// 1 스텝 전진(Velocity-Verlet). 역행은 dt < 0.
+    pub fn step(&mut self, dt: f64) {
+        self.inner.step(dt);
+    }
+
+    /// max_dt 이하로 내부 서브스텝 분할하여 total_dt만큼 적분.
+    pub fn step_chunked(&mut self, total_dt: f64, max_dt: f64) {
+        let abs = total_dt.abs();
+        if abs == 0.0 {
+            return;
+        }
+        let sub_count = (abs / max_dt).ceil() as usize;
+        let sub_dt = total_dt / sub_count as f64;
+        for _ in 0..sub_count {
+            self.inner.step(sub_dt);
+        }
+    }
+
+    /// 현재 위치 3N flat.
+    pub fn positions(&self) -> Vec<f64> {
+        self.inner.pos.clone()
+    }
+
+    /// 현재 속도 3N flat.
+    pub fn velocities(&self) -> Vec<f64> {
+        self.inner.vel.clone()
+    }
+
+    pub fn total_energy(&self) -> f64 {
+        self.inner.total_energy()
+    }
 }
 
 #[cfg(test)]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@astro-simulator/physics-wasm':
+        specifier: workspace:*
+        version: link:../physics-wasm
       '@astro-simulator/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## [#86] WASM ↔ TS 바인딩 + 씬 통합

P2-A 적분기(#85)를 TS에서 사용 가능하게 하고 `solar-system-scene`에 Newton 경로를 **선택 옵션**으로 추가. 기본값은 Kepler 유지 (UI 토글은 #89).

### 변경 사항

**WASM export** (packages/physics-wasm)
- `NBodyEngine` class: `new` / `step` / `step_chunked` / `positions` / `velocities` / `total_energy`
- `package.json` 조건부 exports: `node → pkg/`, `default → pkg-bundler/`
- `build` 스크립트가 두 타깃을 모두 생성

**TS 래퍼** (packages/core)
- `physics/state-vector.ts` — `orbitalStateAt(elements, jd, mu)` → 위치·속도 해석 계산 (수치미분 없음, Vallado 공식)
- `physics/nbody-engine.ts` —
  - `buildInitialState(system, jd)` → `{ ids, masses, positions, velocities }` Float64Array 3N flat
  - `NBodyEngine.advance(dtSeconds)` — 내부 서브스텝 기본 1일
  - 역행 지원 (dt < 0, 심플렉틱 대칭)
- `physics/index.ts` 재노출

**씬 통합** (solar-system-scene.ts)
- `SolarSystemSceneOptions.physicsEngine: 'kepler' | 'newton'` (기본 `'kepler'`)
- Newton 선택 시 `updateAt(jd)`가 Δt 기반으로 적분 → 메쉬 위치 갱신
- 공통 메쉬/광원 업데이트는 outer `updateAt`으로 승격 (중복 제거)

### 테스트 결과

- 신규 단위 테스트 3개 (`nbody-engine.test.ts`):
  - `orbitalStateAt` 지구 속도 크기 29~31 km/s ✅
  - `advance(1일)` 이동 거리 2.0~3.0 Gm ✅
  - 역행 복귀 상대 오차 < **1e-6** ✅
- 전체: core 89+3=**92 PASS**, apps/web 37 PASS, physics-wasm 1 PASS
- `pnpm typecheck` PASS
- `pnpm -C apps/web build` PASS (Next.js가 wasm bundler 타깃 소비)
- `verify:test-coverage` PASS
- 한글 U+FFFD 없음

### 스프린트 계약 (#86 DoD)

- [x] TS NBodyEngine 래퍼 (초기화/step/getPositions)
- [x] createSolarSystemScene에 Newton 경로 추가 — Kepler와 토글 가능
- [x] 태양계 초기 상태 JPL 기반 로드 (orbitalStateAt → buildInitialState)
- [x] 메모리 전달: Float64Array (wasm-bindgen이 wasm memory view 관리)
- [x] TS에서 step 1회 호출 시 WASM 결과 일치 (테스트)

### 브라우저 3단계 검증

> Newton 경로는 기본값이 아니므로 앱 런타임 UI는 변화 없음. 프로덕션 빌드 성공 확인.

- [x] 정적: `pnpm -C apps/web build` 성공, 번들 정상 생성
- [x] 인터랙션: N/A — 기본 Kepler 유지, 기존 UI 동작 무영향 (unit 92 PASS)
- [x] 흐름: N/A — 엔진 전환 UI는 #89

Newton 경로 활성화(`physicsEngine: 'newton'`) 브라우저 검증은 #89 UI PR에서 수행.

### 관련 이슈

Closes #86
Refs #87 (Kepler 대비 정확도), #88 (역행 대칭성 정밀), #89 (UI 토글)

🤖 Generated with [Claude Code](https://claude.com/claude-code)