### PR TITLE
[#100] 거리-의존 per-body 시각 스케일

### DIFF
--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -15,6 +15,7 @@ import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
 import { NBodyEngine, buildInitialState } from '../physics/nbody-engine.js';
 import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js';
+import { computeVisualScale, maxScaleForKind } from './visual-scale.js';
 
 /**
  * 씬 단위: 1 scene unit = 1 AU.
@@ -23,13 +24,10 @@ import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js
 const SCENE_UNIT_PER_METER = 1 / AU;
 
 /**
- * 행성/달 시각 스케일 — 실제 크기로 표시하면 점으로만 보이므로 배율 적용.
- * 시각 일관성을 위해 종류별로 다른 배율 사용.
- * C3에서 실용 검증, C7에서 스케일 전환 시 동적 조정 가능성 있음.
+ * 시각 스케일 — #100에서 카메라 거리 의존 동적 계산으로 전환.
+ * 메쉬는 실제 크기로 생성하고 프레임마다 `mesh.scaling`을 갱신한다.
+ * 상한은 kind별로 다르며 computeVisualScale/maxScaleForKind에서 관리.
  */
-const PLANET_VISUAL_SCALE = 500;
-const STAR_VISUAL_SCALE = 20;
-const MOON_VISUAL_SCALE = 500;
 
 export interface SolarSystemSceneHandles {
   /** id → 메쉬 */
@@ -191,6 +189,25 @@ export function createSolarSystemScene(
       );
     }
 
+    // 거리 기반 per-body 시각 스케일 (#100)
+    const cam = scene.activeCamera;
+    if (cam) {
+      const cx = cam.globalPosition.x;
+      const cy = cam.globalPosition.y;
+      const cz = cam.globalPosition.z;
+      for (const body of system.bodies) {
+        const mesh = meshes.get(body.id);
+        if (!mesh) continue;
+        const dx = mesh.position.x - cx;
+        const dy = mesh.position.y - cy;
+        const dz = mesh.position.z - cz;
+        const distScene = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        const distMeters = distScene * AU;
+        const scale = computeVisualScale(distMeters, body.radius, maxScaleForKind(body.kind));
+        mesh.scaling.setAll(scale);
+      }
+    }
+
     const sunWorld = worldPositions.get('sun') ?? [0, 0, 0];
     sunLight.position.set(
       sunWorld[0] * SCENE_UNIT_PER_METER,
@@ -291,15 +308,9 @@ export function createSolarSystemScene(
   };
 }
 
-function visualScaleOf(body: LoadedCelestialBody): number {
-  if (body.kind === 'star') return STAR_VISUAL_SCALE;
-  if (body.kind === 'moon') return MOON_VISUAL_SCALE;
-  return PLANET_VISUAL_SCALE;
-}
-
 function createBodyMesh(body: LoadedCelestialBody, scene: Scene): Mesh {
-  const scale = visualScaleOf(body);
-  const diameter = body.radius * 2 * scale * SCENE_UNIT_PER_METER;
+  // 메쉬는 실제 직경으로 생성. per-frame `mesh.scaling`에서 거리 기반 스케일 적용 (#100).
+  const diameter = body.radius * 2 * SCENE_UNIT_PER_METER;
   const mesh = MeshBuilder.CreateSphere(body.id, { diameter, segments: 32 }, scene);
 
   const mat = new StandardMaterial(`${body.id}-mat`, scene);

--- a/packages/core/src/scene/visual-scale.test.ts
+++ b/packages/core/src/scene/visual-scale.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeVisualScale,
+  maxScaleForKind,
+  MIN_VISUAL_SCALE,
+  MAX_VISUAL_SCALE_PLANET,
+  MAX_VISUAL_SCALE_STAR,
+  MAX_VISUAL_SCALE_COMET,
+} from './visual-scale.js';
+
+const AU = 1.495_978_707e11;
+const EARTH_R = 6.378e6;
+const MOON_R = 1.737e6;
+const MOON_EARTH_DIST = 3.844e8;
+
+describe('computeVisualScale', () => {
+  it('근접 뷰에서는 실제 크기 (scale=1)', () => {
+    // 카메라가 지구에서 0.001 AU 거리 — 매우 가까움
+    const s = computeVisualScale(0.001 * AU, EARTH_R, MAX_VISUAL_SCALE_PLANET);
+    expect(s).toBe(MIN_VISUAL_SCALE);
+  });
+
+  it('태양계 전체 뷰(30 AU)에서는 max 스케일로 클램프', () => {
+    const s = computeVisualScale(30 * AU, EARTH_R, MAX_VISUAL_SCALE_PLANET);
+    expect(s).toBe(MAX_VISUAL_SCALE_PLANET);
+  });
+
+  it('중간 거리에서 선형 보간 — 1 AU 지구는 ~188', () => {
+    const s = computeVisualScale(1 * AU, EARTH_R, MAX_VISUAL_SCALE_PLANET);
+    expect(s).toBeGreaterThan(100);
+    expect(s).toBeLessThan(300);
+  });
+
+  it('Earth-Moon 거리에서 Earth·Moon 각각 실제 크기 근방 (분리 가능)', () => {
+    // 카메라가 지구-달 거리만큼 떨어짐
+    const earthScale = computeVisualScale(MOON_EARTH_DIST, EARTH_R, MAX_VISUAL_SCALE_PLANET);
+    const moonScale = computeVisualScale(MOON_EARTH_DIST, MOON_R, MAX_VISUAL_SCALE_PLANET);
+    // scale=1일 때 시각 반경이 실제 반경과 같음. Moon 거리(3.84e8m)에서
+    // Earth 반경 6378km는 월등히 작으므로 달이 별개 구로 분리됨.
+    // Earth 반경 대비 Moon-Earth 거리 비 ≈ 60 → Earth는 실제 크기(1x)로 고정,
+    // Moon은 반경 작아 scale ≈ 1.77. 어느 쪽도 원 거리를 덮어쓰지 않아 분리 가능.
+    expect(earthScale).toBe(MIN_VISUAL_SCALE);
+    expect(moonScale).toBeGreaterThan(MIN_VISUAL_SCALE);
+    expect(moonScale).toBeLessThan(5);
+    // 시각 반경 비교: Moon 유효 반경(moonScale*MOON_R) < Moon-Earth 거리
+    expect(moonScale * MOON_R).toBeLessThan(MOON_EARTH_DIST);
+    expect(earthScale * EARTH_R).toBeLessThan(MOON_EARTH_DIST);
+  });
+
+  it('maxScaleForKind — 유형별 상한', () => {
+    expect(maxScaleForKind('star')).toBe(MAX_VISUAL_SCALE_STAR);
+    expect(maxScaleForKind('planet')).toBe(MAX_VISUAL_SCALE_PLANET);
+    expect(maxScaleForKind('moon')).toBe(MAX_VISUAL_SCALE_PLANET);
+    expect(maxScaleForKind('comet')).toBe(MAX_VISUAL_SCALE_COMET);
+    expect(maxScaleForKind('unknown-kind')).toBe(MAX_VISUAL_SCALE_PLANET);
+  });
+
+  it('경계값 — 반경 0 방어', () => {
+    expect(computeVisualScale(1 * AU, 0, 500)).toBe(MIN_VISUAL_SCALE);
+  });
+});

--- a/packages/core/src/scene/visual-scale.ts
+++ b/packages/core/src/scene/visual-scale.ts
@@ -1,0 +1,62 @@
+/**
+ * 거리-의존 per-body 시각 스케일 (#100).
+ *
+ * 문제: 모든 바디에 고정 ×500 배율을 적용하면 Earth 메쉬 반경이 지구-달 거리보다
+ * 커져서 달이 지구 내부에 묻힘. 반대로 실제 크기(×1)로 두면 태양계 전체 뷰에서
+ * 행성이 점으로 사라진다.
+ *
+ * 해법: 각 바디의 시각 반경이 카메라 거리에 비례하도록 동적 스케일.
+ *   visualRadius ≈ cameraDist × angularK
+ *   scale = visualRadius / realRadius
+ *          = cameraDist × angularK / realRadius
+ *
+ * `angularK`(라디안)는 모든 바디에 공통. maxScale로 현재 디자인 톤을 유지하고,
+ * minScale=1(실제 크기 이하로는 줄이지 않음)로 근접 뷰에서 실물 비율을 보존.
+ *
+ * 결과:
+ *  - 태양계 전체 뷰(30 AU): scale ≈ maxScale → 현재와 유사한 가시성
+ *  - 지구 근접 뷰(0.003 AU): scale ≈ 1 → 지구·달이 실제 비율로 분리
+ */
+
+/** 시각 반경이 카메라 거리의 angularK배가 되도록 한다(라디안 근사). */
+export const ANGULAR_K = 0.008;
+export const MIN_VISUAL_SCALE = 1;
+export const MAX_VISUAL_SCALE_PLANET = 500;
+export const MAX_VISUAL_SCALE_MOON = 500;
+export const MAX_VISUAL_SCALE_STAR = 20;
+export const MAX_VISUAL_SCALE_DWARF = 2_000; // 왜소행성·혜성은 작아서 가시성 위해 더 크게
+export const MAX_VISUAL_SCALE_COMET = 20_000;
+
+/**
+ * 거리 기반 시각 스케일 계산. 모든 인자는 SI 또는 scene units — 같은 단위이기만 하면 된다.
+ *
+ * @param cameraDistanceMeters 카메라–바디 거리 (m)
+ * @param bodyRealRadiusMeters 바디 실제 반경 (m)
+ * @param maxScale 해당 kind별 상한
+ */
+export function computeVisualScale(
+  cameraDistanceMeters: number,
+  bodyRealRadiusMeters: number,
+  maxScale: number,
+): number {
+  if (bodyRealRadiusMeters <= 0) return MIN_VISUAL_SCALE;
+  const raw = (cameraDistanceMeters * ANGULAR_K) / bodyRealRadiusMeters;
+  if (raw <= MIN_VISUAL_SCALE) return MIN_VISUAL_SCALE;
+  if (raw >= maxScale) return maxScale;
+  return raw;
+}
+
+export function maxScaleForKind(kind: string): number {
+  switch (kind) {
+    case 'star':
+      return MAX_VISUAL_SCALE_STAR;
+    case 'moon':
+      return MAX_VISUAL_SCALE_MOON;
+    case 'dwarf-planet':
+      return MAX_VISUAL_SCALE_DWARF;
+    case 'comet':
+      return MAX_VISUAL_SCALE_COMET;
+    default:
+      return MAX_VISUAL_SCALE_PLANET;
+  }
+}

--- a/scripts/browser-verify-per-body-scale.mjs
+++ b/scripts/browser-verify-per-body-scale.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * #100 per-body 시각 스케일 검증.
+ *
+ * 1. 정적: 전체 뷰에서 행성이 점으로 사라지지 않음 (max scale 적용됨)
+ * 2. 인터랙션: Earth focus 시 Moon이 별개 구로 분리됨 (가까우면 scale=1)
+ * 3. 흐름: 시간 재생 중 콘솔 에러 없음, 전환 부드러움
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'per-body-scale');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적 — 전체 뷰');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000);
+check('캔버스 렌더', (await page.locator('[data-testid="sim-canvas"]').count()) === 1);
+check('콘솔 에러 0', errs.length === 0);
+await page.screenshot({ path: join(shotDir, '1-overview.png') });
+
+console.log('\n[2/3] 인터랙션 — Earth focus');
+const before = errs.length;
+await page.goto(`${baseUrl}/ko?focus=earth`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2500);
+check('Earth focus 진입 에러 없음', errs.length === before);
+await page.screenshot({ path: join(shotDir, '2-earth-focus.png') });
+
+console.log('\n[3/3] 흐름 — 시간 재생 + Moon focus');
+const before2 = errs.length;
+await page.goto(`${baseUrl}/ko?focus=moon`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000);
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(1500);
+check('Moon focus + 재생 에러 없음', errs.length === before2);
+await page.screenshot({ path: join(shotDir, '3-moon-focus-playing.png') });
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#100] per-body 시각 스케일

P1 회고 버그 — 달이 지구 메쉬에 묻히던 문제 해결.

### 공식
\`scale = clamp(cameraDist × 0.008 / realRadius, 1, maxScale)\`

- **근접 뷰**: scale=1 (실제 크기) → Earth·Moon 실제 비율로 분리 가능
- **전체 뷰(30 AU)**: scale=max (현재 시각 톤 유지)
- **중간**: 선형 보간

### kind별 max
| kind | max |
|---|---|
| star | 20 |
| planet/moon | 500 |
| dwarf-planet | 2000 |
| comet | 20000 |

### 변경
- `packages/core/src/scene/visual-scale.ts` — computeVisualScale + maxScaleForKind
- `solar-system-scene.ts` — 메쉬 실제 직경 생성, updateAt에서 mesh.scaling 매 프레임 갱신
- 기존 static 상수 제거

### 테스트
- `visual-scale.test.ts` 6 PASS (경계값 포함)
- core **111 → 117 PASS**

### 브라우저 3단계 (4/4 PASS)
- 정적: 전체 뷰 렌더 + 콘솔 에러 0
- 인터랙션: `?focus=earth` 진입 에러 없음
- 흐름: `?focus=moon` + 재생 중 에러 없음

스크린샷: `.verify-screenshots/per-body-scale/{1-overview,2-earth-focus,3-moon-focus-playing}.png`

### 스프린트 계약 (#100 DoD)
- [x] 카메라→바디 거리 기반 스케일 보간
- [x] Moon이 Earth 포커스 시 별개 구로 분리 (scale=1에서 실제 비율)
- [x] 전체 뷰에서 행성 가시성 유지 (maxScale 클램프)
- [x] 기존 focus 애니메이션 영향 없음 (mesh.scaling만 변경, position·radius 고정)
- [x] 단위 테스트 경계값
- [x] 브라우저 3단계

Closes #100
Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)