### PR TITLE
chore(harness): CLAUDE.md + knowledge-compilation divergent 수동 머지

### DIFF
--- a/.harness/manifest.json
+++ b/.harness/manifest.json
@@ -1,9 +1,9 @@
 {
   "harnessVersion": "2.6.0",
-  "installedAt": "2026-04-15T09:10:00Z",
+  "installedAt": "2026-04-16T05:40:46Z",
   "files": {
     "CLAUDE.md": {
-      "sha256": "008311bddc44b96557dad0603cae4c2cfb5dc7524135db3fc11eb14a49108539",
+      "sha256": "518208f7c0528d20aff9fe8fc67500ce731e87e6cc8f38a7119aafcbe0b9385c",
       "category": "managed-block"
     },
     ".claude/agents/architect.md": {
@@ -387,11 +387,11 @@
       "category": "atomic"
     },
     "docs/frozen-file-split.md": {
-      "sha256": "c4efa3324c0b1c83b051ec8fe38dcc2ee5d0b501aaa9323f896c63bcafb429ab",
+      "sha256": "ddfdce4b5bfd112c9e25a2c8e293cdf56926c4e4100bbd419247ea6551261fa6",
       "category": "atomic"
     },
     "docs/knowledge-compilation.md": {
-      "sha256": "7c516243210669b442d3f8618a6ef54eb99d1333c1c80bf91ad879f1b7074902",
+      "sha256": "9e8258b96cf43bb7eb7dcadbb4ee698c344442e2a7db482fe02bcd4b1280b375",
       "category": "atomic"
     },
     "docs/model-assumptions.md": {
@@ -490,6 +490,5 @@
       "sha256": "123d7d20e3d758ccc3aa4ff4a660214d7f777fa4a7b8a652cc8313ef114e0d63",
       "category": "atomic"
     }
-  },
-  "lastUpdatedAt": "2026-04-16T05:38:09Z"
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 
 ### 모노레포 가드
 
-- 신규 워크스페이스(apps/_, packages/_) 추가 시 **테스트 설정(vitest/jest config + scripts.test) 필수**
+- 신규 워크스페이스(`apps/*`, `packages/*`) 추가 시 **테스트 설정(vitest/jest config + scripts.test) 필수**
 - `pnpm -r test` / `npm -ws test` 는 scripts.test 누락 워크스페이스를 **조용히 스킵**한다 — 사고 방지를 위해 루트에 `verify:test-coverage` 스크립트(각 워크스페이스에 테스트 설정 존재 검사) 운용을 권장
 - 신규 패키지 스캐폴딩 시 테스트 베이스를 기본 포함시킨다
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,25 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 `rm -rf`로 재구축 시 사용자 터미널의 cwd가 삭제된 디렉토리를 가리킬 수 있다.
 반드시 사전 경고한다.
 
+### 인계 항목 실측 재검증 — NO-OP ADR 패턴
+
+이전 마일스톤 회고가 인계한 "수정 필요 항목"이 환경/코드 변화로 **착수 시점엔 이미 해소**되어 있는 경우가 있다. AI는 인계 항목을 "해야 할 일"로 과신하는 편향이 있으므로 구현 직전 실측으로 전제를 재검증한다.
+
+- 작업 착수 전 현재 동작을 실측 (브라우저/bench/테스트)
+- 이미 만족하면 구현 대신 **NO-OP ADR** 작성: `docs/decisions/<YYYYMMDD>-<topic>-no-op.md`
+- NO-OP 결정도 후보 비교 / 실측 결과 / 재검토 조건을 남긴다 — 다음에 재발굴 시 빠르게 기각 근거
+- 대신 **회귀 가드**를 박제: 현재 동작이 퇴행하지 않도록 verify 스크립트 또는 테스트 추가
+- 근거: volt [#14](https://github.com/coseo12/volt/issues/14) — CRITICAL #2 "모호한 지시 사전 확인"과 상호보완 (명확한 지시를 받았어도 실측으로 범위 축소)
+
+### 커밋 성공 ≠ 의도한 변경 커밋됨
+
+`git commit` 종료 코드 0과 "커밋 성공" 메시지만 믿지 말 것. 특히 lint-staged + tracked/ignored 혼재 상황에서 staged 변경 일부가 **조용히 유실**될 수 있다.
+
+- lint-staged 출력에서 `[FAILED]` 키워드를 발견하면 **커밋 후 필수 검증**
+- 커밋 직후 `git diff <base> HEAD -- <예상 파일 목록>` 또는 `git show --stat HEAD` 로 실제 반영된 파일 확인
+- `.gitignore` 규칙을 새로 추가할 때는 `git ls-files <path>` 로 이미 tracked된 파일이 있는지 확인 후 `git rm --cached` 로 정리
+- 근거: volt [#13](https://github.com/coseo12/volt/issues/13) — "빌드 성공 ≠ 동작", "HTTP 200 ≠ 올바른 리소스" 원칙의 연장선
+
 <!-- harness:managed:real-lessons:end -->
 
 ---

--- a/docs/knowledge-compilation.md
+++ b/docs/knowledge-compilation.md
@@ -88,6 +88,10 @@ CLAUDE.md/스킬의 규칙이 다음 중 하나면 **volt로만 보존하고 행
 - ❌ 1회 관찰을 즉시 CLAUDE.md 규칙으로 박제 — 사례 부족, 일반화 위험
 - ❌ "왜 이 규칙이 있는가"를 CLAUDE.md에 길게 씀 — Why는 volt 이슈 링크로
 
+## 실무 파생 패턴
+
+- **frozen 파일 분리** — frozen 카테고리 파일에 프로젝트 고유 로직을 얹어야 할 때 `ci-<slug>.yml` 형태로 분리하고 manifest에서 추적 제외. 상세: [docs/frozen-file-split.md](frozen-file-split.md)
+
 ## 참고
 
 - `/volt-review` 스킬: 승격 절차


### PR DESCRIPTION
## 요약

harness v2.6.0 업데이트에서 자동 적용 불가했던 **divergent 2건**을 수동 머지.
상위 변경을 diff로 읽고 내용적 변화만 선별 적용.

**Base**: [#174](https://github.com/coseo12/astro-simulator/pull/174) (harness safe 업데이트)

## CLAUDE.md 변경

### ✅ CRITICAL DIRECTIVES 블록 — **내용 변경 없음**

(서식 prettier 차이만 있었음 — 리스크 없음 확인 완료)

### ➕ "실전 교훈" managed-block에 2개 항목 추가

- **인계 항목 실측 재검증 — NO-OP ADR 패턴** (volt [#14](https://github.com/coseo12/volt/issues/14))
  - AI의 "인계 항목 = 해야 할 일" 과신 편향 방어
  - 실측 → NO-OP ADR 또는 회귀 가드 박제
- **커밋 성공 ≠ 의도한 변경 커밋됨** (volt [#13](https://github.com/coseo12/volt/issues/13))
  - lint-staged + .gitignore 혼재 상황에서 staged 일부 유실 방어
  - `git show --stat HEAD` 필수 검증

### 🔧 오타 수정
- 모노레포 가드 `apps/_, packages/_` → `` `apps/*, packages/*` `` (백틱 보호)
  - prettier markdown italic 파서가 `*...*`를 italic으로 오인, escape 해 `_`로 변환하는 문제를 백틱으로 회피

## docs/knowledge-compilation.md 변경

### ➕ "실무 파생 패턴" 섹션 신규

- **frozen 파일 분리** 링크 (harness v2.4.0 실무 교훈 연결)
- `docs/frozen-file-split.md`는 #174에서 추가됨

## 매니페스트

- `harness update --bootstrap`으로 v2.6.0 기준 재생성
- 이후 `harness update --check` 실행 시 divergent 0건

## Test plan

- [ ] CLAUDE.md real-lessons 블록의 2개 신규 항목 가독성 확인
- [ ] prettier 재실행 후 `apps/*`, `packages/*` 백틱 보호 유지 확인
- [ ] 다음 `/harness-update --check` 실행 시 divergent 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)