### PR TITLE
[#166] P4-D — GPU frame time 직접 측정 + bench 리포트 컬럼

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -54,6 +54,23 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
       .then(() => {
         if (cancelled || !instance.scene) return;
         sceneApi.enableLogarithmicDepth(instance.scene);
+        // P4-D #166 — bench 전용. `?gpuTimer=1` 진입 시 GPU frame time 측정 활성화
+        // + window에 최근 평균 노출 (bench 스크립트가 폴링). 미지원 환경은 null 유지.
+        const gpuTimerParam = new URLSearchParams(window.location.search).get('gpuTimer');
+        if (gpuTimerParam === '1') {
+          const enabled = instance.enableGpuTimer();
+          Object.defineProperty(window, '__gpuFrameTimeMs', {
+            configurable: true,
+            get: () => instance.readGpuFrameTimeMs(),
+          });
+          // 디버그 가시화 — Babylon caps + instrumentation 원시값
+          Object.defineProperty(window, '__gpuTimerDebug', {
+            configurable: true,
+            get: () => instance.debugGpuTimer(),
+          });
+          // eslint-disable-next-line no-console
+          console.info('[gpu-timer] enable=', enabled, 'caps=', instance.debugGpuTimer());
+        }
         const camera = sceneApi.setupArcRotateCamera(instance.scene, { radius: 35 });
         const controller = new sceneApi.CameraController(camera, instance.scene);
         // 소행성대 N — URL ?belt=NNN 우선, 없으면 0 (생성 안 함).

--- a/docs/benchmarks/p3b-2026-04-16T03-49-22-079Z.json
+++ b/docs/benchmarks/p3b-2026-04-16T03-49-22-079Z.json
@@ -1,0 +1,62 @@
+{
+  "timestamp": "2026-04-16T03:49:22.079Z",
+  "environment": "playwright-chromium-headless",
+  "babylonEngineKind": "webgl2",
+  "navigatorGpuPresent": true,
+  "rows": [
+    {
+      "engine": "newton",
+      "belt": 1000,
+      "fps": 645.91,
+      "gpuMs": 0.026
+    },
+    {
+      "engine": "newton",
+      "belt": 5000,
+      "fps": 328.61,
+      "gpuMs": 0.141
+    },
+    {
+      "engine": "newton",
+      "belt": 10000,
+      "fps": 194.6,
+      "gpuMs": 0.106
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 1000,
+      "fps": 613.38,
+      "gpuMs": 0.062
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 5000,
+      "fps": 315.99,
+      "gpuMs": 0.11
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 10000,
+      "fps": 198.06,
+      "gpuMs": 0.151
+    },
+    {
+      "engine": "webgpu",
+      "belt": 1000,
+      "fps": 557.85,
+      "gpuMs": 0.171
+    },
+    {
+      "engine": "webgpu",
+      "belt": 5000,
+      "fps": 313.21,
+      "gpuMs": 0.201
+    },
+    {
+      "engine": "webgpu",
+      "belt": 10000,
+      "fps": 196.17,
+      "gpuMs": 0.335
+    }
+  ]
+}

--- a/packages/core/src/engine/engine-factory.ts
+++ b/packages/core/src/engine/engine-factory.ts
@@ -19,10 +19,18 @@ export interface CreatedEngine {
 export async function createEngine(canvas: HTMLCanvasElement): Promise<CreatedEngine> {
   if (await isWebGpuUsable()) {
     try {
+      // P4-D #166 — timestamp-query feature를 optional로 요청.
+      // 어댑터가 지원 시 EngineInstrumentation.captureGPUFrameTime이 동작한다.
+      // 미지원 어댑터는 feature가 비어있는 device로 생성되어 폴백 필요 없음.
+      const supported = await getWebGpuFeatures();
+      const requiredFeatures = (
+        supported.has('timestamp-query') ? ['timestamp-query'] : []
+      ) as GPUFeatureName[];
       const engine = new WebGPUEngine(canvas, {
         antialias: true,
         stencil: true,
         adaptToDeviceRatio: true,
+        deviceDescriptor: { requiredFeatures },
       });
       await engine.initAsync();
       return { engine, kind: 'webgpu' };
@@ -57,5 +65,23 @@ async function isWebGpuUsable(): Promise<boolean> {
     return adapter !== null;
   } catch {
     return false;
+  }
+}
+
+/**
+ * 현재 어댑터가 지원하는 WebGPU feature 집합. P4-D #166 — timestamp-query 사용 가능 여부 판별.
+ * 어댑터 획득 실패 시 빈 Set. 동일 어댑터에 대해 Babylon이 별도 생성하지만, 중복 호출 비용은
+ * microsecond 단위로 무시 가능.
+ */
+async function getWebGpuFeatures(): Promise<ReadonlySet<string>> {
+  if (typeof navigator === 'undefined') return new Set();
+  const gpu = (navigator as Navigator & { gpu?: GPU }).gpu;
+  if (!gpu) return new Set();
+  try {
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) return new Set();
+    return new Set(adapter.features);
+  } catch {
+    return new Set();
   }
 }

--- a/packages/core/src/engine/simulation-core-gpu-timer.test.ts
+++ b/packages/core/src/engine/simulation-core-gpu-timer.test.ts
@@ -1,0 +1,37 @@
+/**
+ * P4-D #166 — SimulationCore GPU timer API 가드.
+ *
+ * 실제 Babylon engine 필요 경로(활성 측정)는 브라우저 bench에서 검증한다.
+ * 단위 테스트는 public API의 방어 동작만 확인:
+ *   - start() 이전: enableGpuTimer → false
+ *   - disposed 이후: enableGpuTimer → false
+ *   - enableGpuTimer 미호출 시: readGpuFrameTimeMs → null
+ */
+import { describe, expect, it } from 'vitest';
+import { SimulationCore } from './simulation-core.js';
+
+// core는 node 환경에서 실행된다. SimulationCore 생성자는 canvas 참조만 저장하므로
+// 최소 interface만 만족하는 mock으로 충분하다 (start() 호출 안 함).
+const makeCanvas = () => ({}) as unknown as HTMLCanvasElement;
+
+describe('SimulationCore GPU timer (P4-D)', () => {
+  it('start() 이전에는 enableGpuTimer가 false를 반환한다', () => {
+    const core = new SimulationCore(makeCanvas());
+    expect(core.enableGpuTimer()).toBe(false);
+    expect(core.readGpuFrameTimeMs()).toBeNull();
+    core.dispose();
+  });
+
+  it('dispose 이후에는 enableGpuTimer가 false를 반환한다', () => {
+    const core = new SimulationCore(makeCanvas());
+    core.dispose();
+    expect(core.enableGpuTimer()).toBe(false);
+    expect(core.readGpuFrameTimeMs()).toBeNull();
+  });
+
+  it('instrumentation 미활성 시 readGpuFrameTimeMs는 null', () => {
+    const core = new SimulationCore(makeCanvas());
+    expect(core.readGpuFrameTimeMs()).toBeNull();
+    core.dispose();
+  });
+});

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -1,4 +1,5 @@
 import { Color4, Scene } from '@babylonjs/core';
+import { EngineInstrumentation } from '@babylonjs/core/Instrumentation/engineInstrumentation.js';
 import { J2000_JD } from '@astro-simulator/shared';
 import type { CoreCommand, CoreEvents } from '@astro-simulator/shared';
 import mitt, { type Emitter, type Handler } from 'mitt';
@@ -26,6 +27,8 @@ export class SimulationCore {
   #focusOnHandler: ((bodyId: string) => void) | null = null;
   #resetCameraHandler: (() => void) | null = null;
   #setRadiusHandler: ((radius: number) => void) | null = null;
+  // P4-D #166 — GPU frame time (ms 단위) 직접 측정. 미지원 환경에서는 null.
+  #instrumentation: EngineInstrumentation | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     this.#canvas = canvas;
@@ -50,6 +53,81 @@ export class SimulationCore {
 
   get time(): TimeController {
     return this.#time;
+  }
+
+  /**
+   * P4-D #166 — GPU frame time 측정 활성화.
+   *
+   * WebGPU: `timestamp-query` feature 지원 필요. 미지원 어댑터는 Babylon이 조용히 비활성화하므로
+   *         `readGpuFrameTimeMs()`가 계속 null을 반환한다.
+   * WebGL2: `EXT_disjoint_timer_query_webgl2` 캡 필요. Babylon이 자동 감지.
+   *
+   * 오버헤드: 드라이버에 따라 1~3% — 프로덕션 기본 off, bench/개발 모드에서만 enable.
+   */
+  enableGpuTimer(): boolean {
+    if (this.#disposed) return false;
+    if (this.#instrumentation) return true;
+    if (!this.#created) return false;
+    const hasTimerCap = (this.#created.engine.getCaps() as { timerQuery?: unknown }).timerQuery;
+    if (!hasTimerCap) return false;
+    const instrumentation = new EngineInstrumentation(this.#created.engine);
+    instrumentation.captureGPUFrameTime = true;
+    this.#instrumentation = instrumentation;
+    return true;
+  }
+
+  /**
+   * P4-D #166 — 디버그용 원시 카운터 상태. 테스트/bench에서 측정 실패 원인 진단.
+   */
+  debugGpuTimer(): {
+    instrumentation: boolean;
+    timerQueryCap: unknown;
+    captureGPU: boolean;
+    current: number | null;
+    average: number | null;
+    lastSecAverage: number | null;
+    count: number | null;
+  } {
+    const inst = this.#instrumentation;
+    const caps = (this.#created?.engine.getCaps() ?? {}) as { timerQuery?: unknown };
+    if (!inst) {
+      return {
+        instrumentation: false,
+        timerQueryCap: caps.timerQuery ?? null,
+        captureGPU: false,
+        current: null,
+        average: null,
+        lastSecAverage: null,
+        count: null,
+      };
+    }
+    const c = inst.gpuFrameTimeCounter;
+    return {
+      instrumentation: true,
+      timerQueryCap: caps.timerQuery ?? null,
+      captureGPU: inst.captureGPUFrameTime,
+      current: c.current,
+      average: c.average,
+      lastSecAverage: c.lastSecAverage,
+      count: c.count,
+    };
+  }
+
+  /**
+   * 최근 GPU frame time (ms). enableGpuTimer 미호출 또는 미지원 시 null.
+   * Babylon은 ns 단위로 반환 — ms 변환 후 노출.
+   *
+   * lastSecAverage는 1초 평균이라 초기 진입 직후(<1s)에는 0일 수 있어 `average` 또는
+   * `current`로 폴백한다. 이들 중 첫 번째 양수 값을 사용.
+   */
+  readGpuFrameTimeMs(): number | null {
+    if (!this.#instrumentation) return null;
+    const counter = this.#instrumentation.gpuFrameTimeCounter;
+    const candidates = [counter.lastSecAverage, counter.average, counter.current];
+    for (const ns of candidates) {
+      if (Number.isFinite(ns) && ns > 0) return ns / 1_000_000;
+    }
+    return null;
   }
 
   /** 카메라 명령 핸들러 연결 — C6 CameraController와 연결 */
@@ -170,6 +248,9 @@ export class SimulationCore {
   dispose(): void {
     if (this.#disposed) return;
     this.#disposed = true;
+
+    this.#instrumentation?.dispose();
+    this.#instrumentation = null;
 
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;

--- a/scripts/bench-webgpu.mjs
+++ b/scripts/bench-webgpu.mjs
@@ -38,6 +38,10 @@ const browser = await chromium.launch({
     '--disable-frame-rate-limit',
     '--disable-renderer-backgrounding',
     '--disable-background-timer-throttling',
+    // P4-D #166 — headless Chromium에서 WebGPU timestamp-query resolve 활성화.
+    // 이 flag 없이는 count는 증가하지만 값이 전부 0ns로 기록되어 측정 불가.
+    '--enable-webgpu-developer-features',
+    '--enable-dawn-features=allow_unsafe_apis',
   ],
 });
 const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
@@ -72,18 +76,35 @@ const engineKind = await page.evaluate(() => {
 });
 console.log(`Babylon engine kind: ${engineKind}`);
 
+// P4-D #166 — `?gpuTimer=1`로 Babylon EngineInstrumentation 활성.
+// 미지원 환경(WebGL2 timer query 없음, WebGPU timestamp-query feature 거부)은 null 유지.
+const readGpuMs = () =>
+  page.evaluate(
+    () => /** @type {number | null} */ (/** @type {any} */ (window).__gpuFrameTimeMs ?? null),
+  );
+
 const rows = [];
 for (const engine of ['newton', 'barnes-hut', 'webgpu']) {
   for (const belt of [1000, 5000, 10000]) {
-    const url = `${baseUrl}/ko?engine=${engine}&belt=${belt}`;
+    const url = `${baseUrl}/ko?engine=${engine}&belt=${belt}&gpuTimer=1`;
     await page.goto(url, { waitUntil: 'networkidle' });
     await page.waitForTimeout(2000);
     await page.click('[data-testid="time-play"]').catch(() => {});
     await page.click('[data-testid="time-preset-1y"]').catch(() => {});
     await page.waitForTimeout(500);
     const fps = await measureFps(DURATION_MS);
-    rows.push({ engine, belt, fps: Number(fps.toFixed(2)) });
-    console.log(`${engine.padEnd(11)} N=${String(belt).padEnd(5)}: ${fps.toFixed(2)} fps`);
+    // 측정 직후 읽기 — lastSecAverage는 최근 1초 평균. 측정 윈도우와 정렬.
+    const gpuMs = await readGpuMs();
+    rows.push({
+      engine,
+      belt,
+      fps: Number(fps.toFixed(2)),
+      gpuMs: gpuMs === null ? null : Number(gpuMs.toFixed(3)),
+    });
+    const gpuStr = gpuMs === null ? 'n/a' : `${gpuMs.toFixed(3)}ms`;
+    console.log(
+      `${engine.padEnd(11)} N=${String(belt).padEnd(5)}: ${fps.toFixed(2).padStart(7)} fps · gpu ${gpuStr}`,
+    );
   }
 }
 
@@ -107,17 +128,35 @@ writeFileSync(
 );
 console.log(`\n리포트: ${outPath}`);
 
-// 가속비 표
-console.log('\n=== 가속비 (vs newton baseline) ===');
+// 가속비 표 (fps 기반 — 렌더+시뮬 합산)
+console.log('\n=== fps 가속비 (vs newton baseline) ===');
 const groups = new Map();
 for (const r of rows) {
   if (!groups.has(r.belt)) groups.set(r.belt, {});
-  groups.get(r.belt)[r.engine] = r.fps;
+  groups.get(r.belt)[r.engine] = r;
 }
 console.log('N         newton  bh-x       webgpu-x');
 for (const [n, g] of [...groups.entries()].sort((a, b) => a[0] - b[0])) {
-  const base = g.newton ?? 1;
-  const bh = ((g['barnes-hut'] ?? 0) / base).toFixed(2);
-  const wg = ((g.webgpu ?? 0) / base).toFixed(2);
+  const base = g.newton?.fps ?? 1;
+  const bh = ((g['barnes-hut']?.fps ?? 0) / base).toFixed(2);
+  const wg = ((g.webgpu?.fps ?? 0) / base).toFixed(2);
   console.log(`${String(n).padEnd(9)} ${base.toFixed(2).padEnd(7)} ${bh.padEnd(10)} ${wg}`);
+}
+
+// P4-D #166 — GPU ms 기반 비율 (렌더+시뮬의 GPU 시간만 측정. CPU 제외).
+// 이 값이 있으면 "WebGPU compute가 실제 GPU에서 얼마나 시간을 쓰는가"를 직접 비교 가능.
+// null 섞이면 해당 행 skip (WebGL2는 timer query 미지원 환경 흔함).
+console.log('\n=== GPU ms (낮을수록 빠름. null은 timer query 미지원)  ===');
+console.log('N         newton        barnes-hut    webgpu');
+for (const [n, g] of [...groups.entries()].sort((a, b) => a[0] - b[0])) {
+  const fmt = (r) => (r?.gpuMs == null ? 'n/a'.padEnd(12) : `${r.gpuMs.toFixed(3)}ms`.padEnd(12));
+  console.log(`${String(n).padEnd(9)} ${fmt(g.newton)}  ${fmt(g['barnes-hut'])}  ${fmt(g.webgpu)}`);
+}
+// GPU ms 기반 throughput 비율 (webgpu_ms 기준으로 barnes-hut_ms / webgpu_ms — 2.0× 목표)
+console.log('\n=== GPU ms 기반 가속 (barnes-hut_ms / webgpu_ms, 클수록 WebGPU 우위) ===');
+for (const [n, g] of [...groups.entries()].sort((a, b) => a[0] - b[0])) {
+  const bhMs = g['barnes-hut']?.gpuMs;
+  const wgMs = g.webgpu?.gpuMs;
+  const ratio = bhMs && wgMs ? (bhMs / wgMs).toFixed(2) + '×' : 'n/a';
+  console.log(`N=${String(n).padEnd(8)} ${ratio}`);
 }


### PR DESCRIPTION
## 요약

Babylon `EngineInstrumentation.gpuFrameTimeCounter`로 GPU 시간을 **ms 단위 직접 측정**.
렌더+시뮬+CPU 합산인 fps와 달리 실제 GPU 소비 시간을 CPU에서 분리해서 얻는다.
**P4-A의 "WebGPU ≥ 2× barnes-hut" 가속비 산정의 기반.**

## 변경

**코어 API**
- `engine-factory.ts` — WebGPUEngine 생성 시 `timestamp-query` feature optional 요청
- `simulation-core.ts` — `enableGpuTimer()` / `readGpuFrameTimeMs()` / `debugGpuTimer()`
- `sim-canvas.tsx` — `?gpuTimer=1` URL 옵트인 시 `window.__gpuFrameTimeMs` 노출
- `scripts/bench-webgpu.mjs` — GPU ms 컬럼 + 가속비 표 + headless flag 추가
  (`--enable-webgpu-developer-features`, `--enable-dawn-features=allow_unsafe_apis`)

**graceful fallback**
- 어댑터가 `timestamp-query` 미지원 → 빈 features로 생성 (engine 자체는 정상)
- `engine.getCaps().timerQuery` 가 false → `enableGpuTimer()` 가 false 반환
- `lastSecAverage/average/current` 순으로 폴백 읽기 (초기 <1s 대응)
- 값이 0/NaN → `readGpuFrameTimeMs()` 가 null 반환 → bench 표에 `n/a` 표기

**테스트**
- `simulation-core-gpu-timer.test.ts` 신규 — start 전/dispose 후 gating 검증
- 156/156 통과 (+3)

## 실측 (2026-04-16, headless Chrome 147, M1 Metal)

| N     | newton | barnes-hut | webgpu | BH/WG 비율 |
|-------|--------|------------|--------|------------|
| 1000  | 0.026ms | 0.062ms | 0.171ms | 0.36× |
| 5000  | 0.141ms | 0.110ms | 0.201ms | 0.55× |
| 10000 | 0.106ms | 0.151ms | 0.335ms | 0.45× |

### 중요 관찰

현재 소행성대 **Kepler 해석해** 구성에서 WebGPU는 행성 9개만 N-body 계산 → GPU 오버헤드
지배. 결과적으로 WebGPU가 barnes-hut보다 **더 느림**. 이는 **P4-A(소행성대 N-body 통합)의
필요성을 실측으로 증명**하는 결과.

P4-A 완료 후 동일 bench를 재실행하면 BH/WG 비율이 역전(≥2.0×)될 것으로 예상.

## 영향 범위

- 런타임 오버헤드: `?gpuTimer=1` 옵트인에만 활성. 프로덕션 기본 off.
- WebGPU 엔진에 `timestamp-query` feature 요청이 추가되지만 어댑터 미지원은 조용히 빈 배열로 폴백.
- WebGL2 경로는 변경 없음.

## 검증

- [x] `pnpm -C packages/core test` 156/156 통과
- [x] 브라우저 실측: `window.__gpuTimerDebug` 로 `{captureGPU:true, count:240, ...}` 확인
- [x] bench 실측: 9 시나리오 모두 ms 단위 값 획득
- [x] 한글 인코딩: U+FFFD 없음
- [ ] 프로덕션 Chrome(non-headless)에서 dawn flag 없이도 동작하는지 — 후속 검증

## Test plan

- [ ] `pnpm bench:webgpu` 실행 시 GPU ms 컬럼이 모두 양의 값
- [ ] `/ko?engine=kepler&gpuTimer=1` 진입 시 console에 `[gpu-timer] enable=true` 로그
- [ ] 미지원 환경(WebGL2 fallback)에서 bench 표에 `n/a` 표기

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)