### PR TITLE
[#134] Barnes-Hut UI 활성화 + auto 모드 라우팅 (P3-A 마감)

### DIFF
--- a/apps/web/src/components/layout/physics-engine-toggle.test.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.test.tsx
@@ -40,20 +40,28 @@ describe('PhysicsEngineToggle', () => {
     expect(screen.getByTestId('engine-newton')).toHaveAttribute('title');
   });
 
-  // P3-0 #126
-  it('barnes-hut/webgpu/auto 버튼은 disabled (미구현)', () => {
+  // P3-A #134 — webgpu만 disabled, barnes-hut/auto는 활성화
+  it('webgpu 버튼만 disabled (P3-B 대기)', () => {
     render(<PhysicsEngineToggle />);
-    for (const id of ['barnes-hut', 'webgpu', 'auto']) {
+    for (const id of ['kepler', 'newton', 'barnes-hut', 'auto']) {
       const btn = screen.getByTestId(`engine-${id}`);
-      expect(btn).toBeDisabled();
-      expect(btn.dataset.runnable).toBe('false');
-      expect(btn).toHaveAttribute('title');
+      expect(btn).not.toBeDisabled();
+      expect(btn.dataset.runnable).toBe('true');
     }
+    const webgpu = screen.getByTestId('engine-webgpu');
+    expect(webgpu).toBeDisabled();
+    expect(webgpu.dataset.runnable).toBe('false');
   });
 
-  it('disabled 엔진 클릭은 store에 반영되지 않음', () => {
+  it('disabled 엔진(webgpu) 클릭은 store에 반영되지 않음', () => {
     render(<PhysicsEngineToggle />);
     fireEvent.click(screen.getByTestId('engine-webgpu'));
     expect(useSimStore.getState().physicsEngine).toBe('kepler');
+  });
+
+  it('barnes-hut 클릭 시 store 반영', () => {
+    render(<PhysicsEngineToggle />);
+    fireEvent.click(screen.getByTestId('engine-barnes-hut'));
+    expect(useSimStore.getState().physicsEngine).toBe('barnes-hut');
   });
 });

--- a/apps/web/src/components/layout/physics-engine-toggle.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.tsx
@@ -23,7 +23,7 @@ const ENGINES: EngineDef[] = [
   {
     id: 'barnes-hut',
     label: 'Barnes-Hut',
-    tooltip: 'O(N log N) octree — N=5000+ 가속 (P3-A에서 활성화).',
+    tooltip: 'O(N log N) octree — N=5000+ 가속. theta=0.5 정확도 ~1e-9.',
   },
   {
     id: 'webgpu',
@@ -33,7 +33,7 @@ const ENGINES: EngineDef[] = [
   {
     id: 'auto',
     label: 'Auto',
-    tooltip: '환경 감지 후 최적 엔진 자동 선택 (P3-A부터 활성화).',
+    tooltip: 'belt N≥1000이면 Barnes-Hut, 아니면 Newton. P3-B 후 WebGPU 우선.',
   },
 ];
 

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -59,10 +59,21 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         // 소행성대 N — URL ?belt=NNN 우선, 없으면 0 (생성 안 함).
         const beltParam = new URLSearchParams(window.location.search).get('belt');
         const beltN = beltParam ? Math.max(0, Math.min(10_000, Number(beltParam) || 0)) : 0;
-        // P3-0 #126 — barnes-hut/webgpu/auto는 아직 런타임 미구현. newton로 폴백.
+        // P3-A #134 — barnes-hut는 wasm 활성화. webgpu는 P3-B 대기. auto는 capability
+        // 기반: WebGPU 미지원 시 N≥1000(소행성대 포함)이면 barnes-hut, 아니면 newton.
+        // P3-B에서 webgpu 활성화 시 auto는 webgpu 우선이 된다.
         const resolveEngine = (
           k: ReturnType<typeof useSimStore.getState>['physicsEngine'],
-        ): 'kepler' | 'newton' => (k === 'kepler' ? 'kepler' : 'newton');
+        ): 'kepler' | 'newton' | 'barnes-hut' => {
+          if (k === 'kepler') return 'kepler';
+          if (k === 'barnes-hut') return 'barnes-hut';
+          if (k === 'auto') {
+            // belt N으로 자동 분기 (P3-B 후 webgpu가 추가됨)
+            return beltN >= 1000 ? 'barnes-hut' : 'newton';
+          }
+          // newton, webgpu, 그 외 → newton로 폴백
+          return 'newton';
+        };
         const solar = sceneApi.createSolarSystemScene(instance.scene, {
           physicsEngine: resolveEngine(useSimStore.getState().physicsEngine),
           asteroidBeltN: beltN,

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -12,8 +12,13 @@ export type UnitSystem = 'si' | 'astro' | 'natural';
  */
 export type PhysicsEngineKind = 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' | 'auto';
 
-/** 현재 런타임에서 실제 동작하는 엔진 (auto/미구현은 newton로 폴백). */
-export const RUNNABLE_ENGINES: ReadonlySet<PhysicsEngineKind> = new Set(['kepler', 'newton']);
+/** 현재 런타임에서 실제 동작하는 엔진. webgpu는 P3-B에서, auto는 capability 기반 자동선택. */
+export const RUNNABLE_ENGINES: ReadonlySet<PhysicsEngineKind> = new Set([
+  'kepler',
+  'newton',
+  'barnes-hut',
+  'auto',
+]);
 
 /**
  * 시뮬레이션 UI 상태 store.

--- a/packages/core/src/physics/barnes-hut-engine.ts
+++ b/packages/core/src/physics/barnes-hut-engine.ts
@@ -1,0 +1,56 @@
+/**
+ * Barnes-Hut N-body 엔진 — WASM `BarnesHutEngine`(#132)을 TS에서 사용하기 위한 얇은 래퍼.
+ *
+ * `NBodyEngine`(직접합)과 동일 인터페이스 — 호출자는 동일 코드로 두 엔진 교체 가능.
+ * P3-A #134에서 scene API가 이 어댑터를 통해 분기한다.
+ */
+import { BarnesHutEngine as WasmEngine } from '@astro-simulator/physics-wasm';
+import type { NBodyEngineOptions, NBodyState } from './nbody-engine.js';
+
+const DEFAULT_MAX_SUB_DT_SECONDS = 86_400; // 1 일
+
+export interface BarnesHutEngineOptions extends NBodyEngineOptions {
+  /** MAC 임계값 (0=직접합, 0.5 권장, 0.7 빠름). 기본 0.5. */
+  theta?: number;
+  /** close-encounter 발산 방지용 ε(미터). 기본 1e3 (1km, 행성 스케일 무시 가능). */
+  softening?: number;
+}
+
+export class BarnesHutNBodyEngine {
+  private wasm: WasmEngine;
+  private readonly maxSubDt: number;
+  readonly ids: readonly string[];
+
+  constructor(state: NBodyState, options: BarnesHutEngineOptions = {}) {
+    const theta = options.theta ?? 0.5;
+    const softening = options.softening ?? 1e3;
+    this.wasm = new WasmEngine(state.masses, state.positions, state.velocities, theta, softening);
+    this.maxSubDt = options.maxSubstepSeconds ?? DEFAULT_MAX_SUB_DT_SECONDS;
+    this.ids = state.ids;
+  }
+
+  advance(dtSeconds: number): void {
+    if (dtSeconds === 0) return;
+    this.wasm.step_chunked(dtSeconds, this.maxSubDt);
+  }
+
+  positions(): Float64Array {
+    return this.wasm.positions();
+  }
+
+  velocities(): Float64Array {
+    return this.wasm.velocities();
+  }
+
+  totalEnergy(): number {
+    return this.wasm.total_energy();
+  }
+
+  setTheta(theta: number): void {
+    this.wasm.set_theta(theta);
+  }
+
+  dispose(): void {
+    this.wasm.free();
+  }
+}

--- a/packages/core/src/physics/index.ts
+++ b/packages/core/src/physics/index.ts
@@ -21,3 +21,4 @@ export {
   type NBodyEngineOptions,
   type NBodyState,
 } from './nbody-engine.js';
+export { BarnesHutNBodyEngine, type BarnesHutEngineOptions } from './barnes-hut-engine.js';

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -14,6 +14,7 @@ import { getSolarSystem, type LoadedCelestialBody } from '../ephemeris/solar-sys
 import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
 import { NBodyEngine, buildInitialState } from '../physics/nbody-engine.js';
+import { BarnesHutNBodyEngine } from '../physics/barnes-hut-engine.js';
 import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js';
 import { computeVisualScale, maxScaleForKind } from './visual-scale.js';
 
@@ -47,7 +48,7 @@ export interface SolarSystemSceneHandles {
   dispose: () => void;
 }
 
-export type PhysicsEngineKind = 'kepler' | 'newton';
+export type PhysicsEngineKind = 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' | 'auto';
 
 export interface SolarSystemSceneOptions {
   /** 초기 시각 (Julian Date). 기본: J2000.0 */
@@ -132,23 +133,24 @@ export function createSolarSystemScene(
   }
   const resolved = new Set<string>();
 
-  // Newton 경로 — 호출 시 초기 상태 빌드 후 updateAt(jd)에서 Δt만큼 적분.
+  // Newton/Barnes-Hut 경로 — 두 엔진 모두 동일 advance/positions 인터페이스라 공용 변수로 관리.
   let activeEngine: PhysicsEngineKind = physicsEngine;
-  let newtonEngine: NBodyEngine | null = null;
+  let newtonEngine: NBodyEngine | BarnesHutNBodyEngine | null = null;
   let newtonLastJd = initialJulianDate;
   let currentJd = initialJulianDate;
   let newtonIdIndex: Map<string, number> | null = null;
 
   const massMultipliers = new Map<string, number>();
-  const buildNewton = (jd: number) => {
+  const buildNewton = (jd: number, kind: 'newton' | 'barnes-hut' = 'newton') => {
     newtonEngine?.dispose();
     const initial = buildInitialState(system, jd);
-    // 질량 배수 적용 (#107) — 초기 상태 생성 후 Newton 엔진에 주입.
+    // 질량 배수 적용 (#107) — 초기 상태 생성 후 엔진에 주입.
     for (const [id, mul] of massMultipliers) {
       const idx = initial.ids.indexOf(id);
       if (idx >= 0) initial.masses[idx] = (initial.masses[idx] ?? 0) * mul;
     }
-    newtonEngine = new NBodyEngine(initial);
+    newtonEngine =
+      kind === 'barnes-hut' ? new BarnesHutNBodyEngine(initial) : new NBodyEngine(initial);
     newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
     newtonLastJd = jd;
   };
@@ -157,14 +159,18 @@ export function createSolarSystemScene(
     newtonEngine = null;
     newtonIdIndex = null;
   };
-  if (physicsEngine === 'newton') {
-    buildNewton(initialJulianDate);
+  if (physicsEngine === 'newton' || physicsEngine === 'barnes-hut') {
+    buildNewton(initialJulianDate, physicsEngine);
   }
   disposables.push({ dispose: disposeNewton });
 
   const updateAt = (jd: number) => {
     currentJd = jd;
-    if (activeEngine === 'newton' && newtonEngine && newtonIdIndex) {
+    if (
+      (activeEngine === 'newton' || activeEngine === 'barnes-hut') &&
+      newtonEngine &&
+      newtonIdIndex
+    ) {
       const dtSec = (jd - newtonLastJd) * SECONDS_PER_DAY;
       if (dtSec !== 0) {
         newtonEngine.advance(dtSec);
@@ -290,11 +296,15 @@ export function createSolarSystemScene(
 
   const setPhysicsEngine = (kind: PhysicsEngineKind) => {
     if (kind === activeEngine) return;
-    // P3-A #132 — barnes-hut/webgpu/auto 모드 수신 시 wasm BarnesHutEngine로의
-    // 직접 라우팅은 #134(JS 어댑터 + UI 활성화)에서 합류한다. 그때까지는 newton로 폴백.
-    const effective: PhysicsEngineKind = kind === 'kepler' ? 'kepler' : 'newton';
-    if (effective === 'newton') buildNewton(currentJd);
-    else disposeNewton();
+    // P3-A #134 — barnes-hut 직접 활성화. webgpu/auto는 P3-B/UI 어댑터에서
+    // capability에 따라 newton 또는 barnes-hut로 매핑되어 들어온다.
+    const effective: PhysicsEngineKind =
+      kind === 'kepler' || kind === 'newton' || kind === 'barnes-hut' ? kind : 'newton';
+    if (effective === 'newton' || effective === 'barnes-hut') {
+      buildNewton(currentJd, effective);
+    } else {
+      disposeNewton();
+    }
     activeEngine = effective;
   };
   const getPhysicsEngine = () => activeEngine;
@@ -303,11 +313,13 @@ export function createSolarSystemScene(
     const clamped = Math.max(0.01, Math.min(1000, multiplier));
     if (clamped === 1) massMultipliers.delete(bodyId);
     else massMultipliers.set(bodyId, clamped);
-    if (activeEngine === 'newton') buildNewton(currentJd);
+    if (activeEngine === 'newton' || activeEngine === 'barnes-hut')
+      buildNewton(currentJd, activeEngine);
   };
   const resetMassMultipliers = () => {
     massMultipliers.clear();
-    if (activeEngine === 'newton') buildNewton(currentJd);
+    if (activeEngine === 'newton' || activeEngine === 'barnes-hut')
+      buildNewton(currentJd, activeEngine);
   };
 
   // 초기 시점 적용


### PR DESCRIPTION
## Summary
P3-A 마지막 — Barnes-Hut을 실제 사용자에게 노출.

- `packages/core/src/physics/barnes-hut-engine.ts` — JS 어댑터 (`NBodyEngine`과 동일 인터페이스)
- `solar-system-scene.ts` — `buildNewton(jd, kind)`, updateAt이 두 엔진 모두 처리
- `PhysicsEngineKind` 확장: `kepler|newton|barnes-hut|webgpu|auto`
- `RUNNABLE_ENGINES`에 `barnes-hut`, `auto` 추가 (toggle에서 활성화). webgpu만 disabled
- `auto` 모드 라우팅 (sim-canvas `resolveEngine`):
  - belt N≥1000이면 `barnes-hut`, 아니면 `newton`
  - P3-B에서 webgpu 활성화 시 webgpu 우선

## DoD 충족
- [x] PhysicsEngineToggle: barnes-hut RUNNABLE_ENGINES 추가, disabled 해제
- [x] auto 모드 활성화 — webgpu 미지원 시 barnes-hut(N≥1000) / newton(N<1000) 분기
- [x] core scene에서 barnes-hut 직접 라우팅 (#132 폴백 제거)
- [x] vitest 57/57, core typecheck/build 통과

## 브라우저 3단계 검증 (CRITICAL #3)
- L1 정적: 토글에서 barnes-hut/auto 활성, webgpu만 disabled 확인
- L2 인터랙션: barnes-hut 클릭 시 URL `?engine=barnes-hut`, active 전환 확인
- L3 흐름: `?engine=barnes-hut&belt=200`, `?engine=auto&belt=2000` 진입 시 런타임 에러 0건
- `scripts/browser-verify.mjs` 25/25 (회귀 없음)

## 스코프 외 (별도 단계)
- N=5000 실측 `docs/benchmarks/baseline.json` 갱신 (로컬 dev 서버 필요)
- `docs/benchmarks/p3a-perf.md` (성능 비교표) — N=5000 측정 후 작성

## P3-A 마감 인계
모든 P3-A 이슈(#130~#134) 완료 → P3-A 마일스톤 close 가능. 다음은 P3-B (WebGPU compute) 이슈 분해.

Closes #134