### PR TITLE
[P2-0] baseline bench 캡처

### DIFF
--- a/docs/benchmarks/2026-04-14T09-22-19-440Z.json
+++ b/docs/benchmarks/2026-04-14T09-22-19-440Z.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-04-14T09:22:19.440Z",
+  "phase": "p2-0-baseline",
+  "durationMs": 3000,
+  "environment": "playwright-chromium-headless",
+  "viewport": "1280x800",
+  "scenarios": [
+    {
+      "name": "idle",
+      "fps": 38.96
+    },
+    {
+      "name": "play-1d",
+      "fps": 38.53
+    },
+    {
+      "name": "play-1y",
+      "fps": 38.75
+    },
+    {
+      "name": "focus-earth",
+      "fps": 100.53
+    },
+    {
+      "name": "focus-neptune",
+      "fps": 108.28
+    }
+  ]
+}

--- a/docs/benchmarks/baseline.json
+++ b/docs/benchmarks/baseline.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-04-14T09:22:19.440Z",
+  "phase": "p2-0-baseline",
+  "durationMs": 3000,
+  "environment": "playwright-chromium-headless",
+  "viewport": "1280x800",
+  "scenarios": [
+    {
+      "name": "idle",
+      "fps": 38.96
+    },
+    {
+      "name": "play-1d",
+      "fps": 38.53
+    },
+    {
+      "name": "play-1y",
+      "fps": 38.75
+    },
+    {
+      "name": "focus-earth",
+      "fps": 100.53
+    },
+    {
+      "name": "focus-neptune",
+      "fps": 108.28
+    }
+  ]
+}


### PR DESCRIPTION
## P2-0 baseline

P2-A 머지 후 시점의 실 브라우저 성능 baseline 캡처. P2-B/C/D에서 이 JSON 대비 diff로 회귀 감지.

### 측정 (Playwright Chromium headless, 1280×800, PORT=3001 production build)

| 시나리오 | FPS |
|---|---|
| idle | 38.96 |
| play-1d | 38.53 |
| play-1y | 38.75 |
| focus-earth | 100.53 |
| focus-neptune | 108.28 |

- 헤드리스 기준 ~38fps — 실 브라우저(GPU 가속)에서 60fps 예상
- P1 E3 36fps → 38fps 소폭 상승 (updateAt 캐시 #76 + orbit LineSystem #77 효과)
- focus는 원거리 컬링으로 100+ fps 여유

### 변경 사항

- `docs/benchmarks/2026-04-14T09-22-19-440Z.json` — 측정 리포트
- `docs/benchmarks/baseline.json` — 최근 리포트 복사, P2-B/C/D 비교 기준

### 브라우저 3단계 검증

- [x] N/A (사유: 측정 JSON만 추가, 코드 변경 없음)