### PR TITLE
[#126] Engine selector 4-mode + auto

### DIFF
--- a/apps/web/src/components/layout/physics-engine-toggle.test.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.test.tsx
@@ -39,4 +39,21 @@ describe('PhysicsEngineToggle', () => {
     expect(screen.getByTestId('engine-kepler')).toHaveAttribute('title');
     expect(screen.getByTestId('engine-newton')).toHaveAttribute('title');
   });
+
+  // P3-0 #126
+  it('barnes-hut/webgpu/auto 버튼은 disabled (미구현)', () => {
+    render(<PhysicsEngineToggle />);
+    for (const id of ['barnes-hut', 'webgpu', 'auto']) {
+      const btn = screen.getByTestId(`engine-${id}`);
+      expect(btn).toBeDisabled();
+      expect(btn.dataset.runnable).toBe('false');
+      expect(btn).toHaveAttribute('title');
+    }
+  });
+
+  it('disabled 엔진 클릭은 store에 반영되지 않음', () => {
+    render(<PhysicsEngineToggle />);
+    fireEvent.click(screen.getByTestId('engine-webgpu'));
+    expect(useSimStore.getState().physicsEngine).toBe('kepler');
+  });
 });

--- a/apps/web/src/components/layout/physics-engine-toggle.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSimStore, type PhysicsEngineKind } from '@/store/sim-store';
+import { useSimStore, type PhysicsEngineKind, RUNNABLE_ENGINES } from '@/store/sim-store';
 
 interface EngineDef {
   id: PhysicsEngineKind;
@@ -8,6 +8,7 @@ interface EngineDef {
   tooltip: string;
 }
 
+// P3-0 #126 — 4-mode + auto. 미구현(barnes-hut, webgpu)은 disabled로 노출해 로드맵 가시화.
 const ENGINES: EngineDef[] = [
   {
     id: 'kepler',
@@ -18,6 +19,21 @@ const ENGINES: EngineDef[] = [
     id: 'newton',
     label: 'Newton',
     tooltip: 'N-body 수치적분(Velocity-Verlet, WASM) — 섭동 포함, 시간 역행 가능.',
+  },
+  {
+    id: 'barnes-hut',
+    label: 'Barnes-Hut',
+    tooltip: 'O(N log N) octree — N=5000+ 가속 (P3-A에서 활성화).',
+  },
+  {
+    id: 'webgpu',
+    label: 'WebGPU',
+    tooltip: 'GPU compute shader — N=10000+ 최대 성능 (P3-B에서 활성화).',
+  },
+  {
+    id: 'auto',
+    label: 'Auto',
+    tooltip: '환경 감지 후 최적 엔진 자동 선택 (P3-A부터 활성화).',
   },
 ];
 
@@ -39,16 +55,24 @@ export function PhysicsEngineToggle() {
     >
       {ENGINES.map((e) => {
         const active = engine === e.id;
+        const runnable = RUNNABLE_ENGINES.has(e.id);
         return (
           <button
             key={e.id}
             type="button"
             data-testid={`engine-${e.id}`}
             data-active={active}
+            data-runnable={runnable}
+            disabled={!runnable}
+            aria-disabled={!runnable}
             title={e.tooltip}
-            onClick={() => setPhysicsEngine(e.id)}
+            onClick={() => runnable && setPhysicsEngine(e.id)}
             className={`num text-caption px-2 py-1 rounded-xs transition-colors ${
-              active ? 'bg-primary/25 text-fg-primary' : 'text-fg-secondary hover:bg-bg-elevated'
+              active
+                ? 'bg-primary/25 text-fg-primary'
+                : runnable
+                  ? 'text-fg-secondary hover:bg-bg-elevated'
+                  : 'text-fg-tertiary opacity-50 cursor-not-allowed'
             }`}
             style={{ transitionDuration: 'var(--duration-fast)' }}
           >

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -39,8 +39,12 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         // 소행성대 N — URL ?belt=NNN 우선, 없으면 0 (생성 안 함).
         const beltParam = new URLSearchParams(window.location.search).get('belt');
         const beltN = beltParam ? Math.max(0, Math.min(10_000, Number(beltParam) || 0)) : 0;
+        // P3-0 #126 — barnes-hut/webgpu/auto는 아직 런타임 미구현. newton로 폴백.
+        const resolveEngine = (
+          k: ReturnType<typeof useSimStore.getState>['physicsEngine'],
+        ): 'kepler' | 'newton' => (k === 'kepler' ? 'kepler' : 'newton');
         const solar = sceneApi.createSolarSystemScene(instance.scene, {
-          physicsEngine: useSimStore.getState().physicsEngine,
+          physicsEngine: resolveEngine(useSimStore.getState().physicsEngine),
           asteroidBeltN: beltN,
         });
 
@@ -50,7 +54,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         // + 질량 배수 변경 → setBodyMassMultiplier (#107)
         unsubEngine = useSimStore.subscribe((state, prev) => {
           if (state.physicsEngine !== prev.physicsEngine) {
-            solar.setPhysicsEngine(state.physicsEngine);
+            solar.setPhysicsEngine(resolveEngine(state.physicsEngine));
           }
           if (state.massMultipliers !== prev.massMultipliers) {
             const prevKeys = new Set(Object.keys(prev.massMultipliers));

--- a/apps/web/src/core/url-sync.tsx
+++ b/apps/web/src/core/url-sync.tsx
@@ -7,7 +7,9 @@ import { useSimStore } from '@/store/sim-store';
 import { useSimCommand } from './sim-context';
 
 const MODE_VALUES: SimMode[] = ['observe', 'research', 'education', 'sandbox'];
-const ENGINE_VALUES = ['kepler', 'newton'] as const;
+// P3-0 #126 — barnes-hut/webgpu/auto는 URL로는 받지만 런타임은 미구현 폴백.
+// 후방호환: 기존 newton/kepler URL은 그대로 동작.
+const ENGINE_VALUES = ['kepler', 'newton', 'barnes-hut', 'webgpu', 'auto'] as const;
 type PhysicsEngineUrl = (typeof ENGINE_VALUES)[number];
 
 /**

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -2,7 +2,18 @@ import type { SimMode } from '@astro-simulator/shared';
 import { create } from 'zustand';
 
 export type UnitSystem = 'si' | 'astro' | 'natural';
-export type PhysicsEngineKind = 'kepler' | 'newton';
+/**
+ * 물리 엔진 종류 (P3-0 #126).
+ *  - kepler: 2-body 해석해 (P1)
+ *  - newton: N-body Velocity-Verlet 직접합 (P2-A, wasm)
+ *  - barnes-hut: O(N log N) octree (P3-A 도입 예정 — 현재 비활성)
+ *  - webgpu: GPU compute shader (P3-B 도입 예정 — 현재 비활성)
+ *  - auto: 환경 capability 감지로 최적 자동 선택 (현재는 newton로 동작)
+ */
+export type PhysicsEngineKind = 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' | 'auto';
+
+/** 현재 런타임에서 실제 동작하는 엔진 (auto/미구현은 newton로 폴백). */
+export const RUNNABLE_ENGINES: ReadonlySet<PhysicsEngineKind> = new Set(['kepler', 'newton']);
 
 /**
  * 시뮬레이션 UI 상태 store.


### PR DESCRIPTION
## Summary
- `PhysicsEngineKind` = `kepler | newton | barnes-hut | webgpu | auto`
- `PhysicsEngineToggle`: 5개 버튼 노출, 미구현 3개(barnes-hut/webgpu/auto)는 `disabled` + tooltip + a11y(`aria-disabled`)
- URL `?engine=...` enum 확장, 후방호환 유지
- `sim-canvas`: `resolveEngine`으로 비-runnable 값 → newton 폴백
- 신규 테스트 2개 추가 (disabled 상태 / 클릭 비반영)

## Why
P3-A(Barnes-Hut), P3-B(WebGPU) 도입 시 UI/URL 골격이 미리 있어야 점진 활성화 가능. `auto`는 P3-A부터 capability 감지로 자동 선택.

## 검증
- `pnpm --filter @astro-simulator/web typecheck` 통과
- `vitest run` 56/56 통과 (engine toggle 5건 포함)
- `node scripts/browser-verify.mjs` Level 1 25/25 통과 — 토글 추가가 기존 흐름에 영향 없음

## Test plan
- [ ] CI 통과
- [ ] PR 미리보기에서 토글 hover 시 "P3-A에서 활성화" 류 tooltip 확인
- [ ] `?engine=barnes-hut` URL로 진입 시 newton로 폴백 + 토글에는 barnes-hut 활성 표시

Refs #126