### PR TITLE
[#89] Kepler↔Newton 엔진 토글 UI + URL 동기화

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -10,6 +10,7 @@ import { ScaleControl } from './scale-control';
 import { TimeControls } from './time-controls';
 import { DateTimePicker } from './date-time-picker';
 import { UnitToggle } from './unit-toggle';
+import { PhysicsEngineToggle } from './physics-engine-toggle';
 import { UrlSync } from '../../core/url-sync';
 import { SimCanvasDynamic } from '../sim-canvas.dynamic';
 
@@ -33,6 +34,7 @@ export function AppShell() {
             <div className="flex items-center gap-2">
               <DateTimePicker />
               <UnitToggle />
+              <PhysicsEngineToggle />
             </div>
           }
         />

--- a/apps/web/src/components/layout/physics-engine-toggle.test.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { PhysicsEngineToggle } from './physics-engine-toggle';
+
+beforeEach(() => {
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'observe',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    physicsEngine: 'kepler',
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('PhysicsEngineToggle', () => {
+  it('초기에 Kepler 활성', () => {
+    render(<PhysicsEngineToggle />);
+    expect(screen.getByTestId('engine-kepler').dataset.active).toBe('true');
+    expect(screen.getByTestId('engine-newton').dataset.active).toBe('false');
+  });
+
+  it('Newton 클릭 시 store 반영 + active 전환', () => {
+    render(<PhysicsEngineToggle />);
+    fireEvent.click(screen.getByTestId('engine-newton'));
+    expect(useSimStore.getState().physicsEngine).toBe('newton');
+    expect(screen.getByTestId('engine-newton').dataset.active).toBe('true');
+    expect(screen.getByTestId('engine-kepler').dataset.active).toBe('false');
+  });
+
+  it('두 버튼 모두 title(툴팁) 보유', () => {
+    render(<PhysicsEngineToggle />);
+    expect(screen.getByTestId('engine-kepler')).toHaveAttribute('title');
+    expect(screen.getByTestId('engine-newton')).toHaveAttribute('title');
+  });
+});

--- a/apps/web/src/components/layout/physics-engine-toggle.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useSimStore, type PhysicsEngineKind } from '@/store/sim-store';
+
+interface EngineDef {
+  id: PhysicsEngineKind;
+  label: string;
+  tooltip: string;
+}
+
+const ENGINES: EngineDef[] = [
+  {
+    id: 'kepler',
+    label: 'Kepler',
+    tooltip: '2-body 해석해 — 행성 간 섭동 없음. 기본값.',
+  },
+  {
+    id: 'newton',
+    label: 'Newton',
+    tooltip: 'N-body 수치적분(Velocity-Verlet, WASM) — 섭동 포함, 시간 역행 가능.',
+  },
+];
+
+/**
+ * 물리 엔진 토글 (P2-A #89).
+ *  - Kepler 2-body ↔ Newton N-body
+ *  - 전환 시 씬이 현재 jd에서 Newton 초기 상태를 빌드해 심리스 전환.
+ *  - URL `?engine=newton`으로 초기 상태 공유 가능.
+ */
+export function PhysicsEngineToggle() {
+  const engine = useSimStore((s) => s.physicsEngine);
+  const setPhysicsEngine = useSimStore((s) => s.setPhysicsEngine);
+
+  return (
+    <div
+      className="flex items-center gap-0.5 bg-bg-surface/80 backdrop-blur border border-border-subtle rounded-sm p-0.5"
+      data-testid="physics-engine-toggle"
+      aria-label="물리 엔진"
+    >
+      {ENGINES.map((e) => {
+        const active = engine === e.id;
+        return (
+          <button
+            key={e.id}
+            type="button"
+            data-testid={`engine-${e.id}`}
+            data-active={active}
+            title={e.tooltip}
+            onClick={() => setPhysicsEngine(e.id)}
+            className={`num text-caption px-2 py-1 rounded-xs transition-colors ${
+              active ? 'bg-primary/25 text-fg-primary' : 'text-fg-secondary hover:bg-bg-elevated'
+            }`}
+            style={{ transitionDuration: 'var(--duration-fast)' }}
+          >
+            {e.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -3,6 +3,7 @@
 import { SimulationCore, scene as sceneApi } from '@astro-simulator/core';
 import { attachCoreToStore } from '@/core/core-adapter';
 import { SimCommandProvider } from '@/core/sim-context';
+import { useSimStore } from '@/store/sim-store';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
 /**
@@ -25,6 +26,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
     const detach = attachCoreToStore(instance);
 
     let cancelled = false;
+    let unsubEngine: (() => void) | null = null;
     instance
       .start()
       .then(() => {
@@ -32,9 +34,18 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         sceneApi.enableLogarithmicDepth(instance.scene);
         const camera = sceneApi.setupArcRotateCamera(instance.scene, { radius: 35 });
         const controller = new sceneApi.CameraController(camera, instance.scene);
-        const solar = sceneApi.createSolarSystemScene(instance.scene);
+        const solar = sceneApi.createSolarSystemScene(instance.scene, {
+          physicsEngine: useSimStore.getState().physicsEngine,
+        });
 
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));
+
+        // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)
+        unsubEngine = useSimStore.subscribe((state, prev) => {
+          if (state.physicsEngine !== prev.physicsEngine) {
+            solar.setPhysicsEngine(state.physicsEngine);
+          }
+        });
         instance.setCameraHandlers(
           (bodyId: string) => {
             const mesh = solar.meshes.get(bodyId);
@@ -53,6 +64,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
 
     return () => {
       cancelled = true;
+      unsubEngine?.();
       detach();
       instance.dispose();
       coreRef.current = null;

--- a/apps/web/src/core/url-sync.tsx
+++ b/apps/web/src/core/url-sync.tsx
@@ -7,6 +7,8 @@ import { useSimStore } from '@/store/sim-store';
 import { useSimCommand } from './sim-context';
 
 const MODE_VALUES: SimMode[] = ['observe', 'research', 'education', 'sandbox'];
+const ENGINE_VALUES = ['kepler', 'newton'] as const;
+type PhysicsEngineUrl = (typeof ENGINE_VALUES)[number];
 
 /**
  * URL ↔ 시뮬레이션 상태 동기화.
@@ -29,11 +31,17 @@ export function UrlSync() {
     'speed',
     parseAsFloat.withOptions({ history: 'replace' }),
   );
+  const [urlEngine, setUrlEngine] = useQueryState(
+    'engine',
+    parseAsStringEnum<PhysicsEngineUrl>([...ENGINE_VALUES]).withOptions({ history: 'replace' }),
+  );
 
   const mode = useSimStore((s) => s.mode);
   const selectedBodyId = useSimStore((s) => s.selectedBodyId);
   const timeScale = useSimStore((s) => s.timeScale);
+  const physicsEngine = useSimStore((s) => s.physicsEngine);
   const setMode = useSimStore((s) => s.setMode);
+  const setPhysicsEngine = useSimStore((s) => s.setPhysicsEngine);
 
   const sendCommand = useSimCommand();
   const initialized = useRef(false);
@@ -56,6 +64,9 @@ export function UrlSync() {
     if (urlSpeed !== null && urlSpeed !== undefined && Number.isFinite(urlSpeed)) {
       sendCommand({ type: 'setTimeScale', scale: urlSpeed });
     }
+    if (urlEngine) {
+      setPhysicsEngine(urlEngine);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -74,6 +85,11 @@ export function UrlSync() {
     if (!initialized.current) return;
     setUrlSpeed(timeScale === 86_400 ? null : timeScale);
   }, [timeScale, setUrlSpeed]);
+
+  useEffect(() => {
+    if (!initialized.current) return;
+    setUrlEngine(physicsEngine === 'kepler' ? null : physicsEngine);
+  }, [physicsEngine, setUrlEngine]);
 
   return null;
 }

--- a/apps/web/src/store/sim-store.test.ts
+++ b/apps/web/src/store/sim-store.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     timeScale: 86_400,
     fps: null,
     unitSystem: 'astro',
+    physicsEngine: 'kepler',
     pingCount: 0,
     lastPingAt: null,
   });
@@ -67,6 +68,14 @@ describe('useSimStore', () => {
     const s = useSimStore.getState();
     expect(s.pingCount).toBe(1);
     expect(s.lastPingAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('setPhysicsEngine — Kepler ↔ Newton 토글', () => {
+    expect(useSimStore.getState().physicsEngine).toBe('kepler');
+    useSimStore.getState().setPhysicsEngine('newton');
+    expect(useSimStore.getState().physicsEngine).toBe('newton');
+    useSimStore.getState().setPhysicsEngine('kepler');
+    expect(useSimStore.getState().physicsEngine).toBe('kepler');
   });
 
   it('engineError — 에러 문자열 설정/클리어', () => {

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -2,6 +2,7 @@ import type { SimMode } from '@astro-simulator/shared';
 import { create } from 'zustand';
 
 export type UnitSystem = 'si' | 'astro' | 'natural';
+export type PhysicsEngineKind = 'kepler' | 'newton';
 
 /**
  * 시뮬레이션 UI 상태 store.
@@ -21,6 +22,7 @@ export interface SimStoreState {
   timeScale: number;
   fps: number | null;
   unitSystem: UnitSystem;
+  physicsEngine: PhysicsEngineKind;
 
   // 개발/디버그용 라운드트립 카운터
   pingCount: number;
@@ -35,6 +37,7 @@ export interface SimStoreState {
   setTimeScale: (scale: number) => void;
   setFps: (fps: number) => void;
   setUnitSystem: (unit: UnitSystem) => void;
+  setPhysicsEngine: (kind: PhysicsEngineKind) => void;
   incrementPing: () => void;
 }
 
@@ -47,6 +50,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   timeScale: 86_400,
   fps: null,
   unitSystem: 'astro',
+  physicsEngine: 'kepler',
   pingCount: 0,
   lastPingAt: null,
 
@@ -58,6 +62,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   setTimeScale: (scale) => set({ timeScale: scale }),
   setFps: (fps) => set({ fps }),
   setUnitSystem: (unit) => set({ unitSystem: unit }),
+  setPhysicsEngine: (kind) => set({ physicsEngine: kind }),
   incrementPing: () =>
     set((state) => ({
       pingCount: state.pingCount + 1,

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -37,6 +37,10 @@ export interface SolarSystemSceneHandles {
   updateAt: (julianDate: number) => void;
   /** 궤도선 가시성 토글 */
   setOrbitLinesVisible: (visible: boolean) => void;
+  /** 런타임 엔진 전환. 현재 jd에서 Newton 초기 상태 재빌드 (심리스). */
+  setPhysicsEngine: (kind: PhysicsEngineKind) => void;
+  /** 현재 활성 엔진 */
+  getPhysicsEngine: () => PhysicsEngineKind;
   dispose: () => void;
 }
 
@@ -119,18 +123,32 @@ export function createSolarSystemScene(
   const resolved = new Set<string>();
 
   // Newton 경로 — 호출 시 초기 상태 빌드 후 updateAt(jd)에서 Δt만큼 적분.
+  let activeEngine: PhysicsEngineKind = physicsEngine;
   let newtonEngine: NBodyEngine | null = null;
   let newtonLastJd = initialJulianDate;
+  let currentJd = initialJulianDate;
   let newtonIdIndex: Map<string, number> | null = null;
-  if (physicsEngine === 'newton') {
-    const initial = buildInitialState(system, initialJulianDate);
+
+  const buildNewton = (jd: number) => {
+    newtonEngine?.dispose();
+    const initial = buildInitialState(system, jd);
     newtonEngine = new NBodyEngine(initial);
     newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
-    disposables.push({ dispose: () => newtonEngine?.dispose() });
+    newtonLastJd = jd;
+  };
+  const disposeNewton = () => {
+    newtonEngine?.dispose();
+    newtonEngine = null;
+    newtonIdIndex = null;
+  };
+  if (physicsEngine === 'newton') {
+    buildNewton(initialJulianDate);
   }
+  disposables.push({ dispose: disposeNewton });
 
   const updateAt = (jd: number) => {
-    if (newtonEngine && newtonIdIndex) {
+    currentJd = jd;
+    if (activeEngine === 'newton' && newtonEngine && newtonIdIndex) {
       const dtSec = (jd - newtonLastJd) * SECONDS_PER_DAY;
       if (dtSec !== 0) {
         newtonEngine.advance(dtSec);
@@ -222,6 +240,14 @@ export function createSolarSystemScene(
     if (orbitLines) orbitLines.isVisible = visible;
   };
 
+  const setPhysicsEngine = (kind: PhysicsEngineKind) => {
+    if (kind === activeEngine) return;
+    if (kind === 'newton') buildNewton(currentJd);
+    else disposeNewton();
+    activeEngine = kind;
+  };
+  const getPhysicsEngine = () => activeEngine;
+
   // 초기 시점 적용
   updateAt(initialJulianDate);
 
@@ -229,6 +255,8 @@ export function createSolarSystemScene(
     meshes,
     updateAt,
     setOrbitLinesVisible,
+    setPhysicsEngine,
+    getPhysicsEngine,
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();

--- a/scripts/browser-verify-engine-toggle.mjs
+++ b/scripts/browser-verify-engine-toggle.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * #89 브라우저 3단계 검증 — 물리 엔진 토글.
+ *
+ * 1. 정적: 토글 버튼 렌더, 콘솔 에러 없음
+ * 2. 인터랙션: Newton 클릭 → data-active 전환 + URL ?engine=newton 반영
+ * 3. 흐름: URL ?engine=newton으로 시작 → 초기 상태 Newton, 토글 상태 일치
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'engine-toggle');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on('console', (m) => {
+  if (m.type() === 'error') consoleErrors.push(m.text());
+});
+
+const results = [];
+const check = (name, pass, detail = '') => {
+  results.push({ name, pass, detail });
+  const mark = pass ? '✓' : '✗';
+  console.log(`  ${mark} ${name}${detail ? ' — ' + detail : ''}`);
+};
+
+// ---- 1. 정적 ----
+console.log('\n[1/3] 정적 확인');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+const toggle = page.locator('[data-testid="physics-engine-toggle"]');
+check('토글 컨테이너 표시', (await toggle.count()) === 1);
+check('Kepler 버튼', (await page.locator('[data-testid="engine-kepler"]').count()) === 1);
+check('Newton 버튼', (await page.locator('[data-testid="engine-newton"]').count()) === 1);
+const initialActive = await page.getAttribute('[data-testid="engine-kepler"]', 'data-active');
+check('초기 Kepler active', initialActive === 'true');
+await page.screenshot({ path: join(shotDir, '1-static.png') });
+
+// ---- 2. 인터랙션 ----
+console.log('\n[2/3] 인터랙션');
+await page.click('[data-testid="engine-newton"]');
+await page.waitForTimeout(500);
+const afterClickNewton = await page.getAttribute('[data-testid="engine-newton"]', 'data-active');
+const afterClickKepler = await page.getAttribute('[data-testid="engine-kepler"]', 'data-active');
+check('Newton active 전환', afterClickNewton === 'true');
+check('Kepler inactive', afterClickKepler === 'false');
+const urlAfter = page.url();
+check('URL에 ?engine=newton 포함', urlAfter.includes('engine=newton'), urlAfter);
+await page.screenshot({ path: join(shotDir, '2-after-newton.png') });
+
+// 다시 Kepler 클릭 → URL에서 engine 파라미터 제거 (kepler는 기본값)
+await page.click('[data-testid="engine-kepler"]');
+await page.waitForTimeout(500);
+const urlBack = page.url();
+check('Kepler 복귀 시 URL engine 파라미터 제거', !urlBack.includes('engine='), urlBack);
+
+// ---- 3. 흐름 ----
+console.log('\n[3/3] 흐름 — URL로 초기 상태 공유');
+await page.goto(`${baseUrl}/ko?engine=newton`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+const initialNewton = await page.getAttribute('[data-testid="engine-newton"]', 'data-active');
+check('?engine=newton 진입 시 Newton active', initialNewton === 'true');
+// 시간 재생 → 위치 업데이트 확인 (씬은 시간 이벤트에서 updateAt 호출)
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(1500);
+const hasEngineErr = consoleErrors.some((e) => /nbody|wasm|NBodyEngine/i.test(e));
+check('시간 재생 중 WASM 관련 콘솔 에러 없음', !hasEngineErr);
+await page.screenshot({ path: join(shotDir, '3-newton-flow.png') });
+
+await browser.close();
+
+console.log('\n========================================');
+const pass = results.filter((r) => r.pass).length;
+const fail = results.length - pass;
+console.log(`결과: ${pass}/${results.length} PASS`);
+if (consoleErrors.length) {
+  console.log(`콘솔 에러 ${consoleErrors.length}건:`);
+  consoleErrors.slice(0, 5).forEach((e) => console.log('  ', e));
+}
+if (fail > 0) process.exit(1);
+console.log(`스크린샷: ${shotDir}`);


### PR DESCRIPTION
## [#89] 엔진 토글 UI

P2-A 마지막 이슈. TopBar 우측에 엔진 토글 배치. 런타임 전환 시 씬이 현재 jd에서 Newton 초기 상태를 재빌드 → 심리스.

### 변경 사항

**packages/core**
- `SolarSystemSceneHandles.setPhysicsEngine(kind)` / `getPhysicsEngine()` 추가
- `buildNewton(jd)` / `disposeNewton()` 내부 헬퍼 — 전환 시 `currentJd`에서 상태 재빌드

**apps/web**
- `sim-store`: `physicsEngine: 'kepler' | 'newton'` + setter (기본 `kepler`)
- `url-sync`: `?engine=newton` (기본값 `kepler`는 URL에 생략)
- `components/layout/physics-engine-toggle.tsx` — TopBar 우측
- `sim-canvas`: store 구독 → `solar.setPhysicsEngine` 전파, 언마운트 시 unsub
- 단위 테스트: 토글 컴포넌트 3 + store setter 1 (총 4)

### 브라우저 3단계 검증 (scripts/browser-verify-engine-toggle.mjs · **10/10 PASS**)

- [x] **정적**: 토글 렌더, 초기 Kepler active
- [x] **인터랙션**: Newton 클릭 → `data-active` 전환 + URL `?engine=newton` / Kepler 복귀 시 URL 파라미터 제거
- [x] **흐름**: `?engine=newton` 진입 시 Newton active + 시간 재생 중 WASM 콘솔 에러 없음

증거: `.verify-screenshots/engine-toggle/` (1-static / 2-after-newton / 3-newton-flow)
실행: `scripts/browser-verify-engine-toggle.mjs http://localhost:3001`

### 스프린트 계약 (#89 DoD)

- [x] HUD/TopBar 엔진 토글 컨트롤 (TopBar 우측 배치 — 관찰/연구 모드 공통 보임)
- [x] 전환 시 현재 위치·속도 유지 (씬이 currentJd에서 Newton 초기 상태 재빌드 → Kepler 해석해와 위치 일치)
- [x] URL `?engine=newton` 포함
- [x] 브라우저 3단계 검증 (Playwright 스크립트 자동화)
- [x] 단위 테스트 — 상태 변환 헬퍼 (store setter + 토글 컴포넌트)

### 테스트

- core 97 PASS, apps/web 41 PASS (신규 4 포함), physics-wasm 1 PASS
- `pnpm typecheck` PASS, `pnpm -C apps/web build` PASS
- `verify:test-coverage` PASS, 한글 U+FFFD 없음

### 관련 이슈

Closes #89 — **P2-A 완료**

🤖 Generated with [Claude Code](https://claude.com/claude-code)