### PR TITLE
[#107] 선택 천체 질량 슬라이더 — Newton 런타임 반영

### DIFF
--- a/apps/web/src/components/panels/celestial-info-panel.tsx
+++ b/apps/web/src/components/panels/celestial-info-panel.tsx
@@ -4,6 +4,7 @@ import { ephemeris as ephemerisApi } from '@astro-simulator/core';
 import { AU } from '@astro-simulator/shared';
 import { useSimStore } from '@/store/sim-store';
 import { TierBadge } from '../ui/tier-badge';
+import { MassSlider } from './mass-slider';
 import { useMemo } from 'react';
 
 const KIND_LABEL: Record<string, string> = {
@@ -84,6 +85,10 @@ export function CelestialInfoPanel() {
           </>
         )}
       </dl>
+
+      <div className="mt-4 pt-3 border-t border-border-subtle">
+        <MassSlider />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/panels/mass-slider.test.tsx
+++ b/apps/web/src/components/panels/mass-slider.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { MassSlider } from './mass-slider';
+
+beforeEach(() => {
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'research',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    physicsEngine: 'newton',
+    massMultipliers: {},
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('MassSlider', () => {
+  it('선택 없음 — 안내 메시지', () => {
+    render(<MassSlider />);
+    expect(screen.getByTestId('mass-slider-empty')).toBeInTheDocument();
+  });
+
+  it('선택 있음 — 슬라이더 렌더 + 초기값 1.0', () => {
+    useSimStore.setState({ selectedBodyId: 'jupiter' });
+    render(<MassSlider />);
+    const input = screen.getByTestId('mass-slider-input') as HTMLInputElement;
+    expect(input.value).toBe('1');
+  });
+
+  it('슬라이더 변경 → store 반영', () => {
+    useSimStore.setState({ selectedBodyId: 'jupiter' });
+    render(<MassSlider />);
+    fireEvent.change(screen.getByTestId('mass-slider-input'), { target: { value: '5' } });
+    expect(useSimStore.getState().massMultipliers).toEqual({ jupiter: 5 });
+  });
+
+  it('프리셋 버튼 10× 클릭', () => {
+    useSimStore.setState({ selectedBodyId: 'earth' });
+    render(<MassSlider />);
+    fireEvent.click(screen.getByTestId('mass-preset-10'));
+    expect(useSimStore.getState().massMultipliers).toEqual({ earth: 10 });
+  });
+
+  it('리셋 버튼 — 전체 클리어', () => {
+    useSimStore.setState({
+      selectedBodyId: 'earth',
+      massMultipliers: { earth: 2, jupiter: 5 },
+    });
+    render(<MassSlider />);
+    fireEvent.click(screen.getByTestId('mass-reset'));
+    expect(useSimStore.getState().massMultipliers).toEqual({});
+  });
+
+  it('Kepler 모드 — 입력 disabled + 힌트', () => {
+    useSimStore.setState({ selectedBodyId: 'earth', physicsEngine: 'kepler' });
+    render(<MassSlider />);
+    const input = screen.getByTestId('mass-slider-input') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/panels/mass-slider.tsx
+++ b/apps/web/src/components/panels/mass-slider.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useSimStore } from '@/store/sim-store';
+
+const PRESETS = [0.1, 0.5, 1, 2, 5, 10];
+
+/**
+ * 선택 천체 질량 배수 슬라이더 (#107).
+ *
+ * Newton 모드에서만 효과적 — Kepler는 2-body 해석해라 질량 변경이 궤도에 영향 없음.
+ * 슬라이더 값은 store.massMultipliers에 반영되고 sim-canvas가 scene에 전파.
+ */
+export function MassSlider() {
+  const selected = useSimStore((s) => s.selectedBodyId);
+  const engine = useSimStore((s) => s.physicsEngine);
+  const mul = useSimStore((s) => (selected ? (s.massMultipliers[selected] ?? 1) : 1));
+  const setMul = useSimStore((s) => s.setMassMultiplier);
+  const resetAll = useSimStore((s) => s.resetMassMultipliers);
+
+  if (!selected) {
+    return (
+      <div data-testid="mass-slider-empty" className="text-caption text-fg-tertiary">
+        천체를 선택하면 질량 조절이 가능합니다.
+      </div>
+    );
+  }
+
+  const disabled = engine !== 'newton';
+
+  return (
+    <div data-testid="mass-slider" className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-caption num text-fg-secondary">질량 배수 · {selected}</span>
+        <span className="text-caption num text-fg-primary">{mul.toFixed(2)}×</span>
+      </div>
+      <input
+        type="range"
+        data-testid="mass-slider-input"
+        min="0.1"
+        max="10"
+        step="0.1"
+        value={mul}
+        disabled={disabled}
+        onChange={(e) => setMul(selected, Number(e.target.value))}
+        className="w-full accent-primary disabled:opacity-40"
+      />
+      <div className="flex items-center gap-1">
+        {PRESETS.map((v) => (
+          <button
+            key={v}
+            type="button"
+            data-testid={`mass-preset-${v}`}
+            disabled={disabled}
+            onClick={() => setMul(selected, v)}
+            className="num text-caption px-1.5 py-0.5 rounded-xs bg-bg-elevated text-fg-secondary hover:bg-primary/20 disabled:opacity-40"
+          >
+            {v}×
+          </button>
+        ))}
+        <button
+          type="button"
+          data-testid="mass-reset"
+          disabled={disabled}
+          onClick={resetAll}
+          className="num text-caption px-1.5 py-0.5 rounded-xs bg-bg-elevated text-fg-secondary hover:bg-primary/20 ml-auto disabled:opacity-40"
+          title="모든 바디 질량을 원래대로"
+        >
+          리셋
+        </button>
+      </div>
+      {disabled && (
+        <div className="text-caption text-fg-tertiary">
+          Newton 엔진에서만 반영됩니다. 상단에서 Newton으로 전환하세요.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -45,9 +45,21 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));
 
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)
+        // + 질량 배수 변경 → setBodyMassMultiplier (#107)
         unsubEngine = useSimStore.subscribe((state, prev) => {
           if (state.physicsEngine !== prev.physicsEngine) {
             solar.setPhysicsEngine(state.physicsEngine);
+          }
+          if (state.massMultipliers !== prev.massMultipliers) {
+            const prevKeys = new Set(Object.keys(prev.massMultipliers));
+            const nextKeys = new Set(Object.keys(state.massMultipliers));
+            // 제거된 키는 1.0으로 복원
+            for (const k of prevKeys) {
+              if (!nextKeys.has(k)) solar.setBodyMassMultiplier(k, 1);
+            }
+            for (const [k, v] of Object.entries(state.massMultipliers)) {
+              if (prev.massMultipliers[k] !== v) solar.setBodyMassMultiplier(k, v);
+            }
           }
         });
         instance.setCameraHandlers(

--- a/apps/web/src/store/sim-store.test.ts
+++ b/apps/web/src/store/sim-store.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
     fps: null,
     unitSystem: 'astro',
     physicsEngine: 'kepler',
+    massMultipliers: {},
     pingCount: 0,
     lastPingAt: null,
   });
@@ -76,6 +77,18 @@ describe('useSimStore', () => {
     expect(useSimStore.getState().physicsEngine).toBe('newton');
     useSimStore.getState().setPhysicsEngine('kepler');
     expect(useSimStore.getState().physicsEngine).toBe('kepler');
+  });
+
+  it('setMassMultiplier — 설정·삭제·리셋', () => {
+    const { setMassMultiplier, resetMassMultipliers } = useSimStore.getState();
+    setMassMultiplier('jupiter', 5);
+    expect(useSimStore.getState().massMultipliers).toEqual({ jupiter: 5 });
+    setMassMultiplier('earth', 2);
+    expect(useSimStore.getState().massMultipliers).toEqual({ jupiter: 5, earth: 2 });
+    setMassMultiplier('jupiter', 1); // 1.0은 삭제
+    expect(useSimStore.getState().massMultipliers).toEqual({ earth: 2 });
+    resetMassMultipliers();
+    expect(useSimStore.getState().massMultipliers).toEqual({});
   });
 
   it('engineError — 에러 문자열 설정/클리어', () => {

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -23,6 +23,8 @@ export interface SimStoreState {
   fps: number | null;
   unitSystem: UnitSystem;
   physicsEngine: PhysicsEngineKind;
+  /** 바디 id → 질량 배수 (#107). 1.0 또는 부재는 원래 질량. */
+  massMultipliers: Record<string, number>;
 
   // 개발/디버그용 라운드트립 카운터
   pingCount: number;
@@ -38,6 +40,8 @@ export interface SimStoreState {
   setFps: (fps: number) => void;
   setUnitSystem: (unit: UnitSystem) => void;
   setPhysicsEngine: (kind: PhysicsEngineKind) => void;
+  setMassMultiplier: (bodyId: string, multiplier: number) => void;
+  resetMassMultipliers: () => void;
   incrementPing: () => void;
 }
 
@@ -51,6 +55,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   fps: null,
   unitSystem: 'astro',
   physicsEngine: 'kepler',
+  massMultipliers: {},
   pingCount: 0,
   lastPingAt: null,
 
@@ -63,6 +68,14 @@ export const useSimStore = create<SimStoreState>((set) => ({
   setFps: (fps) => set({ fps }),
   setUnitSystem: (unit) => set({ unitSystem: unit }),
   setPhysicsEngine: (kind) => set({ physicsEngine: kind }),
+  setMassMultiplier: (bodyId, multiplier) =>
+    set((state) => {
+      const next = { ...state.massMultipliers };
+      if (multiplier === 1) delete next[bodyId];
+      else next[bodyId] = multiplier;
+      return { massMultipliers: next };
+    }),
+  resetMassMultipliers: () => set({ massMultipliers: {} }),
   incrementPing: () =>
     set((state) => ({
       pingCount: state.pingCount + 1,

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -40,6 +40,10 @@ export interface SolarSystemSceneHandles {
   setPhysicsEngine: (kind: PhysicsEngineKind) => void;
   /** 현재 활성 엔진 */
   getPhysicsEngine: () => PhysicsEngineKind;
+  /** 바디 질량 배수 설정. Newton 엔진 재빌드를 유발한다. Kepler 모드에서는 저장만 됨. */
+  setBodyMassMultiplier: (bodyId: string, multiplier: number) => void;
+  /** 모든 배수를 1.0으로 리셋 + Newton 재빌드. */
+  resetMassMultipliers: () => void;
   dispose: () => void;
 }
 
@@ -135,9 +139,15 @@ export function createSolarSystemScene(
   let currentJd = initialJulianDate;
   let newtonIdIndex: Map<string, number> | null = null;
 
+  const massMultipliers = new Map<string, number>();
   const buildNewton = (jd: number) => {
     newtonEngine?.dispose();
     const initial = buildInitialState(system, jd);
+    // 질량 배수 적용 (#107) — 초기 상태 생성 후 Newton 엔진에 주입.
+    for (const [id, mul] of massMultipliers) {
+      const idx = initial.ids.indexOf(id);
+      if (idx >= 0) initial.masses[idx] = (initial.masses[idx] ?? 0) * mul;
+    }
     newtonEngine = new NBodyEngine(initial);
     newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
     newtonLastJd = jd;
@@ -286,6 +296,17 @@ export function createSolarSystemScene(
   };
   const getPhysicsEngine = () => activeEngine;
 
+  const setBodyMassMultiplier = (bodyId: string, multiplier: number) => {
+    const clamped = Math.max(0.01, Math.min(1000, multiplier));
+    if (clamped === 1) massMultipliers.delete(bodyId);
+    else massMultipliers.set(bodyId, clamped);
+    if (activeEngine === 'newton') buildNewton(currentJd);
+  };
+  const resetMassMultipliers = () => {
+    massMultipliers.clear();
+    if (activeEngine === 'newton') buildNewton(currentJd);
+  };
+
   // 초기 시점 적용
   updateAt(initialJulianDate);
 
@@ -295,6 +316,8 @@ export function createSolarSystemScene(
     setOrbitLinesVisible,
     setPhysicsEngine,
     getPhysicsEngine,
+    setBodyMassMultiplier,
+    resetMassMultipliers,
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();

--- a/scripts/browser-verify-mass-slider.mjs
+++ b/scripts/browser-verify-mass-slider.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * #107 브라우저 3단계 — 질량 슬라이더.
+ * 1. 정적: 연구 모드 + jupiter 선택 시 슬라이더 렌더, Kepler면 disabled
+ * 2. 인터랙션: Newton 전환 + 프리셋 5× 클릭 → store + UI 반영
+ * 3. 흐름: 리셋 → 슬라이더 1.0 복귀, 시간 재생 중 콘솔 에러 없음
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'mass-slider');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적 — 연구 모드 + jupiter focus (Kepler)');
+await page.goto(`${baseUrl}/ko?mode=research`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+// focus 버튼으로 선택 (URL focus 파라미터는 적용 시점이 불확정이라 클릭이 안정적)
+await page.click('[data-testid="focus-jupiter"]');
+await page.waitForTimeout(800);
+check('정보 패널 표시', (await page.locator('[data-testid="panel-right"]').count()) === 1);
+await page.locator('[data-testid="mass-slider"]').waitFor({ timeout: 5000 });
+check('질량 슬라이더 존재', (await page.locator('[data-testid="mass-slider"]').count()) === 1);
+const kDisabled = await page.locator('[data-testid="mass-slider-input"]').isDisabled();
+check('Kepler 모드에서 disabled', kDisabled);
+await page.screenshot({ path: join(shotDir, '1-kepler-disabled.png') });
+
+console.log('\n[2/3] 인터랙션 — Newton 전환 + 5× 프리셋');
+await page.click('[data-testid="engine-newton"]');
+await page.waitForTimeout(500);
+const nDisabled = await page.locator('[data-testid="mass-slider-input"]').isDisabled();
+check('Newton 전환 후 enabled', !nDisabled);
+await page.click('[data-testid="mass-preset-5"]');
+await page.waitForTimeout(500);
+const valueAfterPreset = await page.locator('[data-testid="mass-slider-input"]').inputValue();
+check('5× 프리셋 → 슬라이더 값 5', valueAfterPreset === '5');
+await page.screenshot({ path: join(shotDir, '2-newton-5x.png') });
+
+console.log('\n[3/3] 흐름 — 리셋 + 재생');
+await page.click('[data-testid="mass-reset"]');
+await page.waitForTimeout(300);
+const afterReset = await page.locator('[data-testid="mass-slider-input"]').inputValue();
+check('리셋 → 1', afterReset === '1');
+const before = errs.length;
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(1500);
+check('재생 중 콘솔 에러 없음', errs.length === before);
+await page.screenshot({ path: join(shotDir, '3-after-reset-playing.png') });
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#107] 질량 슬라이더

P2-C 시작 — 선택 천체 질량 0.1×~10× 조절 + Newton 엔진 즉시 반영.

### 변경
- `core/scene`: `setBodyMassMultiplier(id, mul)` / `resetMassMultipliers()` — 현재 jd에서 Newton 엔진 재빌드
- `sim-store`: `massMultipliers` + setter/reset
- `components/panels/mass-slider.tsx` — 슬라이더 + 프리셋 6 + 리셋, Kepler disabled
- `sim-canvas` 구독 → 씬 전파 (차분 diff)

### 스프린트 계약 (#107 DoD)
- [x] 질량 슬라이더 0.1~10×
- [x] Newton 엔진 재구성 (buildInitialState + mul 주입)
- [x] Kepler 모드 disabled + 힌트
- [x] 리셋 버튼
- [x] store + component 테스트 (7 신규)
- [x] 브라우저 3단계

### 테스트
- core 126 / apps/web **41 → 48 PASS**
- 브라우저 **7/7 PASS**: Kepler disabled / Newton 5× 프리셋 / 리셋 + 재생

Closes #107
Refs #108, #109, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)