### PR TITLE
[#146] WebGpuNBodyEngine + scene 라우팅 + UI 활성화

### DIFF
--- a/apps/web/src/components/layout/physics-engine-toggle.test.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.test.tsx
@@ -40,28 +40,25 @@ describe('PhysicsEngineToggle', () => {
     expect(screen.getByTestId('engine-newton')).toHaveAttribute('title');
   });
 
-  // P3-A #134 — webgpu만 disabled, barnes-hut/auto는 활성화
-  it('webgpu 버튼만 disabled (P3-B 대기)', () => {
+  // P3-B #146 — 모든 엔진 활성. webgpu는 capability 미지원 시 sim-canvas가 폴백.
+  it('5개 엔진 모두 활성', () => {
     render(<PhysicsEngineToggle />);
-    for (const id of ['kepler', 'newton', 'barnes-hut', 'auto']) {
+    for (const id of ['kepler', 'newton', 'barnes-hut', 'webgpu', 'auto']) {
       const btn = screen.getByTestId(`engine-${id}`);
       expect(btn).not.toBeDisabled();
       expect(btn.dataset.runnable).toBe('true');
     }
-    const webgpu = screen.getByTestId('engine-webgpu');
-    expect(webgpu).toBeDisabled();
-    expect(webgpu.dataset.runnable).toBe('false');
-  });
-
-  it('disabled 엔진(webgpu) 클릭은 store에 반영되지 않음', () => {
-    render(<PhysicsEngineToggle />);
-    fireEvent.click(screen.getByTestId('engine-webgpu'));
-    expect(useSimStore.getState().physicsEngine).toBe('kepler');
   });
 
   it('barnes-hut 클릭 시 store 반영', () => {
     render(<PhysicsEngineToggle />);
     fireEvent.click(screen.getByTestId('engine-barnes-hut'));
     expect(useSimStore.getState().physicsEngine).toBe('barnes-hut');
+  });
+
+  it('webgpu 클릭 시 store 반영', () => {
+    render(<PhysicsEngineToggle />);
+    fireEvent.click(screen.getByTestId('engine-webgpu'));
+    expect(useSimStore.getState().physicsEngine).toBe('webgpu');
   });
 });

--- a/apps/web/src/components/layout/physics-engine-toggle.tsx
+++ b/apps/web/src/components/layout/physics-engine-toggle.tsx
@@ -28,12 +28,12 @@ const ENGINES: EngineDef[] = [
   {
     id: 'webgpu',
     label: 'WebGPU',
-    tooltip: 'GPU compute shader — N=10000+ 최대 성능 (P3-B에서 활성화).',
+    tooltip: 'GPU compute — N=10000+ 최대 성능. 미지원 시 Barnes-Hut 폴백.',
   },
   {
     id: 'auto',
     label: 'Auto',
-    tooltip: 'belt N≥1000이면 Barnes-Hut, 아니면 Newton. P3-B 후 WebGPU 우선.',
+    tooltip: 'WebGPU+N≥1000 → WebGPU / 미지원이면 Barnes-Hut / N<1000 → Newton.',
   },
 ];
 

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -59,19 +59,26 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         // 소행성대 N — URL ?belt=NNN 우선, 없으면 0 (생성 안 함).
         const beltParam = new URLSearchParams(window.location.search).get('belt');
         const beltN = beltParam ? Math.max(0, Math.min(10_000, Number(beltParam) || 0)) : 0;
-        // P3-A #134 — barnes-hut는 wasm 활성화. webgpu는 P3-B 대기. auto는 capability
-        // 기반: WebGPU 미지원 시 N≥1000(소행성대 포함)이면 barnes-hut, 아니면 newton.
-        // P3-B에서 webgpu 활성화 시 auto는 webgpu 우선이 된다.
+        // P3-B #146 — webgpu 활성화. 미지원 환경이면 webgpu 요청도 barnes-hut로 폴백.
+        // auto: WebGPU 가능 + N≥1000이면 webgpu, 가능하지만 N<1000이면 newton(오버헤드 회피),
+        //       WebGPU 미지원이면 N≥1000이면 barnes-hut, 아니면 newton.
+        const isWebGpu = (instance.scene?.getEngine() as { isWebGPU?: boolean })?.isWebGPU === true;
         const resolveEngine = (
           k: ReturnType<typeof useSimStore.getState>['physicsEngine'],
-        ): 'kepler' | 'newton' | 'barnes-hut' => {
+        ): 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' => {
           if (k === 'kepler') return 'kepler';
+          if (k === 'newton') return 'newton';
           if (k === 'barnes-hut') return 'barnes-hut';
-          if (k === 'auto') {
-            // belt N으로 자동 분기 (P3-B 후 webgpu가 추가됨)
-            return beltN >= 1000 ? 'barnes-hut' : 'newton';
+          if (k === 'webgpu') {
+            if (!isWebGpu) {
+              useSimStore.getState().setEngineNotice('WebGPU 미지원 — Barnes-Hut로 폴백.');
+              return 'barnes-hut';
+            }
+            return 'webgpu';
           }
-          // newton, webgpu, 그 외 → newton로 폴백
+          // auto
+          if (isWebGpu && beltN >= 1000) return 'webgpu';
+          if (beltN >= 1000) return 'barnes-hut';
           return 'newton';
         };
         const solar = sceneApi.createSolarSystemScene(instance.scene, {

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -12,11 +12,12 @@ export type UnitSystem = 'si' | 'astro' | 'natural';
  */
 export type PhysicsEngineKind = 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' | 'auto';
 
-/** 현재 런타임에서 실제 동작하는 엔진. webgpu는 P3-B에서, auto는 capability 기반 자동선택. */
+/** 현재 런타임에서 실제 동작하는 엔진. webgpu는 capability 보유 환경에서만 가능 (sim-canvas가 폴백 처리). */
 export const RUNNABLE_ENGINES: ReadonlySet<PhysicsEngineKind> = new Set([
   'kepler',
   'newton',
   'barnes-hut',
+  'webgpu',
   'auto',
 ]);
 

--- a/packages/core/src/physics/index.ts
+++ b/packages/core/src/physics/index.ts
@@ -22,3 +22,4 @@ export {
   type NBodyState,
 } from './nbody-engine.js';
 export { BarnesHutNBodyEngine, type BarnesHutEngineOptions } from './barnes-hut-engine.js';
+export { WebGpuNBodyEngine, type WebGpuEngineOptions } from './webgpu-nbody-engine.js';

--- a/packages/core/src/physics/webgpu-nbody-engine.ts
+++ b/packages/core/src/physics/webgpu-nbody-engine.ts
@@ -1,0 +1,203 @@
+/**
+ * WebGPU N-body 엔진 — GPU-resident V-V 적분기 (#146).
+ *
+ * ADR `docs/decisions/20260415-webgpu-integration-scheme.md`의 B 스킴 구현.
+ * `NBodyEngine`/`BarnesHutNBodyEngine`과 동일 시그니처 — caller 코드 동일.
+ *
+ * 한계
+ * ----
+ * - WGSL f32 정밀도. 행성 SI 좌표(~1e11 m)에서 ~10km 단위 손실. 시각화 충분.
+ * - `positions()`는 **마지막 readback 캐시**를 반환 (1-frame 지연 가능).
+ *   GPU readback이 비동기라 sync API와 호환을 위함. 호출자가 frame 경계에서
+ *   `await flushPositions()`로 강제 동기화 가능.
+ *
+ * 의존
+ * ----
+ * - #143 GpuComputeContext, GpuFloat32Buffer
+ * - #144 createNbodyForceShader, NBODY_FORCE_TILE
+ * - #145 createNbodyVvShader, NBODY_VV_PHASE_PRE/POST, NBODY_VV_TILE
+ */
+import type { ComputeShader } from '@babylonjs/core/Compute/computeShader.js';
+import type { AbstractEngine } from '@babylonjs/core/Engines/abstractEngine.js';
+import { UniformBuffer } from '@babylonjs/core/Materials/uniformBuffer.js';
+import { GpuFloat32Buffer, createGpuComputeContext, type GpuComputeContext } from '../gpu/index.js';
+import { createNbodyForceShader, NBODY_FORCE_TILE } from '../gpu/nbody-force-shader.js';
+import {
+  createNbodyVvShader,
+  NBODY_VV_PHASE_POST,
+  NBODY_VV_PHASE_PRE,
+  NBODY_VV_TILE,
+} from '../gpu/nbody-vv-shader.js';
+import { GRAVITATIONAL_CONSTANT } from '@astro-simulator/shared';
+import type { NBodyEngineOptions, NBodyState } from './nbody-engine.js';
+
+const DEFAULT_MAX_SUB_DT_SECONDS = 86_400; // 1일
+
+export interface WebGpuEngineOptions extends NBodyEngineOptions {
+  /** softening (m). 기본 1km. */
+  softening?: number;
+}
+
+export class WebGpuNBodyEngine {
+  private readonly ctx: GpuComputeContext;
+  private readonly n: number;
+  private readonly maxSubDt: number;
+  private readonly softening: number;
+
+  private readonly positionsBuf: GpuFloat32Buffer;
+  private readonly velocitiesBuf: GpuFloat32Buffer;
+  private readonly accelerationsBuf: GpuFloat32Buffer;
+  private readonly massesBuf: GpuFloat32Buffer;
+  private readonly forceParams: UniformBuffer;
+  private readonly vvParams: UniformBuffer;
+  private readonly forceShader: ComputeShader;
+  private readonly vvShader: ComputeShader;
+
+  private cachedPositions: Float32Array;
+  private pendingRead: Promise<void> | null = null;
+
+  readonly ids: readonly string[];
+
+  constructor(state: NBodyState, engine: AbstractEngine, options: WebGpuEngineOptions = {}) {
+    this.ctx = createGpuComputeContext(engine);
+    this.n = state.ids.length;
+    this.maxSubDt = options.maxSubstepSeconds ?? DEFAULT_MAX_SUB_DT_SECONDS;
+    this.softening = options.softening ?? 1e3;
+    this.ids = state.ids;
+
+    // f32 다운캐스트 (입력은 f64 Float64Array일 수 있음)
+    const pos32 = toFloat32(state.positions);
+    const vel32 = toFloat32(state.velocities);
+    const mass32 = toFloat32(state.masses);
+
+    this.positionsBuf = new GpuFloat32Buffer(this.ctx, 3 * this.n, 'nbody-positions');
+    this.velocitiesBuf = new GpuFloat32Buffer(this.ctx, 3 * this.n, 'nbody-velocities');
+    this.accelerationsBuf = new GpuFloat32Buffer(this.ctx, 3 * this.n, 'nbody-accelerations');
+    this.massesBuf = new GpuFloat32Buffer(this.ctx, this.n, 'nbody-masses');
+    this.positionsBuf.write(pos32);
+    this.velocitiesBuf.write(vel32);
+    this.massesBuf.write(mass32);
+
+    // Uniform buffers (4 floats each)
+    this.forceParams = new UniformBuffer(this.ctx.engine, undefined, true, 'nbody-force-params');
+    this.forceParams.addUniform('n', 1);
+    this.forceParams.addUniform('softening_sq', 1);
+    this.forceParams.addUniform('g', 1);
+    this.forceParams.addUniform('_pad', 1);
+    this.forceParams.create();
+
+    this.vvParams = new UniformBuffer(this.ctx.engine, undefined, true, 'nbody-vv-params');
+    this.vvParams.addUniform('n', 1);
+    this.vvParams.addUniform('phase', 1);
+    this.vvParams.addUniform('dt', 1);
+    this.vvParams.addUniform('_pad', 1);
+    this.vvParams.create();
+
+    this.forceShader = createNbodyForceShader(this.ctx);
+    this.vvShader = createNbodyVvShader(this.ctx);
+
+    // 셰이더 binding — 호출 1회 (storage buffer는 fixed)
+    this.forceShader.setUniformBuffer('params', this.forceParams);
+    this.forceShader.setStorageBuffer('positions', this.positionsBuf.raw());
+    this.forceShader.setStorageBuffer('masses', this.massesBuf.raw());
+    this.forceShader.setStorageBuffer('accelerations', this.accelerationsBuf.raw());
+
+    this.vvShader.setUniformBuffer('params', this.vvParams);
+    this.vvShader.setStorageBuffer('positions', this.positionsBuf.raw());
+    this.vvShader.setStorageBuffer('velocities', this.velocitiesBuf.raw());
+    this.vvShader.setStorageBuffer('accelerations', this.accelerationsBuf.raw());
+
+    // 초기 가속도 계산
+    this.dispatchForce();
+
+    this.cachedPositions = pos32.slice();
+    void this.scheduleReadback();
+  }
+
+  /**
+   * dtSeconds 만큼 적분. maxSubstep으로 sub-step 분할.
+   * 음수 dt는 V-V 대칭성으로 역행 가능.
+   */
+  advance(dtSeconds: number): void {
+    if (dtSeconds === 0) return;
+    const abs = Math.abs(dtSeconds);
+    const subCount = Math.max(1, Math.ceil(abs / this.maxSubDt));
+    const subDt = dtSeconds / subCount;
+    for (let s = 0; s < subCount; s++) {
+      this.dispatchVv(NBODY_VV_PHASE_PRE, subDt);
+      this.dispatchForce();
+      this.dispatchVv(NBODY_VV_PHASE_POST, subDt);
+    }
+    void this.scheduleReadback();
+  }
+
+  /** 마지막 readback 캐시. 비동기 readback 진행 중일 수 있음 (1-frame 지연 허용). */
+  positions(): Float32Array {
+    return this.cachedPositions;
+  }
+
+  /** 강제 동기 readback. 정확도가 중요할 때 호출 (주의: GPU stall). */
+  async flushPositions(): Promise<Float32Array> {
+    this.cachedPositions = await this.positionsBuf.read(true);
+    return this.cachedPositions;
+  }
+
+  /** 속도 readback 필요 시. 사용 빈도 낮아 동기 캐시 미보유. */
+  async velocities(): Promise<Float32Array> {
+    return this.velocitiesBuf.read(true);
+  }
+
+  totalEnergy(): number {
+    // GPU 측 reduce가 필요 — #147 정확도 검증 시점에 추가. 현재는 미지원.
+    return Number.NaN;
+  }
+
+  dispose(): void {
+    // Babylon ComputeShader는 GC 대상. UniformBuffer만 명시적 해제.
+    this.forceParams.dispose();
+    this.vvParams.dispose();
+  }
+
+  private dispatchForce(): void {
+    this.forceParams.updateUInt('n', this.n);
+    this.forceParams.updateFloat('softening_sq', this.softening * this.softening);
+    this.forceParams.updateFloat('g', GRAVITATIONAL_CONSTANT);
+    this.forceParams.updateFloat('_pad', 0);
+    this.forceParams.update();
+    const groups = Math.ceil(this.n / NBODY_FORCE_TILE);
+    this.forceShader.dispatch(groups, 1, 1);
+  }
+
+  private dispatchVv(phase: number, dt: number): void {
+    this.vvParams.updateUInt('n', this.n);
+    this.vvParams.updateUInt('phase', phase);
+    this.vvParams.updateFloat('dt', dt);
+    this.vvParams.updateFloat('_pad', 0);
+    this.vvParams.update();
+    const groups = Math.ceil(this.n / NBODY_VV_TILE);
+    this.vvShader.dispatch(groups, 1, 1);
+  }
+
+  /** 비동기 readback — 결과를 cachedPositions에 반영. 동시 1개만. */
+  private async scheduleReadback(): Promise<void> {
+    if (this.pendingRead) return; // skip — 이전 read 완료 대기
+    this.pendingRead = (async () => {
+      try {
+        this.cachedPositions = await this.positionsBuf.read(false);
+      } finally {
+        this.pendingRead = null;
+      }
+    })();
+  }
+}
+
+function toFloat32(arr: Float64Array | Float32Array): Float32Array {
+  if (arr instanceof Float32Array) return arr;
+  const out = new Float32Array(arr.length);
+  for (let i = 0; i < arr.length; i++) out[i] = arr[i] ?? 0;
+  return out;
+}
+
+/** ADR 조건상 NBODY_VV_PHASE_PRE === 0이지만, 명확성을 위해 재 export 안 함 */
+void NBODY_VV_PHASE_PRE;
+void NBODY_VV_PHASE_POST;

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -15,6 +15,8 @@ import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
 import { NBodyEngine, buildInitialState } from '../physics/nbody-engine.js';
 import { BarnesHutNBodyEngine } from '../physics/barnes-hut-engine.js';
+import { WebGpuNBodyEngine } from '../physics/webgpu-nbody-engine.js';
+import { isWebGpuEngine, WebGpuUnavailableError } from '../gpu/index.js';
 import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js';
 import { computeVisualScale, maxScaleForKind } from './visual-scale.js';
 
@@ -133,15 +135,16 @@ export function createSolarSystemScene(
   }
   const resolved = new Set<string>();
 
-  // Newton/Barnes-Hut 경로 — 두 엔진 모두 동일 advance/positions 인터페이스라 공용 변수로 관리.
+  // Newton / Barnes-Hut / WebGPU 경로 — 세 엔진 모두 동일 advance/positions 인터페이스 (positions는
+  // WebGPU의 경우 마지막 readback 캐시 — 1-frame 지연 허용).
   let activeEngine: PhysicsEngineKind = physicsEngine;
-  let newtonEngine: NBodyEngine | BarnesHutNBodyEngine | null = null;
+  let newtonEngine: NBodyEngine | BarnesHutNBodyEngine | WebGpuNBodyEngine | null = null;
   let newtonLastJd = initialJulianDate;
   let currentJd = initialJulianDate;
   let newtonIdIndex: Map<string, number> | null = null;
 
   const massMultipliers = new Map<string, number>();
-  const buildNewton = (jd: number, kind: 'newton' | 'barnes-hut' = 'newton') => {
+  const buildNewton = (jd: number, kind: 'newton' | 'barnes-hut' | 'webgpu' = 'newton') => {
     newtonEngine?.dispose();
     const initial = buildInitialState(system, jd);
     // 질량 배수 적용 (#107) — 초기 상태 생성 후 엔진에 주입.
@@ -149,8 +152,19 @@ export function createSolarSystemScene(
       const idx = initial.ids.indexOf(id);
       if (idx >= 0) initial.masses[idx] = (initial.masses[idx] ?? 0) * mul;
     }
-    newtonEngine =
-      kind === 'barnes-hut' ? new BarnesHutNBodyEngine(initial) : new NBodyEngine(initial);
+    if (kind === 'webgpu') {
+      const engine = scene.getEngine();
+      if (!isWebGpuEngine(engine)) {
+        throw new WebGpuUnavailableError(
+          'scene engine is not WebGPU — auto fallback에서 처리 필요',
+        );
+      }
+      newtonEngine = new WebGpuNBodyEngine(initial, engine);
+    } else if (kind === 'barnes-hut') {
+      newtonEngine = new BarnesHutNBodyEngine(initial);
+    } else {
+      newtonEngine = new NBodyEngine(initial);
+    }
     newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
     newtonLastJd = jd;
   };
@@ -159,7 +173,7 @@ export function createSolarSystemScene(
     newtonEngine = null;
     newtonIdIndex = null;
   };
-  if (physicsEngine === 'newton' || physicsEngine === 'barnes-hut') {
+  if (physicsEngine === 'newton' || physicsEngine === 'barnes-hut' || physicsEngine === 'webgpu') {
     buildNewton(initialJulianDate, physicsEngine);
   }
   disposables.push({ dispose: disposeNewton });
@@ -167,7 +181,7 @@ export function createSolarSystemScene(
   const updateAt = (jd: number) => {
     currentJd = jd;
     if (
-      (activeEngine === 'newton' || activeEngine === 'barnes-hut') &&
+      (activeEngine === 'newton' || activeEngine === 'barnes-hut' || activeEngine === 'webgpu') &&
       newtonEngine &&
       newtonIdIndex
     ) {
@@ -296,11 +310,13 @@ export function createSolarSystemScene(
 
   const setPhysicsEngine = (kind: PhysicsEngineKind) => {
     if (kind === activeEngine) return;
-    // P3-A #134 — barnes-hut 직접 활성화. webgpu/auto는 P3-B/UI 어댑터에서
-    // capability에 따라 newton 또는 barnes-hut로 매핑되어 들어온다.
+    // P3-B #146 — webgpu 직접 활성화. UI 어댑터(sim-canvas resolveEngine)가
+    // capability/auto 분기를 처리한 후 진입한다. 미지원 환경 진입 시 throw.
     const effective: PhysicsEngineKind =
-      kind === 'kepler' || kind === 'newton' || kind === 'barnes-hut' ? kind : 'newton';
-    if (effective === 'newton' || effective === 'barnes-hut') {
+      kind === 'kepler' || kind === 'newton' || kind === 'barnes-hut' || kind === 'webgpu'
+        ? kind
+        : 'newton';
+    if (effective === 'newton' || effective === 'barnes-hut' || effective === 'webgpu') {
       buildNewton(currentJd, effective);
     } else {
       disposeNewton();


### PR DESCRIPTION
## Summary
- `packages/core/src/physics/webgpu-nbody-engine.ts` — GPU buffers + force/vv shaders + cached readback
- `solar-system-scene.ts` — buildNewton에 webgpu 분기 (WebGpuUnavailableError 명시)
- `sim-canvas.tsx` resolveEngine — webgpu 미지원 시 barnes-hut 폴백 + engineNotice
- PhysicsEngineToggle: 5개 엔진 모두 활성, RUNNABLE_ENGINES에 webgpu 추가

## auto 모드 정책
| 환경 | belt N | 선택 |
|---|---|---|
| WebGPU 가능 | ≥1000 | webgpu |
| WebGPU 가능 | <1000 | newton (오버헤드 회피) |
| WebGPU 미지원 | ≥1000 | barnes-hut |
| WebGPU 미지원 | <1000 | newton |

## DoD 충족
- [x] WebGpuNBodyEngine 노출
- [x] scene 라우팅 + auto 정책
- [x] PhysicsEngineToggle webgpu 활성화 + 폴백 안내
- [x] vitest 57/57, core typecheck/build 통과
- [x] **브라우저 3단계 검증**: 토글 활성, webgpu 클릭 시 폴백 notice, ?engine=webgpu URL 진입 에러 0건

## 한계
- positions()는 비동기 readback 캐시 — 1-frame 지연 (시각화 충분)
- f32 정밀도 (~10km 행성 좌표 손실), 정밀 시뮬은 CPU 경로(NBodySystem) 사용
- totalEnergy()는 GPU reduce 미구현 → NaN. #147에서 추가

## 다음 (#147)
- N=10000 GPU vs CPU 정확도 (RMS<1e-4)
- 실 GPU 환경 성능 측정 (CPU ≥2× 가속 확인)
- bench 확장 + p3b-perf.md + baseline.json P3-B 갱신

Refs #146