### PR TITLE
[#109] "만약에" 프리셋 시나리오 3개

### DIFF
--- a/apps/web/src/components/layout/side-panels.tsx
+++ b/apps/web/src/components/layout/side-panels.tsx
@@ -4,6 +4,7 @@ import { useSimStore } from '@/store/sim-store';
 import { motion, AnimatePresence } from 'framer-motion';
 import { CelestialTree } from '../panels/celestial-tree';
 import { CelestialInfoPanel } from '../panels/celestial-info-panel';
+import { ScenarioPresets } from '../panels/scenario-presets';
 
 export function SidePanels() {
   const mode = useSimStore((s) => s.mode);
@@ -34,6 +35,9 @@ export function SidePanels() {
             className="absolute top-12 bottom-16 right-0 w-[340px] bg-bg-surface/90 backdrop-blur border-l border-border-subtle z-[var(--z-panel)] p-3 overflow-y-auto"
           >
             <CelestialInfoPanel />
+            <div className="mt-4 pt-3 border-t border-border-subtle">
+              <ScenarioPresets />
+            </div>
           </motion.aside>
         </>
       )}

--- a/apps/web/src/components/panels/scenario-presets.test.tsx
+++ b/apps/web/src/components/panels/scenario-presets.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoreCommand } from '@astro-simulator/shared';
+import { useSimStore } from '@/store/sim-store';
+import { ScenarioPresets } from './scenario-presets';
+
+let sent: CoreCommand[] = [];
+vi.mock('@/core/sim-context', () => ({
+  useSimCommand: () => (cmd: CoreCommand) => sent.push(cmd),
+}));
+
+beforeEach(() => {
+  sent = [];
+  useSimStore.setState({
+    rendererKind: null,
+    engineError: null,
+    mode: 'research',
+    julianDate: null,
+    selectedBodyId: null,
+    timeScale: 86_400,
+    fps: null,
+    unitSystem: 'astro',
+    physicsEngine: 'kepler',
+    massMultipliers: { earth: 2 },
+    pingCount: 0,
+    lastPingAt: null,
+  });
+});
+
+describe('ScenarioPresets', () => {
+  it('3개 프리셋 + 원복 버튼 렌더', () => {
+    render(<ScenarioPresets />);
+    expect(screen.getByTestId('preset-jupiter-x10')).toBeInTheDocument();
+    expect(screen.getByTestId('preset-no-jupiter')).toBeInTheDocument();
+    expect(screen.getByTestId('preset-sun-half')).toBeInTheDocument();
+    expect(screen.getByTestId('scenario-reset')).toBeInTheDocument();
+  });
+
+  it('목성 10× 적용 — 엔진 Newton + 질량 10 + 시간 J2000 리셋', () => {
+    render(<ScenarioPresets />);
+    fireEvent.click(screen.getByTestId('preset-jupiter-x10'));
+    const s = useSimStore.getState();
+    expect(s.physicsEngine).toBe('newton');
+    expect(s.massMultipliers).toEqual({ jupiter: 10 });
+    expect(sent).toContainEqual({ type: 'jumpToJulianDate', julianDate: 2_451_545.0 });
+  });
+
+  it('원복 — Kepler + 질량 초기화 + 시간 J2000', () => {
+    render(<ScenarioPresets />);
+    fireEvent.click(screen.getByTestId('scenario-reset'));
+    const s = useSimStore.getState();
+    expect(s.physicsEngine).toBe('kepler');
+    expect(s.massMultipliers).toEqual({});
+    expect(sent).toContainEqual({ type: 'jumpToJulianDate', julianDate: 2_451_545.0 });
+  });
+});

--- a/apps/web/src/components/panels/scenario-presets.tsx
+++ b/apps/web/src/components/panels/scenario-presets.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useSimStore } from '@/store/sim-store';
+import { useSimCommand } from '@/core/sim-context';
+
+interface Preset {
+  id: string;
+  label: string;
+  description: string;
+  massMultipliers: Record<string, number>;
+}
+
+/**
+ * 프리셋 "만약에" 시나리오 (#109).
+ *
+ * 질량 배수(#107)만 다루는 순수 설정. 적용 시:
+ *  1. Newton 엔진으로 전환 (Kepler 2-body는 섭동 관찰 불가)
+ *  2. 시간을 J2000으로 리셋 — 비교 관찰을 동일 시점에서 시작
+ *  3. 질량 배수 교체
+ */
+const PRESETS: Preset[] = [
+  {
+    id: 'jupiter-x10',
+    label: '목성 10배 질량',
+    description: '내행성 및 소행성대 궤도 섭동을 관찰. 소행성대와 함께 볼 것 (URL ?belt=300).',
+    massMultipliers: { jupiter: 10 },
+  },
+  {
+    id: 'no-jupiter',
+    label: '목성 제거 (질량 1%)',
+    description: '수성·화성 궤도가 Kepler 해석해와 어떻게 일치하는지 관찰.',
+    massMultipliers: { jupiter: 0.01 },
+  },
+  {
+    id: 'sun-half',
+    label: '태양 0.5배 질량',
+    description: '모든 행성의 공전주기가 √2배 길어진다(Kepler 3법칙). 1일/초 재생에서 체감.',
+    massMultipliers: { sun: 0.5 },
+  },
+];
+
+const J2000 = 2_451_545.0;
+
+export function ScenarioPresets() {
+  const resetMasses = useSimStore((s) => s.resetMassMultipliers);
+  const setMass = useSimStore((s) => s.setMassMultiplier);
+  const setEngine = useSimStore((s) => s.setPhysicsEngine);
+  const sendCommand = useSimCommand();
+
+  const apply = (preset: Preset) => {
+    setEngine('newton');
+    resetMasses();
+    for (const [id, mul] of Object.entries(preset.massMultipliers)) {
+      setMass(id, mul);
+    }
+    sendCommand({ type: 'jumpToJulianDate', julianDate: J2000 });
+  };
+
+  const resetAll = () => {
+    resetMasses();
+    setEngine('kepler');
+    sendCommand({ type: 'jumpToJulianDate', julianDate: J2000 });
+  };
+
+  return (
+    <div data-testid="scenario-presets" className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-body-sm text-fg-secondary">만약에 시나리오</span>
+        <button
+          type="button"
+          data-testid="scenario-reset"
+          onClick={resetAll}
+          className="num text-caption px-1.5 py-0.5 rounded-xs bg-bg-elevated text-fg-secondary hover:bg-primary/20"
+          title="Kepler 2-body + 모든 질량 원복 + J2000 리셋"
+        >
+          원복
+        </button>
+      </div>
+      {PRESETS.map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          data-testid={`preset-${p.id}`}
+          onClick={() => apply(p)}
+          className="text-left bg-bg-elevated/50 hover:bg-primary/15 rounded-sm px-2 py-1.5 border border-border-subtle"
+        >
+          <div className="text-body-sm text-fg-primary">{p.label}</div>
+          <div className="text-caption text-fg-tertiary leading-snug">{p.description}</div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/scripts/browser-verify-presets.mjs
+++ b/scripts/browser-verify-presets.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * #109 브라우저 3단계 — 프리셋 "만약에" 시나리오.
+ * 1. 정적: 연구 모드에서 프리셋 3개 렌더
+ * 2. 인터랙션: jupiter-x10 클릭 → Newton 토글 active + 재생 가능
+ * 3. 흐름: 원복 → Kepler 복귀
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'presets');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const out = [];
+const check = (n, p, d = '') => {
+  out.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/3] 정적');
+await page.goto(`${baseUrl}/ko?mode=research`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+await page.locator('[data-testid="scenario-presets"]').waitFor({ timeout: 5000 });
+check('프리셋 패널', (await page.locator('[data-testid="scenario-presets"]').count()) === 1);
+check(
+  'jupiter-x10 프리셋',
+  (await page.locator('[data-testid="preset-jupiter-x10"]').count()) === 1,
+);
+check('no-jupiter 프리셋', (await page.locator('[data-testid="preset-no-jupiter"]').count()) === 1);
+check('sun-half 프리셋', (await page.locator('[data-testid="preset-sun-half"]').count()) === 1);
+await page.screenshot({ path: join(shotDir, '1-static.png') });
+
+console.log('\n[2/3] 인터랙션 — jupiter-x10 적용');
+await page.click('[data-testid="preset-jupiter-x10"]');
+await page.waitForTimeout(1000);
+const newtonActive = await page.getAttribute('[data-testid="engine-newton"]', 'data-active');
+check('Newton 엔진 자동 전환', newtonActive === 'true');
+const before = errs.length;
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(2000);
+check('재생 중 콘솔 에러 없음', errs.length === before);
+await page.screenshot({ path: join(shotDir, '2-jupiter-x10.png') });
+
+console.log('\n[3/3] 흐름 — 원복');
+await page.click('[data-testid="scenario-reset"]');
+await page.waitForTimeout(800);
+const keplerActive = await page.getAttribute('[data-testid="engine-kepler"]', 'data-active');
+check('Kepler 엔진 복귀', keplerActive === 'true');
+await page.screenshot({ path: join(shotDir, '3-reset.png') });
+
+await browser.close();
+const pass = out.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${out.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < out.length) process.exit(1);


### PR DESCRIPTION
## [#109] 프리셋 시나리오

연구 모드 우 패널에 프리셋 버튼. 클릭 → Newton 자동 전환 + 질량 배수 적용 + J2000 리셋.

### 프리셋 3개
| ID | 설명 |
|---|---|
| jupiter-x10 | 목성 10배 질량 → 내행성/소행성대 섭동 (?belt=300 권장) |
| no-jupiter | 목성 0.01배 → Kepler 해석해와 비교용 |
| sun-half | 태양 0.5배 → 공전주기 √2배 (Kepler 3법칙 체감) |

### 원복 버튼
Kepler 복귀 + 질량 원복 + J2000.

### 테스트
- `scenario-presets.test.tsx` 3 PASS
- apps/web **51 → 54 PASS**
- 브라우저 **7/7 PASS**: jupiter-x10 적용 → Newton active → 재생 / 원복 → Kepler active

### 스프린트 계약 (#109 DoD)
- [x] 프리셋 목록 UI (버튼 그룹)
- [x] 3개 이상 시나리오
- [x] 엔진 Newton 자동 전환 + 파라미터 + 시간 리셋
- [x] 브라우저 3단계 검증

Closes #109
Refs #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)