### PR TITLE
[#98] 혜성 3개 추가 (Halley/Encke/Swift-Tuttle)

### DIFF
--- a/packages/core/src/ephemeris/jpl-validation.test.ts
+++ b/packages/core/src/ephemeris/jpl-validation.test.ts
@@ -151,6 +151,36 @@ describe('JPL Horizons 대비 궤도 정확도 검증 (E1)', () => {
     }
   });
 
+  describe('혜성 궤도 요소 공칭값 (JPL SBDB 기반 ±2%)', () => {
+    // 혜성은 태양풍 비중력 효과로 공전 간 약간 변동 — ±2% 여유.
+    const COMET_REF = [
+      { id: 'halley', a_AU: 17.834, e: 0.96714, iDeg: 162.26, periodYears: 75.32 },
+      { id: 'encke', a_AU: 2.2152, e: 0.848, iDeg: 11.78, periodYears: 3.3 },
+      { id: 'swift-tuttle', a_AU: 26.09, e: 0.963, iDeg: 113.45, periodYears: 133.28 },
+    ];
+    for (const ref of COMET_REF) {
+      it(`${ref.id} 장반경 오차 ≤2%`, () => {
+        const body = byId.get(ref.id);
+        const a_AU = (body?.orbit?.semiMajorAxis ?? 0) / AU;
+        expect(Math.abs(a_AU - ref.a_AU) / ref.a_AU).toBeLessThan(0.02);
+      });
+      it(`${ref.id} 이심률/경사 오차 ≤2%`, () => {
+        const body = byId.get(ref.id);
+        const e = body?.orbit?.eccentricity ?? 0;
+        const iDeg = ((body?.orbit?.inclination ?? 0) * 180) / Math.PI;
+        // inclination 부호는 normalize가 [-π, π]로 가져와서 음수일 수 있음 → abs
+        expect(Math.abs(e - ref.e) / ref.e).toBeLessThan(0.02);
+        expect(Math.abs(Math.abs(iDeg) - ref.iDeg) / ref.iDeg).toBeLessThan(0.02);
+      });
+      it(`${ref.id} 공전주기 ≈ ${ref.periodYears}년`, () => {
+        const body = byId.get(ref.id);
+        if (!body?.orbit) throw new Error(ref.id);
+        const periodYears = orbitalPeriod(body.orbit.semiMajorAxis, MU_SUN) / 86_400 / 365.25;
+        expect(Math.abs(periodYears - ref.periodYears) / ref.periodYears).toBeLessThan(0.02);
+      });
+    }
+  });
+
   describe('지구-달 시스템 (부모 중심 좌표)', () => {
     it('달-지구 거리 [356k, 407k] km', () => {
       const moon = byId.get('moon');

--- a/packages/core/src/ephemeris/solar-system-loader.test.ts
+++ b/packages/core/src/ephemeris/solar-system-loader.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { loadSolarSystem } from './solar-system-loader.js';
 
 describe('loadSolarSystem', () => {
-  it('로드 성공 + 15개 바디 (sun + 8행성 + moon + 왜소행성 5)', () => {
+  it('로드 성공 + 18개 바디 (sun + 8행성 + moon + 왜소행성 5 + 혜성 3)', () => {
     const data = loadSolarSystem();
     expect(data.epoch).toBe(2451545.0);
     expect(data.tier).toBe(1);
-    expect(data.bodies).toHaveLength(15);
+    expect(data.bodies).toHaveLength(18);
     expect(data.bodies.filter((b) => b.kind === 'dwarf-planet')).toHaveLength(5);
+    expect(data.bodies.filter((b) => b.kind === 'comet')).toHaveLength(3);
   });
 
   it('태양은 궤도가 없다', () => {

--- a/packages/shared/data/solar-system.json
+++ b/packages/shared/data/solar-system.json
@@ -266,6 +266,60 @@
         "longitudeOfPerihelionDeg": 186.0223,
         "meanLongitudeDeg": 204.16
       }
+    },
+    {
+      "id": "halley",
+      "kind": "comet",
+      "nameKo": "핼리 혜성",
+      "nameEn": "1P/Halley",
+      "mass": 2.2e14,
+      "radius": 5.5e3,
+      "parentId": "sun",
+      "colorHint": { "hex": "#A8D8E8" },
+      "orbit": {
+        "semiMajorAxisAU": 17.834,
+        "eccentricity": 0.96714,
+        "inclinationDeg": 162.26,
+        "longitudeOfAscendingNodeDeg": 58.42,
+        "longitudeOfPerihelionDeg": 169.75,
+        "meanLongitudeDeg": 236.05
+      }
+    },
+    {
+      "id": "encke",
+      "kind": "comet",
+      "nameKo": "엥케 혜성",
+      "nameEn": "2P/Encke",
+      "mass": 1.0e13,
+      "radius": 2.4e3,
+      "parentId": "sun",
+      "colorHint": { "hex": "#B5E0D1" },
+      "orbit": {
+        "semiMajorAxisAU": 2.2152,
+        "eccentricity": 0.848,
+        "inclinationDeg": 11.78,
+        "longitudeOfAscendingNodeDeg": 334.57,
+        "longitudeOfPerihelionDeg": 161.11,
+        "meanLongitudeDeg": 100.0
+      }
+    },
+    {
+      "id": "swift-tuttle",
+      "kind": "comet",
+      "nameKo": "스위프트-터틀 혜성",
+      "nameEn": "109P/Swift-Tuttle",
+      "mass": 2.5e16,
+      "radius": 1.3e4,
+      "parentId": "sun",
+      "colorHint": { "hex": "#C8D8E8" },
+      "orbit": {
+        "semiMajorAxisAU": 26.09,
+        "eccentricity": 0.963,
+        "inclinationDeg": 113.45,
+        "longitudeOfAscendingNodeDeg": 139.38,
+        "longitudeOfPerihelionDeg": 292.36,
+        "meanLongitudeDeg": 300.0
+      }
     }
   ]
 }

--- a/scripts/browser-verify-comets.mjs
+++ b/scripts/browser-verify-comets.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * #98 브라우저 3단계 검증 — 혜성 3개 (Halley/Encke/Swift-Tuttle).
+ *
+ * 고이심률(e≥0.848) 궤도선이 LineSystem 64세그먼트로 끊김 없이 그려지는지.
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'comets');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+check('캔버스 렌더', (await page.locator('[data-testid="sim-canvas"]').count()) === 1);
+check('콘솔 에러 0', errs.length === 0);
+await page.screenshot({ path: join(shotDir, '1-static.png') });
+
+console.log('\n[2/3] 인터랙션 — 시간 재생');
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(1500);
+check('재생 중 에러 없음', errs.length === 0);
+await page.screenshot({ path: join(shotDir, '2-playing.png') });
+
+console.log('\n[3/3] 흐름 — 혜성 focus URL');
+for (const id of ['halley', 'encke', 'swift-tuttle']) {
+  const before = errs.length;
+  await page.goto(`${baseUrl}/ko?focus=${id}`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1500);
+  const newErrs = errs.slice(before);
+  const bad = newErrs.some((e) => new RegExp(id, 'i').test(e) || /undefined|null/.test(e));
+  check(`?focus=${id} 진입 에러 없음`, !bad);
+  await page.screenshot({ path: join(shotDir, `3-${id}-focus.png`) });
+}
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#98] 혜성 샘플

고이심률 궤도 렌더 검증용 대표 혜성 3개.

### 데이터 (J2000, JPL SBDB)

| ID | a (AU) | e | i (°) | 주기 |
|---|---|---|---|---|
| halley (1P) | 17.83 | 0.967 | 162.3 (역행) | 75.3년 |
| encke (2P) | 2.22 | 0.848 | 11.8 | 3.3년 |
| swift-tuttle (109P) | 26.09 | 0.963 | 113.5 (역행) | 133.3년 |

### 테스트
- core **102 → 111 PASS** (혜성 9 테스트: a·e·i·주기)
- 브라우저 3단계 **6/6 PASS** — focus URL 3혜성 모두 에러 없음
- typecheck / build PASS / 한글 U+FFFD 없음

### 스프린트 계약 (#98 DoD)
- [x] Halley + 2개 (Encke, Swift-Tuttle) 궤도 요소
- [x] 이심률 >0.5 (모두 해당)
- [x] `kind: 'comet'` 처리 (스키마 기존 지원)
- [x] JPL 대비 ±2% (비중력 효과 마진)
- [x] 브라우저 3단계 검증 스크립트

### 시각 스케일 (후속)
혜성 핵 km단위 → 점. #100 per-body 스케일에서 가시화.

Closes #98
Refs #100, #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)