### PR TITLE
[#108] 시간 포함 URL 북마크 버튼

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -11,6 +11,7 @@ import { TimeControls } from './time-controls';
 import { DateTimePicker } from './date-time-picker';
 import { UnitToggle } from './unit-toggle';
 import { PhysicsEngineToggle } from './physics-engine-toggle';
+import { BookmarkButton } from './bookmark-button';
 import { UrlSync } from '../../core/url-sync';
 import { SimCanvasDynamic } from '../sim-canvas.dynamic';
 
@@ -35,6 +36,7 @@ export function AppShell() {
               <DateTimePicker />
               <UnitToggle />
               <PhysicsEngineToggle />
+              <BookmarkButton />
             </div>
           }
         />

--- a/apps/web/src/components/layout/bookmark-button.test.tsx
+++ b/apps/web/src/components/layout/bookmark-button.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { BookmarkButton } from './bookmark-button';
+
+const writeText = vi.fn(async (_text: string) => {});
+
+beforeEach(() => {
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'research',
+    julianDate: 2_451_545.5,
+    selectedBodyId: 'jupiter',
+    timeScale: 3600,
+    fps: null,
+    unitSystem: 'astro',
+    physicsEngine: 'newton',
+    massMultipliers: {},
+    pingCount: 0,
+    lastPingAt: null,
+  });
+  writeText.mockClear();
+  // @ts-expect-error — jsdom navigator.clipboard 주입
+  navigator.clipboard = { writeText };
+  window.history.replaceState({}, '', '/ko');
+});
+
+describe('BookmarkButton', () => {
+  it('julianDate 없으면 disabled', () => {
+    useSimStore.setState({ julianDate: null });
+    render(<BookmarkButton />);
+    expect(screen.getByTestId('bookmark-button')).toBeDisabled();
+  });
+
+  it('클릭 시 클립보드에 URL 복사 — t/focus/speed/engine/mode 파라미터 포함', async () => {
+    render(<BookmarkButton />);
+    fireEvent.click(screen.getByTestId('bookmark-button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const url = writeText.mock.calls[0]?.[0] ?? '';
+    expect(url).toContain('t=2451545.50000');
+    expect(url).toContain('focus=jupiter');
+    expect(url).toContain('speed=3600');
+    expect(url).toContain('engine=newton');
+    expect(url).toContain('mode=research');
+  });
+
+  it('기본값(observe/kepler/1일/포커스 없음)은 URL에서 생략', async () => {
+    useSimStore.setState({
+      mode: 'observe',
+      selectedBodyId: null,
+      timeScale: 86_400,
+      physicsEngine: 'kepler',
+    });
+    render(<BookmarkButton />);
+    fireEvent.click(screen.getByTestId('bookmark-button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const url = writeText.mock.calls[0]?.[0] ?? '';
+    expect(url).toContain('t=2451545.50000');
+    expect(url).not.toContain('focus=');
+    expect(url).not.toContain('speed=');
+    expect(url).not.toContain('engine=');
+    expect(url).not.toContain('mode=');
+  });
+});

--- a/apps/web/src/components/layout/bookmark-button.tsx
+++ b/apps/web/src/components/layout/bookmark-button.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useSimStore } from '@/store/sim-store';
+import { useCallback, useState } from 'react';
+
+/**
+ * 현재 시뮬 상태(t/focus/speed/engine/mode)를 담은 URL을 클립보드에 복사 (#108).
+ *
+ * URL sync는 기본 쓰기를 t에 대해 하지 않는다(매 프레임 쓰기 → 렌더 폭주).
+ * 대신 이 버튼으로 "지금 이 순간"의 스냅샷을 URL로 고정해 공유/복원 가능.
+ */
+export function BookmarkButton() {
+  const julianDate = useSimStore((s) => s.julianDate);
+  const mode = useSimStore((s) => s.mode);
+  const selectedBodyId = useSimStore((s) => s.selectedBodyId);
+  const timeScale = useSimStore((s) => s.timeScale);
+  const physicsEngine = useSimStore((s) => s.physicsEngine);
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    if (typeof window === 'undefined' || julianDate === null) return;
+    const url = new URL(window.location.href);
+    const sp = url.searchParams;
+    sp.set('t', julianDate.toFixed(5));
+    if (mode !== 'observe') sp.set('mode', mode);
+    else sp.delete('mode');
+    if (selectedBodyId) sp.set('focus', selectedBodyId);
+    else sp.delete('focus');
+    if (timeScale !== 86_400) sp.set('speed', String(timeScale));
+    else sp.delete('speed');
+    if (physicsEngine !== 'kepler') sp.set('engine', physicsEngine);
+    else sp.delete('engine');
+    const text = url.toString();
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // 폴백 — 클립보드 API 미지원 브라우저
+      window.prompt('이 URL을 복사하세요', text);
+    }
+  }, [julianDate, mode, selectedBodyId, timeScale, physicsEngine]);
+
+  return (
+    <button
+      type="button"
+      data-testid="bookmark-button"
+      onClick={copy}
+      disabled={julianDate === null}
+      title="현재 시각·포커스·엔진·속도를 URL에 담아 복사"
+      className="num text-caption px-2 py-1 rounded-sm border border-border-subtle bg-bg-surface/80 backdrop-blur text-fg-secondary hover:bg-bg-elevated disabled:opacity-40"
+    >
+      {copied ? '✓ 복사됨' : '🔖 북마크'}
+    </button>
+  );
+}

--- a/scripts/browser-verify-bookmark.mjs
+++ b/scripts/browser-verify-bookmark.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * #108 브라우저 3단계 — 시간 포함 URL 북마크.
+ * 1. 정적: TopBar에 북마크 버튼 렌더
+ * 2. 인터랙션: 시간 이동 + Newton 전환 + focus → 북마크 클릭 → 클립보드 URL 유효
+ * 3. 흐름: 복사된 URL로 새 페이지 로드 → 상태(engine/focus) 복원
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'bookmark');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1280, height: 800 },
+  permissions: ['clipboard-read', 'clipboard-write'],
+});
+const page = await ctx.newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+check('북마크 버튼 렌더', (await page.locator('[data-testid="bookmark-button"]').count()) === 1);
+await page.screenshot({ path: join(shotDir, '1-static.png') });
+
+console.log('\n[2/3] 인터랙션 — Newton + focus + 북마크 클릭');
+await page.click('[data-testid="engine-newton"]');
+await page.waitForTimeout(300);
+await page.click('[data-testid="focus-jupiter"]');
+await page.waitForTimeout(500);
+await page.click('[data-testid="bookmark-button"]');
+await page.waitForTimeout(400);
+const copiedText = await page.evaluate(() => navigator.clipboard.readText());
+check('클립보드 URL 획득', typeof copiedText === 'string' && copiedText.length > 0, copiedText);
+check('URL에 engine=newton 포함', copiedText.includes('engine=newton'));
+check('URL에 focus=jupiter 포함', copiedText.includes('focus=jupiter'));
+check('URL에 t= 포함', /t=\d+/.test(copiedText));
+await page.screenshot({ path: join(shotDir, '2-copied.png') });
+
+console.log('\n[3/3] 흐름 — 새 페이지에서 상태 복원');
+await page.goto(copiedText, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000);
+const engineActive = await page.getAttribute('[data-testid="engine-newton"]', 'data-active');
+check('URL 진입 Newton active', engineActive === 'true');
+await page.screenshot({ path: join(shotDir, '3-restored.png') });
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#108] 북마크 버튼

현재 시뮬 상태(t/focus/engine/speed/mode) URL을 클립보드 복사 — 공유·재현 가능.

### 변경
- `components/layout/bookmark-button.tsx` — clipboard.writeText + 폴백 window.prompt
- `app-shell` TopBar 우측 배치
- 기본값(observe/kepler/1일/포커스 없음)은 URL에서 생략 (깔끔한 공유)

### 설계
매 프레임 t 쓰기는 렌더 폭주(P1 회고) → 사용자 명시 버튼으로만 쓴다. 읽기는 `url-sync`에서 초기 1회.

### 테스트
- bookmark-button.test **3 신규** (disabled / 전체 파라미터 / 기본값 생략)
- apps/web **48 → 51 PASS**
- 브라우저 **6/6 PASS**:
  - 정적: 버튼 렌더
  - 인터랙션: Newton + focus=jupiter + 클릭 → URL `?engine=newton&focus=jupiter&t=2451548.76300`
  - 흐름: 복사 URL로 재진입 → Newton active 복원

### 스프린트 계약 (#108 DoD)
- [x] ?t=JD 진입 복원 (기존 url-sync + DateTimePicker 연동)
- [x] 북마크 버튼 → URL 복사 (focus/engine/speed/mode 포함)
- [x] 단위 테스트
- [x] 브라우저 3단계 (복사 → 재진입 → 상태 일치)

Closes #108
Refs #109, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)