### PR TITLE
[#117] 접근성 + 브라우저 호환 재검증 + P2-C UI axe 수정

### DIFF
--- a/apps/web/src/components/panels/mass-slider.tsx
+++ b/apps/web/src/components/panels/mass-slider.tsx
@@ -36,6 +36,7 @@ export function MassSlider() {
       <input
         type="range"
         data-testid="mass-slider-input"
+        aria-label={`${selected} 질량 배수`}
         min="0.1"
         max="10"
         step="0.1"

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -21,6 +21,8 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
     if (coreRef.current && !coreRef.current.disposed) return;
 
     const instance = new SimulationCore(canvas);
+    // Babylon이 기본 tabindex=1을 설정 — a11y(WCAG 2.4.3) 권고상 양수 금지.
+    canvas.setAttribute('tabindex', '0');
     coreRef.current = instance;
     setCore(instance);
     const detach = attachCoreToStore(instance);

--- a/scripts/browser-verify-a11y-p2c.mjs
+++ b/scripts/browser-verify-a11y-p2c.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * #117 P2-C UI 접근성 확장 — MassSlider / BookmarkButton / ScenarioPresets
+ * axe-core 위반 재검증.
+ */
+import { chromium } from 'playwright';
+import AxeBuilder from '@axe-core/playwright';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const browser = await chromium.launch();
+const page = await (await browser.newContext({ viewport: { width: 1280, height: 800 } })).newPage();
+
+const errs = [];
+page.on('console', (m) => m.type() === 'error' && errs.push(m.text()));
+
+const results = [];
+const check = (n, p, d = '') => {
+  results.push({ n, p });
+  console.log(`  ${p ? '✓' : '✗'} ${n}${d ? ' — ' + d : ''}`);
+};
+
+console.log('\n[1/2] 연구 모드 + jupiter focus → P2-C UI 표시');
+await page.goto(`${baseUrl}/ko?mode=research`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+await page.click('[data-testid="focus-jupiter"]');
+await page.waitForTimeout(800);
+check('MassSlider 렌더', (await page.locator('[data-testid="mass-slider"]').count()) === 1);
+check('BookmarkButton 렌더', (await page.locator('[data-testid="bookmark-button"]').count()) === 1);
+check(
+  'ScenarioPresets 렌더',
+  (await page.locator('[data-testid="scenario-presets"]').count()) === 1,
+);
+
+console.log('\n[2/2] axe-core 위반 재검증 (P2-C UI 포함 상태)');
+const axe = await new AxeBuilder({ page }).analyze();
+const criticalOrSerious = axe.violations.filter((v) => ['critical', 'serious'].includes(v.impact));
+check(
+  `axe critical/serious 위반 ${criticalOrSerious.length}건`,
+  criticalOrSerious.length === 0,
+  criticalOrSerious.map((v) => v.id).join(', ') || 'none',
+);
+if (criticalOrSerious.length > 0) {
+  for (const v of criticalOrSerious) {
+    console.log(`    - ${v.id}: ${v.help}`);
+  }
+}
+
+// 키보드 네비게이션 — 탭으로 북마크/프리셋 도달 가능 확인
+console.log('\n[보조] 키보드 포커스');
+await page.keyboard.press('Tab');
+await page.keyboard.press('Tab');
+const active = await page.evaluate(
+  () => document.activeElement?.getAttribute('data-testid') ?? null,
+);
+check('Tab 포커스 이동 (최초 요소 data-testid 확인)', active !== null, active ?? 'null');
+
+await browser.close();
+const pass = results.filter((r) => r.p).length;
+console.log(`\n결과: ${pass}/${results.length} PASS`);
+if (errs.length) errs.slice(0, 5).forEach((e) => console.log(' ', e));
+if (pass < results.length) process.exit(1);


### PR DESCRIPTION
## [#117] 접근성 + 브라우저 호환 재검증

### 발견·수정
| 이슈 | 영향도 | 해결 |
|---|---|---|
| MassSlider input 라벨 없음 | critical | `aria-label="{id} 질량 배수"` 추가 |
| Babylon canvas `tabindex=1` | serious (WCAG 2.4.3) | `canvas.setAttribute('tabindex','0')` |

### 검증 결과 (전부 PASS)
- `pnpm verify:a11y`: 8/8 (axe 0, focusable 47, 색약 시뮬 정상)
- `pnpm verify:browser`: 전체 PASS
- `pnpm verify:mobile`: 7/7
- `scripts/browser-verify-a11y-p2c.mjs` (신규): 5/5 — axe 0건 (P2-C UI 포함)

### 변경
- `apps/web/src/components/panels/mass-slider.tsx`: aria-label
- `apps/web/src/components/sim-canvas.tsx`: tabindex 덮어쓰기
- `scripts/browser-verify-a11y-p2c.mjs` (신규)

### 스프린트 계약 (#117 DoD)
- [x] verify:a11y 재실행 (P2-C UI 포함 확장 스크립트)
- [x] 브라우저 호환성 재실행
- [x] 발견 이슈 수정 (2건)

Closes #117
Refs #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)