### PR TITLE
[#124] WebGPU 감지 + 자동 폴백

### DIFF
--- a/apps/web/src/components/layout/hud-corners.tsx
+++ b/apps/web/src/components/layout/hud-corners.tsx
@@ -10,6 +10,8 @@ import { useSimStore } from '@/store/sim-store';
 export function HudCorners() {
   const renderer = useSimStore((s) => s.rendererKind);
   const engineError = useSimStore((s) => s.engineError);
+  const engineNotice = useSimStore((s) => s.engineNotice);
+  const setEngineNotice = useSimStore((s) => s.setEngineNotice);
   const julianDate = useSimStore((s) => s.julianDate);
   const selected = useSimStore((s) => s.selectedBodyId);
 
@@ -40,6 +42,26 @@ export function HudCorners() {
               : 'initializing…'}
         </div>
       </div>
+
+      {/* 상단 중앙 — 비-fatal 알림 (P3-0 #124, dismissible) */}
+      {engineNotice && (
+        <div
+          data-testid="engine-notice"
+          role="status"
+          className="absolute top-14 left-1/2 -translate-x-1/2 max-w-md text-caption num text-fg-primary bg-bg-surface/90 backdrop-blur px-3 py-1.5 rounded-sm border border-border-subtle flex items-center gap-2"
+        >
+          <span>{engineNotice}</span>
+          <button
+            type="button"
+            data-testid="engine-notice-dismiss"
+            aria-label="알림 닫기"
+            onClick={() => setEngineNotice(null)}
+            className="text-fg-tertiary hover:text-fg-primary px-1"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {/* 좌하 — 선택 천체 */}
       {selected && (

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SimulationCore, scene as sceneApi } from '@astro-simulator/core';
+import { SimulationCore, scene as sceneApi, gpu as gpuApi } from '@astro-simulator/core';
 import { attachCoreToStore } from '@/core/core-adapter';
 import { SimCommandProvider } from '@/core/sim-context';
 import { useSimStore } from '@/store/sim-store';
@@ -19,6 +19,26 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
     const canvas = canvasRef.current;
     if (!canvas) return;
     if (coreRef.current && !coreRef.current.disposed) return;
+
+    // P3-0 #124 — WebGPU capability 감지 (마운트 시 1회). 사용자가 webgpu/auto
+    // 엔진을 요청했는데 미지원이면 콘솔 경고 + HUD notice + newton 폴백 안내.
+    gpuApi.detectGpuCapability().then((cap) => {
+      const requested = useSimStore.getState().physicsEngine;
+      const wantsGpu = requested === 'webgpu' || requested === 'auto';
+      if (!cap.webgpu) {
+        // 항상 경고: 향후 P3-A/B 활성화 시 진단에 도움.
+        // eslint-disable-next-line no-console
+        console.warn('[gpu] WebGPU 미지원:', cap.reason);
+        if (wantsGpu) {
+          useSimStore
+            .getState()
+            .setEngineNotice(`WebGPU 미지원 — ${cap.reason ?? 'unknown'} · Newton로 폴백.`);
+        }
+      } else if (cap.adapterInfo) {
+        // eslint-disable-next-line no-console
+        console.info('[gpu] adapter:', cap.adapterInfo);
+      }
+    });
 
     const instance = new SimulationCore(canvas);
     // Babylon이 기본 tabindex=1을 설정 — a11y(WCAG 2.4.3) 권고상 양수 금지.

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -25,6 +25,8 @@ export interface SimStoreState {
   // 엔진 상태
   rendererKind: 'webgpu' | 'webgl2' | null;
   engineError: string | null;
+  /** 비-fatal 알림 (예: WebGPU 미지원 폴백). dismiss 가능. */
+  engineNotice: string | null;
 
   // 시뮬레이션 상태
   mode: SimMode;
@@ -44,6 +46,7 @@ export interface SimStoreState {
   // actions (Core → store)
   setRenderer: (kind: 'webgpu' | 'webgl2' | null) => void;
   setEngineError: (message: string | null) => void;
+  setEngineNotice: (message: string | null) => void;
   setMode: (mode: SimMode) => void;
   setTime: (julianDate: number) => void;
   setSelectedBody: (id: string | null) => void;
@@ -59,6 +62,7 @@ export interface SimStoreState {
 export const useSimStore = create<SimStoreState>((set) => ({
   rendererKind: null,
   engineError: null,
+  engineNotice: null,
   mode: 'observe',
   julianDate: null,
   selectedBodyId: null,
@@ -72,6 +76,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
 
   setRenderer: (kind) => set({ rendererKind: kind }),
   setEngineError: (message) => set({ engineError: message }),
+  setEngineNotice: (message) => set({ engineNotice: message }),
   setMode: (mode) => set({ mode }),
   setTime: (julianDate) => set({ julianDate }),
   setSelectedBody: (id) => set({ selectedBodyId: id }),

--- a/packages/core/src/gpu/capability.test.ts
+++ b/packages/core/src/gpu/capability.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { detectGpuCapability } from './capability';
+
+const setNavigator = (value: unknown) => {
+  Object.defineProperty(globalThis, 'navigator', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+};
+
+afterEach(() => {
+  setNavigator(undefined);
+});
+
+describe('detectGpuCapability', () => {
+  it('navigator 미존재 환경에서 webgpu:false 반환', async () => {
+    setNavigator(undefined);
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(false);
+    expect(cap.reason).toContain('지원하지');
+  });
+
+  it('navigator.gpu 미노출 시 false', async () => {
+    setNavigator({});
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(false);
+  });
+
+  it('requestAdapter null 반환 시 false', async () => {
+    setNavigator({ gpu: { requestAdapter: vi.fn().mockResolvedValue(null) } });
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(false);
+    expect(cap.reason).toContain('어댑터');
+  });
+
+  it('어댑터 획득 시 true + adapterInfo', async () => {
+    setNavigator({
+      gpu: {
+        requestAdapter: vi.fn().mockResolvedValue({
+          requestAdapterInfo: vi.fn().mockResolvedValue({
+            vendor: 'apple',
+            architecture: 'metal',
+            description: 'Apple M1',
+          }),
+        }),
+      },
+    });
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(true);
+    expect(cap.adapterInfo?.vendor).toBe('apple');
+  });
+
+  it('requestAdapterInfo 실패해도 webgpu:true 유지', async () => {
+    setNavigator({
+      gpu: {
+        requestAdapter: vi.fn().mockResolvedValue({
+          requestAdapterInfo: vi.fn().mockRejectedValue(new Error('not supported')),
+        }),
+      },
+    });
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(true);
+    expect(cap.adapterInfo).toBeUndefined();
+  });
+
+  it('requestAdapter throw 시 false + reason', async () => {
+    setNavigator({
+      gpu: { requestAdapter: vi.fn().mockRejectedValue(new Error('boom')) },
+    });
+    const cap = await detectGpuCapability();
+    expect(cap.webgpu).toBe(false);
+    expect(cap.reason).toBe('boom');
+  });
+});

--- a/packages/core/src/gpu/capability.ts
+++ b/packages/core/src/gpu/capability.ts
@@ -1,0 +1,61 @@
+/**
+ * GPU capability 감지 (P3-0 #124).
+ *
+ * 브라우저별 WebGPU 지원 여부를 단일 진입점에서 판정한다. P3-A의 `auto` 엔진과
+ * P3-B의 WebGPU compute가 이 함수로 분기한다.
+ *
+ * 결과는 캐시되지 않는다 — 호출자가 마운트 시 1회 호출 후 자체 보관.
+ */
+
+export interface GpuCapability {
+  /** `navigator.gpu`가 존재하고 어댑터 요청까지 성공했는가. */
+  webgpu: boolean;
+  /** 어댑터 정보 (vendor/architecture). 일부 브라우저는 빈 문자열 반환. */
+  adapterInfo?: { vendor: string; architecture: string; description: string };
+  /** 감지 실패 사유 (사용자에게 노출 가능한 한 줄). */
+  reason?: string;
+}
+
+/**
+ * navigator.gpu 감지 + adapter 요청.
+ * SSR/비-브라우저 환경에서 호출되면 `webgpu: false`로 안전하게 반환.
+ */
+export async function detectGpuCapability(): Promise<GpuCapability> {
+  if (typeof navigator === 'undefined' || !('gpu' in navigator)) {
+    return { webgpu: false, reason: '브라우저가 WebGPU를 지원하지 않습니다.' };
+  }
+  try {
+    // 환경별 GPU/GPUAdapter 타입 충돌을 피하기 위해 unknown 캐스팅으로 좁게 사용.
+    const gpu = (navigator as { gpu?: { requestAdapter: () => Promise<unknown> } }).gpu;
+    if (!gpu) return { webgpu: false, reason: 'navigator.gpu 미노출.' };
+    const adapter = (await gpu.requestAdapter()) as {
+      requestAdapterInfo?: () => Promise<{
+        vendor?: string;
+        architecture?: string;
+        description?: string;
+      }>;
+    } | null;
+    if (!adapter) {
+      return { webgpu: false, reason: 'GPU 어댑터를 가져오지 못했습니다.' };
+    }
+    let adapterInfo: NonNullable<GpuCapability['adapterInfo']> | undefined;
+    if (typeof adapter.requestAdapterInfo === 'function') {
+      try {
+        const info = await adapter.requestAdapterInfo();
+        adapterInfo = {
+          vendor: info.vendor ?? '',
+          architecture: info.architecture ?? '',
+          description: info.description ?? '',
+        };
+      } catch {
+        // info 실패해도 webgpu 자체는 사용 가능
+      }
+    }
+    return adapterInfo ? { webgpu: true, adapterInfo } : { webgpu: true };
+  } catch (err) {
+    return {
+      webgpu: false,
+      reason: err instanceof Error ? err.message : 'WebGPU 감지 중 알 수 없는 오류.',
+    };
+  }
+}

--- a/packages/core/src/gpu/index.ts
+++ b/packages/core/src/gpu/index.ts
@@ -7,4 +7,4 @@
  * P3 WebGPU N-body Compute에서 본격 활용.
  */
 
-export {};
+export { detectGpuCapability, type GpuCapability } from './capability';


### PR DESCRIPTION
## Summary
- `packages/core/src/gpu/capability.ts` — `detectGpuCapability()` async 유틸 + `GpuCapability` 타입
- 단위 테스트 6건 (navigator 부재 / gpu 미노출 / adapter null / adapter throw / info 폴백 / 정상 케이스)
- store: `engineNotice` 필드 + `setEngineNotice` 액션
- `sim-canvas`: 마운트 시 detect → console.warn + (webgpu/auto 요청 시) HUD notice
- `hud-corners`: 상단 중앙 dismissible notice (`role=status`, aria-label='알림 닫기')

## Why
P3-A(Barnes-Hut), P3-B(WebGPU compute) 도입 시 환경별 분기 단일 진입점 필요. 미지원 환경에서도 사용자에게 명확히 안내하면서 Newton로 폴백.

## 검증
- `pnpm --filter @astro-simulator/core test` 6/6
- `pnpm --filter @astro-simulator/web test` 56/56
- `pnpm --filter @astro-simulator/web typecheck` 통과
- `node scripts/browser-verify.mjs` 25/25 (Level 1)
- 수동: `/ko?engine=webgpu` 진입 시 헤드리스 Chromium에서 notice + 콘솔 경고 + Newton 폴백 확인

## Test plan
- [ ] CI 통과 (bench best-effort)
- [ ] 실 브라우저(Chrome desktop, WebGPU 지원)에서 `?engine=webgpu` 진입 시 notice 미표시 확인
- [ ] Safari/구형 Android에서 진입 시 notice 표시 + dismiss 동작 확인

## P3 후속
- #124 머지 후 P3-0 마일스톤 완료. 다음은 P3-A Barnes-Hut 마일스톤 첫 이슈 분해.

Refs #124