### PR TITLE
[#143] WebGPU compute 인프라 — context + buffer + WGSL helpers

### DIFF
--- a/packages/core/src/gpu/buffer.test.ts
+++ b/packages/core/src/gpu/buffer.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { GpuFloat32Buffer } from './buffer';
+
+describe('GpuFloat32Buffer', () => {
+  it('잘못된 length는 RangeError', () => {
+    // 실제 GPU 컨텍스트 없이 length 검증만 확인
+    const fakeCtx = { engine: {} } as never;
+    expect(() => new GpuFloat32Buffer(fakeCtx, 0)).toThrow(RangeError);
+    expect(() => new GpuFloat32Buffer(fakeCtx, -1)).toThrow(RangeError);
+    expect(() => new GpuFloat32Buffer(fakeCtx, 1.5)).toThrow(RangeError);
+  });
+});

--- a/packages/core/src/gpu/buffer.ts
+++ b/packages/core/src/gpu/buffer.ts
@@ -1,0 +1,55 @@
+/**
+ * GPU storage buffer 래퍼 (P3-B #143).
+ *
+ * Babylon `StorageBuffer`를 Float32Array I/O 중심으로 단순화. N-body 입자 상태(위치/속도/가속도)
+ * 는 모두 Float32Array AoS-flat (3N 길이)로 처리한다.
+ *
+ * 주의 — float64 미지원
+ * --------------------
+ * WebGPU/WGSL은 f64 미지원. CPU(`NBodySystem`/`BarnesHutSystem`)는 f64를 쓰지만 GPU 경로에서는
+ * **f32로 다운캐스트**된다. 행성 SI 좌표 (~1e11 m)에서 f32 정밀도 7 자리 → ~1e4m(10km) 단위 오차.
+ * 시각화/인터랙션 용도는 충분하지만 장기 적분 정확도는 CPU 경로 대비 ~1000× 떨어짐.
+ *
+ * P3-B #145에서 적분 스킴 결정 시 정밀도 보전 전략 확정 (예: relative origin shift).
+ */
+import { StorageBuffer } from '@babylonjs/core/Buffers/storageBuffer.js';
+import type { GpuComputeContext } from './compute-context.js';
+
+/** Float32 storage buffer. 길이는 element 수, 바이트 크기는 length×4. */
+export class GpuFloat32Buffer {
+  private readonly buffer: StorageBuffer;
+  readonly length: number;
+
+  constructor(ctx: GpuComputeContext, length: number, label?: string) {
+    if (length <= 0 || !Number.isInteger(length)) {
+      throw new RangeError(`length must be positive integer, got ${length}`);
+    }
+    this.length = length;
+    this.buffer = new StorageBuffer(ctx.engine, length * 4, undefined, label);
+  }
+
+  /** CPU → GPU 업로드. data 길이는 buffer length와 동일해야. */
+  write(data: Float32Array): void {
+    if (data.length !== this.length) {
+      throw new RangeError(
+        `write size mismatch: buffer length ${this.length}, data length ${data.length}`,
+      );
+    }
+    this.buffer.update(data);
+  }
+
+  /**
+   * GPU → CPU readback. 비동기.
+   * @param noDelay true면 flushFramebuffer 호출 (지연 ↓, 약간의 perf 비용)
+   */
+  async read(noDelay = true): Promise<Float32Array> {
+    const out = new Float32Array(this.length);
+    await this.buffer.read(0, this.length * 4, out, noDelay);
+    return out;
+  }
+
+  /** Babylon 원본. ComputeShader 바인딩에 사용. */
+  raw(): StorageBuffer {
+    return this.buffer;
+  }
+}

--- a/packages/core/src/gpu/compute-context.test.ts
+++ b/packages/core/src/gpu/compute-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { createGpuComputeContext, isWebGpuEngine, WebGpuUnavailableError } from './compute-context';
+
+describe('isWebGpuEngine', () => {
+  it('isWebGPU=true 엔진을 인식', () => {
+    const fake = { isWebGPU: true } as never;
+    expect(isWebGpuEngine(fake)).toBe(true);
+  });
+
+  it('isWebGPU 미설정/false는 거부', () => {
+    expect(isWebGpuEngine({} as never)).toBe(false);
+    expect(isWebGpuEngine({ isWebGPU: false } as never)).toBe(false);
+  });
+});
+
+describe('createGpuComputeContext', () => {
+  it('non-WebGPU 엔진은 WebGpuUnavailableError', () => {
+    expect(() => createGpuComputeContext({ isWebGPU: false } as never)).toThrow(
+      WebGpuUnavailableError,
+    );
+  });
+});

--- a/packages/core/src/gpu/compute-context.ts
+++ b/packages/core/src/gpu/compute-context.ts
@@ -1,0 +1,59 @@
+/**
+ * GPU compute 컨텍스트 (P3-B #143).
+ *
+ * Babylon의 `WebGPUEngine`에 ComputeShader API를 활용하기 위한 얇은 래퍼.
+ * #144(force shader), #145(적분기)가 이 위에 빌드된다.
+ *
+ * 비-WebGPU 환경(WebGL2 fallback)은 명시적으로 거부 — 호출자는 `detectGpuCapability()`로
+ * 사전 분기 후 진입해야 한다.
+ */
+import {
+  ComputeShader,
+  type IComputeShaderOptions,
+} from '@babylonjs/core/Compute/computeShader.js';
+import type { WebGPUEngine } from '@babylonjs/core/Engines/webgpuEngine.js';
+import type { AbstractEngine } from '@babylonjs/core/Engines/abstractEngine.js';
+
+/**
+ * GPU compute가 가능한 Babylon 엔진인지 좁힌다.
+ * Babylon의 `AbstractEngine`은 WebGL2/WebGPU 양쪽을 감싸므로 caller가 안전하게 분기 가능.
+ */
+export function isWebGpuEngine(engine: AbstractEngine): engine is WebGPUEngine {
+  // Babylon은 런타임에 isWebGPU 플래그를 노출. 런타임 체크가 가장 신뢰성 높음.
+  return (engine as { isWebGPU?: boolean }).isWebGPU === true;
+}
+
+/** GPU compute 기능이 없을 때 던지는 에러. 호출자가 폴백 분기에 사용. */
+export class WebGpuUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`WebGPU compute unavailable: ${reason}`);
+    this.name = 'WebGpuUnavailableError';
+  }
+}
+
+/**
+ * GPU compute 컨텍스트. WebGPUEngine + 헬퍼 묶음.
+ * 직접 생성하지 말고 `createGpuComputeContext(engine)`을 사용한다.
+ */
+export class GpuComputeContext {
+  constructor(public readonly engine: WebGPUEngine) {}
+
+  /**
+   * WGSL 소스에서 ComputeShader 빌드.
+   * `bindingsMapping`은 WGSL 변수명 ↔ (group, binding) 매핑. WGSL reflection 미지원
+   * 환경 호환을 위해 명시적으로 전달해야 한다.
+   */
+  createShader(name: string, wgslSource: string, options: IComputeShaderOptions): ComputeShader {
+    return new ComputeShader(name, this.engine, { computeSource: wgslSource }, options);
+  }
+}
+
+/**
+ * 엔진에서 GPU compute 컨텍스트를 만든다. WebGPU가 아니면 `WebGpuUnavailableError`.
+ */
+export function createGpuComputeContext(engine: AbstractEngine): GpuComputeContext {
+  if (!isWebGpuEngine(engine)) {
+    throw new WebGpuUnavailableError('engine is not WebGPU (WebGL2 fallback in use)');
+  }
+  return new GpuComputeContext(engine);
+}

--- a/packages/core/src/gpu/index.ts
+++ b/packages/core/src/gpu/index.ts
@@ -8,3 +8,11 @@
  */
 
 export { detectGpuCapability, type GpuCapability } from './capability';
+export {
+  GpuComputeContext,
+  WebGpuUnavailableError,
+  createGpuComputeContext,
+  isWebGpuEngine,
+} from './compute-context.js';
+export { GpuFloat32Buffer } from './buffer.js';
+export { WGSL_GRAVITY_PAIR } from './wgsl-helpers.js';

--- a/packages/core/src/gpu/wgsl-helpers.ts
+++ b/packages/core/src/gpu/wgsl-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * 재사용 가능한 WGSL 헬퍼 코드 스니펫 (P3-B #143).
+ *
+ * 컴파일된 WGSL 소스를 그대로 prepend해서 사용. 헬퍼는 namespace 충돌을 피하기 위해
+ * `_bh_` 접두사 (Barnes-Hut/Babylon 약자) 사용.
+ */
+
+/** softening 적용 거리 제곱 + G/r³ 가중치 계산 헬퍼. */
+export const WGSL_GRAVITY_PAIR = /* wgsl */ `
+fn _bh_pair_acc(target_pos: vec3<f32>, src_pos: vec3<f32>, src_mass: f32, softening_sq: f32, g: f32) -> vec3<f32> {
+  let d = src_pos - target_pos;
+  let r2 = dot(d, d) + softening_sq;
+  // r2.powf(-1.5) — WGSL은 pow(f, f) 사용
+  let inv_r3 = pow(r2, -1.5);
+  return d * (g * src_mass * inv_r3);
+}
+`;


### PR DESCRIPTION
## Summary
P3-B 첫 단계 — Babylon ComputeShader API 활용 토대.

신규 모듈 (`packages/core/src/gpu/`):
- `compute-context.ts` — `isWebGpuEngine`, `GpuComputeContext`, `WebGpuUnavailableError`, `createGpuComputeContext`
- `buffer.ts` — `GpuFloat32Buffer` (StorageBuffer 래퍼, write/async read/raw)
- `wgsl-helpers.ts` — `WGSL_GRAVITY_PAIR` (#144 force shader 재사용)

## DoD 충족
- [x] `compute-context.ts` ComputeShader 빌더
- [x] `buffer.ts` StorageBuffer 래퍼 + Float32Array I/O
- [x] WGSL 헬퍼 모듈 (vec3 가속도)
- [x] WebGPU 미지원 환경 에러 (`WebGpuUnavailableError`)
- [x] 단위 테스트 4건 (138/138 통과)

## 설계 결정 (#145에서 ADR 확정 예정)
- WGSL **f32 한정** → 행성 SI 좌표(~1e11 m)에서 ~10km 단위 정밀도 손실
- 시각화 충분, 장기 적분은 CPU 경로(~1e-9 정밀도) 대비 ~1000× 차이
- relative origin shift 등 보전 전략은 #145 ADR에서 결정

## 한계
실제 GPU 동작은 node 환경에서 검증 불가 (mock 단위 테스트만). #144(force shader vs CPU 직접합)에서 GPU 경로 통합 검증.

Refs #143