### PR TITLE
[#78] bench:scene N-sweep + PR fps diff CI 코멘트

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,68 @@
+name: bench:scene
+
+# PR마다 bench:scene:sweep을 실행하여 baseline 대비 fps diff를 코멘트.
+# CI 헤드리스 환경 변동성이 크므로 best-effort(continue-on-error) 운용.
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/**'
+      - 'scripts/bench-scene.mjs'
+      - 'docs/benchmarks/baseline.json'
+      - '.github/workflows/bench.yml'
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+
+      - name: Playwright 브라우저 설치
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 앱 빌드
+        run: pnpm build
+
+      - name: 웹 서버 기동 (백그라운드)
+        run: |
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          echo "WEB_PID=$!" >> $GITHUB_ENV
+          # 서버 준비 대기
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+
+      - name: bench:scene:sweep
+        env:
+          BENCH_PHASE: pr-${{ github.event.pull_request.number }}
+          BENCH_SUMMARY_OUT: bench-summary.md
+          BENCH_REGRESSION_FPS: '-10'
+        run: pnpm bench:scene:sweep
+
+      - name: PR 코멘트 게시
+        if: always() && hashFiles('bench-summary.md') != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bench-scene
+          path: bench-summary.md
+
+      - name: 서버 종료
+        if: always()
+        run: kill $WEB_PID || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,6 +30,15 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Rust 툴체인 설정
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: wasm-pack 설치
+        run: cargo install wasm-pack --version 0.14.0 --locked
+
       - name: 의존성 설치
         run: pnpm install --frozen-lockfile
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -11,9 +11,19 @@ pnpm dev
 # 벤치 실행 → docs/benchmarks/{timestamp}.json 생성
 BENCH_PHASE=p1-end pnpm bench:scene
 
+# N-sweep 모드 (소행성대 N=10,100,200,1000 각각 play-1y fps)
+BENCH_PHASE=p2-0-end pnpm bench:scene:sweep
+
 # 첫 실행 시 baseline 설정
 pnpm bench:scene:set-baseline
 ```
+
+### 환경변수
+
+- `BENCH_PATH` — 측정 경로 (기본 `/ko`). 예: `BENCH_PATH=/ko?belt=200`
+- `BENCH_N_SWEEP` — N-sweep 대상 (쉼표구분). 설정 시 각 N마다 `?belt=N` 재방문
+- `BENCH_REGRESSION_FPS` — 회귀 판정 임계값 (기본 `-2`, CI는 `-10`)
+- `BENCH_SUMMARY_OUT` — Markdown 요약 출력 경로 (CI 코멘트용)
 
 ## 파일 규칙
 
@@ -26,6 +36,10 @@ pnpm bench:scene:set-baseline
 bench 실행 시 baseline 대비 각 시나리오의 fps 변화율을 출력한다.
 `Δ < -2 fps` 인 시나리오는 `⚠` 마크. PR에 그 출력을 첨부하거나 값 악화 원인을 분석 후 PR 본문에 기록한다.
 
-## P2-A 이후
+## N-sweep 리포트 스키마
 
-Newton N-body 전환 후 `nBody: [{ n, fps }]` 필드가 추가된다. N=[10, 100, 200, 1000] 샘플.
+`bench:scene:sweep` 실행 시 리포트에 `nBody: [{ n, fps }]` 필드가 추가된다. N=[10, 100, 200, 1000] 샘플을 `/ko?belt=N` 경로에서 play-1y 시나리오로 측정.
+
+## CI 연동
+
+`.github/workflows/bench.yml` — PR 이벤트에서 sweep을 실행해 baseline 대비 diff를 sticky comment로 게시한다 (best-effort). 헤드리스 GitHub Actions runner의 GPU 변동성이 크므로 임계값을 `-10 fps`로 완화하며, 정식 성능 게이트는 로컬 실 GPU 측정(#116, `scripts/bench-scene-real-gpu.mjs`)을 기준으로 한다.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "verify:a11y": "node scripts/browser-verify-a11y.mjs",
     "verify:test-coverage": "node scripts/verify-test-coverage.mjs",
     "bench:scene": "node scripts/bench-scene.mjs",
+    "bench:scene:sweep": "BENCH_N_SWEEP=10,100,200,1000 node scripts/bench-scene.mjs",
     "bench:scene:set-baseline": "node scripts/bench-set-baseline.mjs"
   },
   "devDependencies": {

--- a/scripts/bench-scene.mjs
+++ b/scripts/bench-scene.mjs
@@ -14,9 +14,11 @@
  * - JSON 리포트 docs/benchmarks/{timestamp}.json 저장
  * - docs/benchmarks/baseline.json 대비 diff 콘솔 출력
  *
- * P2-A 이후 확장 예정
- * -----------------
- * - N = [10, 100, 200, 1000] 소천체 개수 파라미터화 (씬에 N-body 주입 후)
+ * N-sweep 모드
+ * ------------
+ * `BENCH_N_SWEEP=10,100,200,1000` 설정 시 각 N마다 `/ko?belt=N`을 재방문해
+ * play-1y 시나리오 fps를 측정하고 리포트에 `nBody: [{ n, fps }]`로 기록한다.
+ * 시간이 길어지므로 시나리오 측정과 병행 실행된다.
  */
 import { chromium } from 'playwright';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -79,6 +81,25 @@ for (const s of steps) {
   scenarios.push({ name: s.name, fps: Number(fps.toFixed(2)) });
 }
 
+// N-sweep: 소행성대 개수별 fps 측정 (play-1y 시나리오 기준)
+const nBody = [];
+const sweepEnv = process.env.BENCH_N_SWEEP;
+if (sweepEnv) {
+  const ns = sweepEnv
+    .split(',')
+    .map((x) => Number.parseInt(x.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  for (const n of ns) {
+    await page.goto(`${baseUrl}${path.split('?')[0]}?belt=${n}`, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(1500);
+    await page.click('[data-testid="time-play"]').catch(() => {});
+    await page.click('[data-testid="time-preset-1y"]').catch(() => {});
+    await page.waitForTimeout(500);
+    const fps = await measureFps(SCENARIO_DURATION_MS);
+    nBody.push({ n, fps: Number(fps.toFixed(2)) });
+  }
+}
+
 await browser.close();
 
 const timestamp = new Date().toISOString();
@@ -89,14 +110,15 @@ const report = {
   environment: 'playwright-chromium-headless',
   viewport: '1280x800',
   scenarios,
-  // P2-A 이후: nBody: [{ n: 10, fps: ... }, ...]
+  ...(nBody.length > 0 && { nBody }),
 };
 
 const slug = timestamp.replace(/[:.]/g, '-');
 const outPath = join(benchDir, `${slug}.json`);
 writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n');
 
-// baseline diff
+// baseline diff — CI 환경 변동성 고려해 임계값은 환경변수로 조정 (기본 -2 fps)
+const regressionThreshold = Number.parseFloat(process.env.BENCH_REGRESSION_FPS ?? '-2');
 const baselinePath = join(benchDir, 'baseline.json');
 let diffLines = [];
 if (existsSync(baselinePath)) {
@@ -109,10 +131,25 @@ if (existsSync(baselinePath)) {
     } else {
       const delta = s.fps - b;
       const pct = ((delta / b) * 100).toFixed(1);
-      const mark = delta >= -2 ? '✓' : '⚠';
+      const mark = delta >= regressionThreshold ? '✓' : '⚠';
       diffLines.push(
         `  ${mark} ${s.name}: ${s.fps} fps (baseline ${b} → Δ ${delta >= 0 ? '+' : ''}${delta.toFixed(2)}, ${pct}%)`,
       );
+    }
+  }
+  if (nBody.length > 0) {
+    const baseN = new Map((base.nBody ?? []).map((x) => [x.n, x.fps]));
+    diffLines.push('  --- N-sweep ---');
+    for (const x of nBody) {
+      const b = baseN.get(x.n);
+      if (b == null) diffLines.push(`  N=${x.n}: ${x.fps} fps (신규)`);
+      else {
+        const delta = x.fps - b;
+        const mark = delta >= regressionThreshold ? '✓' : '⚠';
+        diffLines.push(
+          `  ${mark} N=${x.n}: ${x.fps} fps (baseline ${b} → Δ ${delta >= 0 ? '+' : ''}${delta.toFixed(2)})`,
+        );
+      }
     }
   }
 } else {
@@ -126,6 +163,36 @@ console.log(`bench:scene — ${timestamp}`);
 console.log(`리포트: ${outPath}`);
 console.log('----------------------------------------');
 for (const s of scenarios) console.log(`  ${s.name}: ${s.fps} fps`);
+for (const x of nBody) console.log(`  N=${x.n}: ${x.fps} fps`);
 console.log('----------------------------------------');
 console.log('baseline diff:');
 diffLines.forEach((l) => console.log(l));
+
+// CI 연동: Markdown 요약을 BENCH_SUMMARY_OUT 경로에 기록 (PR 코멘트용)
+if (process.env.BENCH_SUMMARY_OUT) {
+  const md = [
+    '### bench:scene 리포트',
+    `- timestamp: \`${timestamp}\``,
+    `- phase: \`${report.phase}\``,
+    '',
+    '#### 시나리오 (fps)',
+    '| scenario | fps |',
+    '| --- | --- |',
+    ...scenarios.map((s) => `| ${s.name} | ${s.fps} |`),
+    ...(nBody.length > 0
+      ? [
+          '',
+          '#### N-sweep (play-1y, fps)',
+          '| N | fps |',
+          '| --- | --- |',
+          ...nBody.map((x) => `| ${x.n} | ${x.fps} |`),
+        ]
+      : []),
+    '',
+    '#### baseline diff',
+    '```',
+    ...diffLines,
+    '```',
+  ].join('\n');
+  writeFileSync(process.env.BENCH_SUMMARY_OUT, md + '\n');
+}


### PR DESCRIPTION
## Summary
- `BENCH_N_SWEEP`로 N=[10,100,200,1000] play-1y fps를 단일 실행에서 측정 → 리포트 `nBody` 배열 기록
- `pnpm bench:scene:sweep` 스크립트 + `BENCH_REGRESSION_FPS`, `BENCH_SUMMARY_OUT` 환경변수
- `.github/workflows/bench.yml` — PR 이벤트에서 sweep 실행 후 sticky comment 게시 (best-effort, `continue-on-error`)
- `docs/benchmarks/README.md` 환경변수·CI 섹션 보강

## Why
#78 DoD(N=[10,100,200,1000] 리포트 + CI fps diff 코멘트) 해결. 기존 scripts/`bench-scene.mjs`는 시나리오 fps만 기록하고 N은 `BENCH_PATH` 수동 반복이 필요했음.

## 설계 결정
- **CI 임계값 -10 fps** — headless Actions runner의 GPU 변동성이 크므로 완화. 정식 성능 게이트는 실 GPU 로컬 측정(#116, `bench-scene-real-gpu.mjs`)이 담당.
- **best-effort** — bench 실패가 PR 병합을 막지 않도록 `continue-on-error: true`.
- **sticky comment** — `marocchino/sticky-pull-request-comment` 로 PR당 하나의 코멘트를 갱신.

## Test plan
- [ ] 로컬 `pnpm dev` 후 `BENCH_PHASE=p2-0-end pnpm bench:scene:sweep` 실행 → `nBody` 필드 포함된 JSON 생성 확인
- [ ] 이 PR에서 CI `bench:scene` 워크플로가 실행되어 본 스레드에 코멘트가 달리는지 확인
- [ ] 기존 `pnpm bench:scene` (sweep 미지정)의 동작 불변 확인

Closes #78