### PR TITLE
[#99] 소행성대 N=100~1000 ThinInstances 렌더

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -34,8 +34,12 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         sceneApi.enableLogarithmicDepth(instance.scene);
         const camera = sceneApi.setupArcRotateCamera(instance.scene, { radius: 35 });
         const controller = new sceneApi.CameraController(camera, instance.scene);
+        // 소행성대 N — URL ?belt=NNN 우선, 없으면 0 (생성 안 함).
+        const beltParam = new URLSearchParams(window.location.search).get('belt');
+        const beltN = beltParam ? Math.max(0, Math.min(10_000, Number(beltParam) || 0)) : 0;
         const solar = sceneApi.createSolarSystemScene(instance.scene, {
           physicsEngine: useSimStore.getState().physicsEngine,
+          asteroidBeltN: beltN,
         });
 
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));

--- a/docs/benchmarks/2026-04-14T13-12-08-070Z.json
+++ b/docs/benchmarks/2026-04-14T13-12-08-070Z.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-04-14T13:12:08.070Z",
+  "phase": "p2-belt-100",
+  "durationMs": 3000,
+  "environment": "playwright-chromium-headless",
+  "viewport": "1280x800",
+  "scenarios": [
+    {
+      "name": "idle",
+      "fps": 24.5
+    },
+    {
+      "name": "play-1d",
+      "fps": 23
+    },
+    {
+      "name": "play-1y",
+      "fps": 23.51
+    },
+    {
+      "name": "focus-earth",
+      "fps": 99.41
+    },
+    {
+      "name": "focus-neptune",
+      "fps": 104.88
+    }
+  ]
+}

--- a/docs/benchmarks/2026-04-14T13-12-32-305Z.json
+++ b/docs/benchmarks/2026-04-14T13-12-32-305Z.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-04-14T13:12:32.305Z",
+  "phase": "p2-belt-200",
+  "durationMs": 3000,
+  "environment": "playwright-chromium-headless",
+  "viewport": "1280x800",
+  "scenarios": [
+    {
+      "name": "idle",
+      "fps": 19.71
+    },
+    {
+      "name": "play-1d",
+      "fps": 19.12
+    },
+    {
+      "name": "play-1y",
+      "fps": 19.7
+    },
+    {
+      "name": "focus-earth",
+      "fps": 90.57
+    },
+    {
+      "name": "focus-neptune",
+      "fps": 104.89
+    }
+  ]
+}

--- a/docs/benchmarks/2026-04-14T13-13-01-668Z.json
+++ b/docs/benchmarks/2026-04-14T13-13-01-668Z.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-04-14T13:13:01.668Z",
+  "phase": "p2-belt-1000",
+  "durationMs": 3000,
+  "environment": "playwright-chromium-headless",
+  "viewport": "1280x800",
+  "scenarios": [
+    {
+      "name": "idle",
+      "fps": 7.7
+    },
+    {
+      "name": "play-1d",
+      "fps": 7.53
+    },
+    {
+      "name": "play-1y",
+      "fps": 7.54
+    },
+    {
+      "name": "focus-earth",
+      "fps": 97.52
+    },
+    {
+      "name": "focus-neptune",
+      "fps": 103.57
+    }
+  ]
+}

--- a/docs/benchmarks/asteroid-belt-n-sweep.md
+++ b/docs/benchmarks/asteroid-belt-n-sweep.md
@@ -1,0 +1,36 @@
+# 소행성대 N 스윕 (#99)
+
+`bench:scene`을 `BENCH_PATH=/ko?belt=N` 로 실행한 결과. baseline은 belt 없는 P2-0 캡처(`baseline.json`).
+
+## 환경
+
+- Playwright Chromium **headless** (GPU 가속 없음 — JS/CPU 한계)
+- 1280×800
+- 측정 윈도우 3000ms × 5 시나리오
+
+## 결과
+
+| 시나리오      | baseline | N=100        | N=200        | N=1000          |
+| ------------- | -------- | ------------ | ------------ | --------------- |
+| idle          | 38.96    | 24.50 (-37%) | 19.71 (-49%) | **7.70 (-80%)** |
+| play-1d       | 38.53    | 23.00 (-40%) | 19.12 (-50%) | 7.53 (-81%)     |
+| play-1y       | 38.75    | 23.51 (-39%) | 19.70 (-49%) | 7.54 (-81%)     |
+| focus-earth   | 100.53   | 99.41        | 90.57        | 97.52           |
+| focus-neptune | 108.28   | 104.88       | 104.89       | 103.57          |
+
+> Focus 시나리오에서 fps가 크게 떨어지지 않는 이유: 카메라가 한 천체에 매우 가까워 view frustum 밖 인스턴스가 컬링됨. 렌더링 비용이 아니라 **per-frame Kepler 계산 + matrix buffer write** 가 병목임을 시사.
+
+## 해석
+
+- 헤드리스 환경 한계가 큼. **실 브라우저에서는 GPU instancing** 으로 훨씬 나음 — P2-D에서 실 브라우저 측정 별도.
+- 병목은 1) JS Kepler `positionAt` × N, 2) `thinInstanceBufferUpdated` 매 프레임 GPU 업로드.
+- 후속 최적화 후보 (P2-D 또는 P3):
+  - WASM Kepler batch (`packages/physics-wasm` 확장)
+  - 매 프레임이 아닌 매 N프레임 업데이트 (소행성 위치는 분 단위로 거의 변하지 않음)
+  - GPU compute shader로 위치 계산
+
+## 권장 N (P2-B 단계)
+
+- 기본값 0 (생성 안 함) — UX 영향 없음
+- 시각 데모: ?belt=200 권장 (실 브라우저에서 60fps 기대)
+- 부하 테스트: ?belt=1000 (현재는 헤드리스 8fps)

--- a/packages/core/src/scene/asteroid-belt.ts
+++ b/packages/core/src/scene/asteroid-belt.ts
@@ -1,0 +1,160 @@
+/**
+ * 소행성대 샘플 — N=100~1000 가상 소행성 (#99).
+ *
+ * - 분포만 실제(2.2~3.2 AU, e<0.2, i<20°), 개별 궤도는 seeded PRNG로 생성.
+ * - Babylon ThinInstances: 전체를 단일 draw call로 렌더.
+ * - 물리: 각 소행성 Kepler 2-body(태양 중력)만 — 상호 중력 무시(실제도 무시 가능 수준).
+ *   Newton 엔진에 합류시키지 않는다 (O(N²) 폭발 방지).
+ * - 프레임당 위치 갱신: ThinInstance matrix 버퍼를 in-place로 갱신한 뒤 업데이트 플래그.
+ */
+import {
+  Color3,
+  Matrix,
+  MeshBuilder,
+  StandardMaterial,
+  type Mesh,
+  type Scene,
+} from '@babylonjs/core';
+import { AU, GRAVITATIONAL_CONSTANT } from '@astro-simulator/shared';
+import { positionAt } from '../physics/kepler.js';
+import type { LoadedOrbitalElements } from '../ephemeris/solar-system-loader.js';
+
+const SCENE_UNIT_PER_METER = 1 / AU;
+
+export interface AsteroidBeltOptions {
+  /** 생성할 소행성 수. 기본 200. */
+  n?: number;
+  /** 결정적 생성을 위한 seed. 기본 42. */
+  seed?: number;
+  /** 에폭(JD). 기본 J2000.0 */
+  epoch?: number;
+}
+
+export interface AsteroidBeltHandles {
+  /** ThinInstance 호스트 메쉬 */
+  mesh: Mesh;
+  /** 각 소행성의 Kepler 요소 (진단용) */
+  elements: ReadonlyArray<LoadedOrbitalElements>;
+  /** 주어진 jd에 위치 갱신 */
+  updateAt: (jd: number) => void;
+  dispose: () => void;
+}
+
+/** mulberry32 — 32bit PRNG, 결정적 재현 */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const DEG = Math.PI / 180;
+const MAIN_BELT_INNER_AU = 2.2;
+const MAIN_BELT_OUTER_AU = 3.2;
+const MAX_ECCENTRICITY = 0.2;
+const MAX_INCLINATION_DEG = 20;
+/** 시각 크기 — 진짜 크기(수 km)는 AU 단위에서 완전히 점. 띠 형태가 보이도록 강조. */
+const ASTEROID_VISUAL_DIAMETER_AU = 0.008;
+
+export function createAsteroidBelt(
+  scene: Scene,
+  options: AsteroidBeltOptions = {},
+): AsteroidBeltHandles {
+  const n = Math.max(0, Math.min(10_000, options.n ?? 200));
+  const seed = options.seed ?? 42;
+  const epoch = options.epoch ?? 2_451_545.0;
+
+  const rnd = mulberry32(seed);
+  const elements: LoadedOrbitalElements[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const aAU = MAIN_BELT_INNER_AU + rnd() * (MAIN_BELT_OUTER_AU - MAIN_BELT_INNER_AU);
+    const e = rnd() * MAX_ECCENTRICITY;
+    const incl = rnd() * MAX_INCLINATION_DEG * DEG;
+    const lan = rnd() * 2 * Math.PI;
+    const argP = rnd() * 2 * Math.PI;
+    const m0 = rnd() * 2 * Math.PI - Math.PI;
+    elements.push({
+      semiMajorAxis: aAU * AU,
+      eccentricity: e,
+      inclination: incl,
+      longitudeOfAscendingNode: lan,
+      argumentOfPeriapsis: argP,
+      meanAnomalyAtEpoch: m0,
+      epoch,
+    });
+  }
+
+  const template = MeshBuilder.CreateSphere(
+    'asteroid-template',
+    { diameter: ASTEROID_VISUAL_DIAMETER_AU, segments: 6 },
+    scene,
+  );
+  const mat = new StandardMaterial('asteroid-mat', scene);
+  mat.diffuseColor = new Color3(0.55, 0.5, 0.45);
+  mat.specularColor = new Color3(0.02, 0.02, 0.02);
+  template.material = mat;
+  template.isPickable = false;
+
+  // 16 floats per instance (4x4 matrix). Babylon 요구 사항.
+  const matrixBuffer = new Float32Array(n * 16);
+  for (let i = 0; i < n; i += 1) {
+    Matrix.IdentityToRef(new Matrix()); // noop — 아래에서 즉시 갱신
+    writeTranslation(matrixBuffer, i, 0, 0, 0);
+  }
+  template.thinInstanceSetBuffer('matrix', matrixBuffer, 16, false);
+
+  const sun = GRAVITATIONAL_CONSTANT * 1.98892e30;
+
+  const updateAt = (jd: number) => {
+    for (let i = 0; i < n; i += 1) {
+      const el = elements[i]!;
+      const p = positionAt(el, jd, sun);
+      writeTranslation(
+        matrixBuffer,
+        i,
+        p[0] * SCENE_UNIT_PER_METER,
+        p[1] * SCENE_UNIT_PER_METER,
+        p[2] * SCENE_UNIT_PER_METER,
+      );
+    }
+    template.thinInstanceBufferUpdated('matrix');
+  };
+
+  // 초기 위치
+  updateAt(epoch);
+
+  return {
+    mesh: template,
+    elements,
+    updateAt,
+    dispose: () => {
+      template.material?.dispose();
+      template.dispose();
+    },
+  };
+}
+
+/** 4x4 row-major identity에 translation만 덮어쓴다. 회전/스케일 사용 안 함. */
+function writeTranslation(buf: Float32Array, i: number, x: number, y: number, z: number): void {
+  const o = i * 16;
+  buf[o + 0] = 1;
+  buf[o + 1] = 0;
+  buf[o + 2] = 0;
+  buf[o + 3] = 0;
+  buf[o + 4] = 0;
+  buf[o + 5] = 1;
+  buf[o + 6] = 0;
+  buf[o + 7] = 0;
+  buf[o + 8] = 0;
+  buf[o + 9] = 0;
+  buf[o + 10] = 1;
+  buf[o + 11] = 0;
+  buf[o + 12] = x;
+  buf[o + 13] = y;
+  buf[o + 14] = z;
+  buf[o + 15] = 1;
+}

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -15,4 +15,10 @@ export { enableLogarithmicDepth } from './log-depth.js';
 export { createNearFarProbe } from './near-far-probe.js';
 export type { NearFarProbeHandles } from './near-far-probe.js';
 export { createSolarSystemScene } from './solar-system-scene.js';
-export type { SolarSystemSceneHandles, SolarSystemSceneOptions } from './solar-system-scene.js';
+export type {
+  SolarSystemSceneHandles,
+  SolarSystemSceneOptions,
+  PhysicsEngineKind,
+} from './solar-system-scene.js';
+export { createAsteroidBelt } from './asteroid-belt.js';
+export type { AsteroidBeltHandles, AsteroidBeltOptions } from './asteroid-belt.js';

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -14,6 +14,7 @@ import { getSolarSystem, type LoadedCelestialBody } from '../ephemeris/solar-sys
 import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
 import { NBodyEngine, buildInitialState } from '../physics/nbody-engine.js';
+import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js';
 
 /**
  * 씬 단위: 1 scene unit = 1 AU.
@@ -53,6 +54,8 @@ export interface SolarSystemSceneOptions {
   showOrbitLines?: boolean;
   /** 물리 엔진 선택. 기본: 'kepler' (해석해). 'newton'은 #86에서 추가. */
   physicsEngine?: PhysicsEngineKind;
+  /** 소행성대 샘플 수. 0 또는 undefined면 생성 안 함. */
+  asteroidBeltN?: number;
 }
 
 /**
@@ -65,7 +68,12 @@ export function createSolarSystemScene(
   scene: Scene,
   options: SolarSystemSceneOptions = {},
 ): SolarSystemSceneHandles {
-  const { initialJulianDate = J2000_JD, showOrbitLines = true, physicsEngine = 'kepler' } = options;
+  const {
+    initialJulianDate = J2000_JD,
+    showOrbitLines = true,
+    physicsEngine = 'kepler',
+    asteroidBeltN = 0,
+  } = options;
   const SECONDS_PER_DAY = 86_400;
 
   const system = getSolarSystem();
@@ -189,6 +197,9 @@ export function createSolarSystemScene(
       sunWorld[1] * SCENE_UNIT_PER_METER,
       sunWorld[2] * SCENE_UNIT_PER_METER,
     );
+
+    // 소행성대 업데이트 — Kepler 경로와 동일한 jd 사용 (Newton 모드에서도 belt는 Kepler).
+    asteroidBelt?.updateAt(jd);
   };
 
   const updateAtKepler = (jd: number) => {
@@ -239,6 +250,16 @@ export function createSolarSystemScene(
   const setOrbitLinesVisible = (visible: boolean) => {
     if (orbitLines) orbitLines.isVisible = visible;
   };
+
+  // 소행성대 (#99) — Kepler 경로 전용. ThinInstances 단일 draw call.
+  let asteroidBelt: AsteroidBeltHandles | null = null;
+  if (asteroidBeltN > 0) {
+    asteroidBelt = createAsteroidBelt(scene, {
+      n: asteroidBeltN,
+      epoch: initialJulianDate,
+    });
+    disposables.push({ dispose: () => asteroidBelt?.dispose() });
+  }
 
   const setPhysicsEngine = (kind: PhysicsEngineKind) => {
     if (kind === activeEngine) return;

--- a/scripts/bench-scene.mjs
+++ b/scripts/bench-scene.mjs
@@ -49,7 +49,9 @@ const measureFps = (durationMs) =>
     durationMs,
   );
 
-await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+// 경로 쿼리는 BENCH_PATH 환경변수로 추가 가능 (예: /ko?belt=200)
+const path = process.env.BENCH_PATH ?? '/ko';
+await page.goto(`${baseUrl}${path}`, { waitUntil: 'networkidle' });
 await page.waitForTimeout(2000);
 
 const steps = [

--- a/scripts/browser-verify-asteroid-belt.mjs
+++ b/scripts/browser-verify-asteroid-belt.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * #99 브라우저 3단계 검증 — 소행성대 (?belt=N).
+ * 1. 정적: 캔버스 + ?belt=300 진입 시 콘솔 에러 0
+ * 2. 인터랙션: 시간 재생 중 thinInstance 갱신 에러 없음
+ * 3. 흐름: ?belt=1000 (대규모) 부하 진입 후도 로드 성공
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'asteroid-belt');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적 — ?belt=300');
+await page.goto(`${baseUrl}/ko?belt=300`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000);
+check('캔버스 렌더', (await page.locator('[data-testid="sim-canvas"]').count()) === 1);
+check('?belt=300 콘솔 에러 0', errs.length === 0);
+await page.screenshot({ path: join(shotDir, '1-belt-300.png') });
+
+console.log('\n[2/3] 인터랙션 — 시간 재생 (소행성 위치 갱신)');
+const before = errs.length;
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(2000);
+const newErrs = errs.length - before;
+check('재생 중 추가 에러 없음', newErrs === 0);
+await page.screenshot({ path: join(shotDir, '2-belt-300-playing.png') });
+
+console.log('\n[3/3] 흐름 — ?belt=1000 부하');
+const beforeBig = errs.length;
+await page.goto(`${baseUrl}/ko?belt=1000`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(3000);
+const newBigErrs = errs.length - beforeBig;
+check('?belt=1000 진입 에러 없음', newBigErrs === 0);
+await page.screenshot({ path: join(shotDir, '3-belt-1000.png') });
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#99] 소행성대 샘플

가상 소행성을 단일 draw call로 렌더 (Babylon ThinInstances). URL `?belt=N` 활성화.

### 변경
- `packages/core/src/scene/asteroid-belt.ts` 신규
- `solar-system-scene.ts` 옵션 `asteroidBeltN` 추가
- `apps/web/sim-canvas.tsx` URL `?belt=` 파싱
- `bench-scene.mjs` `BENCH_PATH` 환경변수 지원
- `docs/benchmarks/asteroid-belt-n-sweep.md` 결과

### 분포 (메인 벨트 근사)
- a ∈ [2.2, 3.2] AU
- e < 0.2
- i < 20°
- mulberry32(seed=42) 결정적

### 물리
- Kepler 2-body 전용 (태양 중력만)
- Newton N-body에 합류 안 함 — O(N²) 폭발 방지
- 매 프레임 `positionAt` × N → ThinInstance matrix 갱신

### 성능 (headless, baseline=39fps)
| N | idle | play-1y | focus-earth |
|---|---|---|---|
| 100 | 24.5 (-37%) | 23.5 | 99.4 |
| 200 | 19.7 (-49%) | 19.7 | 90.6 |
| 1000 | 7.7 (-80%) | 7.5 | 97.5 |

> 헤드리스 한계 (CPU/JS 기반). 실 브라우저 GPU instancing은 P2-D에서 별도 측정.

### 브라우저 3단계 (4/4 PASS)
- 정적: ?belt=300 캔버스 + 콘솔 에러 0
- 인터랙션: 시간 재생 중 에러 없음
- 흐름: ?belt=1000 부하 진입 OK

### 스프린트 계약 (#99 DoD)
- [x] 2.2~3.2 AU 가상 소행성 N개
- [x] InstancedMesh/ThinInstances 단일 draw call
- [x] URL ?belt=N 조절 (기본 0)
- [x] Kepler 경로 전용
- [x] N=[100, 200, 1000] bench 측정 + baseline 대비 기록
- [x] 브라우저 3단계 검증

Closes #99
Refs #100, #101, P2-D 성능 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)