### PR TITLE
[#144] N-body force WGSL compute shader (direct sum O(N²) tiled)

### DIFF
--- a/packages/core/src/gpu/index.ts
+++ b/packages/core/src/gpu/index.ts
@@ -16,3 +16,11 @@ export {
 } from './compute-context.js';
 export { GpuFloat32Buffer } from './buffer.js';
 export { WGSL_GRAVITY_PAIR } from './wgsl-helpers.js';
+export {
+  NBODY_FORCE_TILE,
+  NBODY_FORCE_WGSL,
+  createNbodyForceShader,
+  dispatchNbodyForce,
+  type NbodyForceDispatchOptions,
+} from './nbody-force-shader.js';
+export { computeForcesF32 } from './nbody-force-cpu.js';

--- a/packages/core/src/gpu/nbody-force-cpu.ts
+++ b/packages/core/src/gpu/nbody-force-cpu.ts
@@ -1,0 +1,46 @@
+/**
+ * GPU force shader의 CPU 참조 구현 (P3-B #144).
+ *
+ * GPU 결과 검증용 — 동일한 알고리즘(direct sum + softening)을 f32로 수행해 GPU와 비교.
+ * f32 정밀도가 동일하므로 GPU vs CPU 차이는 누적 순서 차이만 남는다.
+ *
+ * 시뮬레이션 본체에는 사용 금지 — `NBodySystem`(f64) 사용.
+ */
+
+/**
+ * positions(3N f32), masses(N f32) → accelerations(3N f32).
+ * GPU 셰이더와 동일 알고리즘: 모든 페어, self 제외, softening_sq 적용.
+ */
+export function computeForcesF32(
+  positions: Float32Array,
+  masses: Float32Array,
+  softeningSq: number,
+  gravitationalConstant: number,
+): Float32Array {
+  const n = masses.length;
+  const acc = new Float32Array(3 * n);
+  for (let i = 0; i < n; i++) {
+    const xi = positions[3 * i] ?? 0;
+    const yi = positions[3 * i + 1] ?? 0;
+    const zi = positions[3 * i + 2] ?? 0;
+    let ax = 0;
+    let ay = 0;
+    let az = 0;
+    for (let j = 0; j < n; j++) {
+      if (j === i) continue;
+      const dx = (positions[3 * j] ?? 0) - xi;
+      const dy = (positions[3 * j + 1] ?? 0) - yi;
+      const dz = (positions[3 * j + 2] ?? 0) - zi;
+      const r2 = dx * dx + dy * dy + dz * dz + softeningSq;
+      const invR3 = Math.pow(r2, -1.5);
+      const f = gravitationalConstant * (masses[j] ?? 0) * invR3;
+      ax += f * dx;
+      ay += f * dy;
+      az += f * dz;
+    }
+    acc[3 * i] = ax;
+    acc[3 * i + 1] = ay;
+    acc[3 * i + 2] = az;
+  }
+  return acc;
+}

--- a/packages/core/src/gpu/nbody-force-shader.test.ts
+++ b/packages/core/src/gpu/nbody-force-shader.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { NBODY_FORCE_TILE, NBODY_FORCE_WGSL } from './nbody-force-shader';
+import { computeForcesF32 } from './nbody-force-cpu';
+
+describe('NBODY_FORCE_WGSL', () => {
+  it('TILE 크기 64로 컴파일 시 workgroup_size 일치', () => {
+    expect(NBODY_FORCE_TILE).toBe(64);
+    expect(NBODY_FORCE_WGSL).toContain('@workgroup_size(64)');
+  });
+
+  it('필수 binding 4개 모두 선언', () => {
+    expect(NBODY_FORCE_WGSL).toContain('@group(0) @binding(0) var<uniform> params');
+    expect(NBODY_FORCE_WGSL).toContain('@group(0) @binding(1) var<storage, read> positions');
+    expect(NBODY_FORCE_WGSL).toContain('@group(0) @binding(2) var<storage, read> masses');
+    expect(NBODY_FORCE_WGSL).toContain(
+      '@group(0) @binding(3) var<storage, read_write> accelerations',
+    );
+  });
+
+  it('헬퍼 함수 _bh_pair_acc 인라인 포함', () => {
+    expect(NBODY_FORCE_WGSL).toContain('fn _bh_pair_acc');
+  });
+});
+
+describe('computeForcesF32 (CPU 참조)', () => {
+  const G = 6.6743e-11;
+
+  it('단일 입자 → 가속도 0', () => {
+    const acc = computeForcesF32(new Float32Array([0, 0, 0]), new Float32Array([1e10]), 1e-6, G);
+    expect(acc[0]).toBe(0);
+    expect(acc[1]).toBe(0);
+    expect(acc[2]).toBe(0);
+  });
+
+  it('대칭 2-body — 동일 질량은 중심 향해 같은 크기/반대 방향', () => {
+    const positions = new Float32Array([-1, 0, 0, 1, 0, 0]);
+    const masses = new Float32Array([1e10, 1e10]);
+    const acc = computeForcesF32(positions, masses, 0, G);
+    expect(acc[0]).toBeCloseTo(-acc[3], 5);
+    expect(Math.sign(acc[0])).toBe(1); // -1에 있는 입자는 +x 방향으로 끌림
+    expect(Math.sign(acc[3])).toBe(-1);
+  });
+
+  it('softening_sq가 close-encounter 발산 방지', () => {
+    const positions = new Float32Array([0, 0, 0, 0, 0, 0]); // 동일 위치
+    const masses = new Float32Array([1e10, 1e10]);
+    const acc = computeForcesF32(positions, masses, 1e10, G);
+    // softening 덕분에 NaN/Inf 없이 finite 값
+    for (const v of acc) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it('N=8 직접합 결과가 GPU 셰이더와 동일 알고리즘 (검증 #147에서 GPU 비교)', () => {
+    // 무작위 N=8 — 자체 정합성만 검증
+    const n = 8;
+    const pos = new Float32Array(3 * n);
+    const m = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      pos[3 * i] = i;
+      pos[3 * i + 1] = i * 2;
+      pos[3 * i + 2] = -i;
+      m[i] = 1e22;
+    }
+    const a = computeForcesF32(pos, m, 1, G);
+    expect(a.length).toBe(3 * n);
+    // 입자별 가속도 magnitude는 0 이상
+    for (let i = 0; i < n; i++) {
+      const mag = Math.hypot(a[3 * i] ?? 0, a[3 * i + 1] ?? 0, a[3 * i + 2] ?? 0);
+      expect(mag).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/core/src/gpu/nbody-force-shader.ts
+++ b/packages/core/src/gpu/nbody-force-shader.ts
@@ -1,0 +1,146 @@
+/**
+ * N-body 가속도 WGSL compute shader (P3-B #144).
+ *
+ * 알고리즘
+ * --------
+ * 1 thread = 1 target 입자. 64-입자 tile을 workgroup shared memory(`var<workgroup>`)에 로드한 뒤
+ * 모든 thread가 동기화 barrier 이후 tile 내 64 source와 페어 계산 → tile 단위로 누적.
+ * N/TILE 회 반복하면 각 thread가 모든 source에 대한 가속도를 얻는다.
+ *
+ * 자기 자신(self-force)은 거리 0에서 softening_sq로 안전하게 0에 가까운 값이 되지만,
+ * 정확한 0을 위해 인덱스 비교로 명시 제거.
+ *
+ * 정밀도 — f32 한정. 행성 SI 좌표(~1e11 m)에서 ~10km 단위 정밀도 손실. P3-B #145에서
+ * relative origin shift 등으로 보전 전략 결정.
+ */
+import type { ComputeShader } from '@babylonjs/core/Compute/computeShader.js';
+import type { GpuComputeContext } from './compute-context.js';
+import type { GpuFloat32Buffer } from './buffer.js';
+import { WGSL_GRAVITY_PAIR } from './wgsl-helpers.js';
+
+export const NBODY_FORCE_TILE = 64;
+
+export const NBODY_FORCE_WGSL = /* wgsl */ `
+${WGSL_GRAVITY_PAIR}
+
+struct Params {
+  n: u32,
+  softening_sq: f32,
+  g: f32,
+  _pad: f32,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> positions: array<f32>;   // 3N flat (xyz, xyz, ...)
+@group(0) @binding(2) var<storage, read> masses: array<f32>;      // N
+@group(0) @binding(3) var<storage, read_write> accelerations: array<f32>; // 3N flat
+
+const TILE: u32 = ${NBODY_FORCE_TILE}u;
+
+var<workgroup> tile_pos: array<vec3<f32>, TILE>;
+var<workgroup> tile_mass: array<f32, TILE>;
+
+@compute @workgroup_size(${NBODY_FORCE_TILE})
+fn main(
+  @builtin(global_invocation_id) gid: vec3<u32>,
+  @builtin(local_invocation_id) lid: vec3<u32>,
+) {
+  let i = gid.x;
+  let local_idx = lid.x;
+  let n = params.n;
+
+  // self position (out-of-range thread는 dummy 위치 사용 — 결과는 버려짐)
+  var self_pos: vec3<f32>;
+  if (i < n) {
+    self_pos = vec3<f32>(positions[3u * i], positions[3u * i + 1u], positions[3u * i + 2u]);
+  } else {
+    self_pos = vec3<f32>(0.0);
+  }
+
+  var acc = vec3<f32>(0.0);
+
+  let tile_count = (n + TILE - 1u) / TILE;
+  for (var t: u32 = 0u; t < tile_count; t = t + 1u) {
+    let src_idx = t * TILE + local_idx;
+    if (src_idx < n) {
+      tile_pos[local_idx] = vec3<f32>(
+        positions[3u * src_idx],
+        positions[3u * src_idx + 1u],
+        positions[3u * src_idx + 2u],
+      );
+      tile_mass[local_idx] = masses[src_idx];
+    } else {
+      tile_mass[local_idx] = 0.0; // 가중치 0 — pair 계산이 무시됨
+      tile_pos[local_idx] = vec3<f32>(0.0);
+    }
+    workgroupBarrier();
+
+    // 내 i가 유효할 때만 누적 (out-of-range thread는 작업 안 함)
+    if (i < n) {
+      for (var k: u32 = 0u; k < TILE; k = k + 1u) {
+        let src_global = t * TILE + k;
+        // self 제거 (질량이 0이거나 자기 자신)
+        if (src_global < n && src_global != i && tile_mass[k] > 0.0) {
+          acc = acc + _bh_pair_acc(self_pos, tile_pos[k], tile_mass[k], params.softening_sq, params.g);
+        }
+      }
+    }
+    workgroupBarrier();
+  }
+
+  if (i < n) {
+    accelerations[3u * i] = acc.x;
+    accelerations[3u * i + 1u] = acc.y;
+    accelerations[3u * i + 2u] = acc.z;
+  }
+}
+`;
+
+/** Compute shader 빌드. ctx는 #143 GpuComputeContext. */
+export function createNbodyForceShader(ctx: GpuComputeContext): ComputeShader {
+  return ctx.createShader('nbody-force', NBODY_FORCE_WGSL, {
+    bindingsMapping: {
+      params: { group: 0, binding: 0 },
+      positions: { group: 0, binding: 1 },
+      masses: { group: 0, binding: 2 },
+      accelerations: { group: 0, binding: 3 },
+    },
+  });
+}
+
+export interface NbodyForceDispatchOptions {
+  positions: GpuFloat32Buffer; // 3N
+  masses: GpuFloat32Buffer; // N
+  accelerations: GpuFloat32Buffer; // 3N (output)
+  paramsBuffer: { update(data: Float32Array): void; raw(): unknown };
+  n: number;
+  softening: number;
+  gravitationalConstant: number;
+}
+
+/**
+ * Force shader 디스패치 + readback. 호출자가 매 step마다 사용.
+ *
+ * `paramsBuffer`는 16-byte aligned uniform (n: u32, softening_sq: f32, g: f32, pad: f32).
+ * 호출자 측 UniformBuffer 또는 GpuFloat32Buffer로 관리.
+ */
+export function dispatchNbodyForce(shader: ComputeShader, opts: NbodyForceDispatchOptions): void {
+  // params 갱신 — n은 u32지만 Float32Array slot에 bit-cast로 박는 게 일반적.
+  // 안전을 위해 호출자는 별도 Uint32Array 헬퍼를 사용 권장. 여기서는 inline conversion.
+  const params = new Float32Array(4);
+  // n을 i32로 reinterpret (양의 정수 N≤2^31는 안전)
+  new Uint32Array(params.buffer)[0] = opts.n >>> 0;
+  params[1] = opts.softening * opts.softening;
+  params[2] = opts.gravitationalConstant;
+  params[3] = 0;
+  opts.paramsBuffer.update(params);
+
+  shader.setStorageBuffer('positions', opts.positions.raw());
+  shader.setStorageBuffer('masses', opts.masses.raw());
+  shader.setStorageBuffer('accelerations', opts.accelerations.raw());
+  // params는 storage buffer로도 가능 (호환성 ↑), uniform이면 setUniformBuffer 사용
+  // 호출자 셋팅 책임 — paramsBuffer는 호출자가 미리 shader에 바인딩.
+
+  const groups = Math.ceil(opts.n / NBODY_FORCE_TILE);
+  shader.dispatch(groups, 1, 1);
+}


### PR DESCRIPTION
## Summary
P3-B 두 번째 단계 — GPU 가속도 계산.

신규:
- `packages/core/src/gpu/nbody-force-shader.ts`:
  - `NBODY_FORCE_WGSL` — workgroup_size=64 tiled algorithm
  - `var<workgroup>` shared memory로 64-입자 tile 캐싱 + barrier 동기화
  - self-force 명시 제거, out-of-bound thread는 mass=0
  - `createNbodyForceShader(ctx)` + `dispatchNbodyForce(shader, opts)`
- `packages/core/src/gpu/nbody-force-cpu.ts`:
  - `computeForcesF32` — 동일 알고리즘 CPU 참조 (#147 비교용)

테스트: 145/145 (신규 7건)
- WGSL 소스 정합성 (workgroup, bindings, helper)
- CPU 참조: 단일 입자, 2-body 대칭, softening 발산 방지, N=8

## DoD 충족
- [x] WGSL workgroup_size=64 tile 알고리즘
- [x] softening uniform
- [x] 출력 가속도 storage buffer
- [x] CPU 참조 함수 제공 (#147 GPU 비교 토대)
- [ ] N=128/N=10000 GPU vs CPU 일치성 — **#147에서 통합 검증** (node 환경 WebGPU 부재)

## 정밀도
WGSL f32만 지원. 행성 SI 좌표(~1e11 m)에서 ~10km 단위 손실. #145 ADR에서 보전 전략 (relative origin shift 등) 결정.

Refs #144