### PR TITLE
[#176] P5-E — bench baseline v0.4.0 스냅샷 + 비교 기능

### DIFF
--- a/docs/benchmarks/baseline-v0.4.0.json
+++ b/docs/benchmarks/baseline-v0.4.0.json
@@ -1,0 +1,64 @@
+{
+  "timestamp": "2026-04-16T04:19:41.743Z",
+  "environment": "playwright-chromium-headless",
+  "babylonEngineKind": "webgl2",
+  "navigatorGpuPresent": true,
+  "rows": [
+    {
+      "engine": "newton",
+      "belt": 1000,
+      "fps": 249.78,
+      "gpuMs": 0.048
+    },
+    {
+      "engine": "newton",
+      "belt": 5000,
+      "fps": null,
+      "gpuMs": null,
+      "skipped": true
+    },
+    {
+      "engine": "newton",
+      "belt": 10000,
+      "fps": null,
+      "gpuMs": null,
+      "skipped": true
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 1000,
+      "fps": 31.16,
+      "gpuMs": 0.053
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 5000,
+      "fps": 3.24,
+      "gpuMs": 0.072
+    },
+    {
+      "engine": "barnes-hut",
+      "belt": 10000,
+      "fps": 1.23,
+      "gpuMs": 0.151
+    },
+    {
+      "engine": "webgpu",
+      "belt": 1000,
+      "fps": 998,
+      "gpuMs": 0.26
+    },
+    {
+      "engine": "webgpu",
+      "belt": 5000,
+      "fps": 732.95,
+      "gpuMs": 0.943
+    },
+    {
+      "engine": "webgpu",
+      "belt": 10000,
+      "fps": 351.94,
+      "gpuMs": 2.178
+    }
+  ]
+}

--- a/scripts/bench-set-baseline.mjs
+++ b/scripts/bench-set-baseline.mjs
@@ -1,21 +1,94 @@
 #!/usr/bin/env node
 /**
- * 가장 최근 bench:scene 리포트를 baseline.json으로 복사.
- * 의미 있는 기준점(예: P1 종료, P2-0 완료) 갱신 시 호출.
+ * bench 리포트를 baseline으로 복사 + 릴리스 태그별 비교.
+ *
+ * 사용:
+ *   pnpm bench:scene:set-baseline           # 최신 bench:scene → baseline.json
+ *   pnpm bench:scene:set-baseline -- --tag v0.4.0  # 최신 bench:webgpu → baseline-v0.4.0.json
+ *   pnpm bench:scene:set-baseline -- --compare v0.4.0  # 현재 baseline vs v0.4.0 비교 출력
+ *
+ * P5-E #176 — 릴리스별 bench 스냅샷 관리.
  */
-import { copyFileSync, readdirSync } from 'node:fs';
+import { copyFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const dir = join('docs', 'benchmarks');
+const args = process.argv.slice(2);
+
+const tagIdx = args.indexOf('--tag');
+const tag = tagIdx >= 0 ? args[tagIdx + 1] : null;
+
+const compareIdx = args.indexOf('--compare');
+const compareTag = compareIdx >= 0 ? args[compareIdx + 1] : null;
+
+if (compareTag) {
+  const currentPath = join(dir, 'baseline.json');
+  const taggedPath = join(dir, `baseline-${compareTag}.json`);
+  if (!existsSync(currentPath)) {
+    console.error('baseline.json 없음. 먼저 `pnpm bench:scene:set-baseline`을 실행하세요.');
+    process.exit(1);
+  }
+  if (!existsSync(taggedPath)) {
+    console.error(`baseline-${compareTag}.json 없음.`);
+    process.exit(1);
+  }
+  const current = JSON.parse(readFileSync(currentPath, 'utf-8'));
+  const tagged = JSON.parse(readFileSync(taggedPath, 'utf-8'));
+
+  console.log(`\n=== baseline 비교: current vs ${compareTag} ===\n`);
+  console.log(`current: ${current.timestamp ?? 'unknown'}`);
+  console.log(`${compareTag}: ${tagged.timestamp ?? 'unknown'}\n`);
+
+  const currentRows = current.rows ?? [];
+  const taggedRows = tagged.rows ?? [];
+
+  if (currentRows.length && taggedRows.length) {
+    console.log('engine      belt   current_fps  tagged_fps   delta');
+    for (const cr of currentRows) {
+      const tr = taggedRows.find((r) => r.engine === cr.engine && r.belt === cr.belt);
+      if (!tr || cr.fps == null || tr.fps == null) continue;
+      const delta = (((cr.fps - tr.fps) / tr.fps) * 100).toFixed(1);
+      const sign = cr.fps >= tr.fps ? '+' : '';
+      console.log(
+        `${cr.engine.padEnd(11)} ${String(cr.belt).padEnd(6)} ${String(cr.fps).padEnd(12)} ${String(tr.fps).padEnd(12)} ${sign}${delta}%`,
+      );
+    }
+  } else {
+    console.log('rows 데이터 없음 — 수동 비교 필요.');
+  }
+  process.exit(0);
+}
+
+// baseline 저장
+const prefix = tag ? `p3b-` : '';
+const exclude = tag ? [] : ['baseline.json'];
 const files = readdirSync(dir)
-  .filter((f) => f.endsWith('.json') && f !== 'baseline.json')
+  .filter(
+    (f) =>
+      f.endsWith('.json') && !f.startsWith('baseline') && (!prefix || f.startsWith(prefix) || !tag),
+  )
   .sort();
 
-if (!files.length) {
-  console.error('리포트 없음. 먼저 `pnpm bench:scene`을 실행하세요.');
+const candidates = tag
+  ? readdirSync(dir)
+      .filter((f) => f.endsWith('.json') && f.startsWith('p3b-'))
+      .sort()
+  : readdirSync(dir)
+      .filter(
+        (f) =>
+          f.endsWith('.json') &&
+          !f.startsWith('baseline') &&
+          !f.startsWith('p3b-') &&
+          !f.startsWith('p2d'),
+      )
+      .sort();
+
+if (!candidates.length) {
+  console.error('리포트 없음. 먼저 bench를 실행하세요.');
   process.exit(1);
 }
 
-const latest = files.at(-1);
-copyFileSync(join(dir, latest), join(dir, 'baseline.json'));
-console.log(`baseline ← ${latest}`);
+const latest = candidates.at(-1);
+const dest = tag ? `baseline-${tag}.json` : 'baseline.json';
+copyFileSync(join(dir, latest), join(dir, dest));
+console.log(`${dest} ← ${latest}`);


### PR DESCRIPTION
## 요약

v0.4.0 릴리스 기준 bench 결과를 `baseline-v0.4.0.json`으로 스냅샷.
이후 릴리스에서 `--compare v0.4.0`으로 delta 비교 가능.

## 변경

- `docs/benchmarks/baseline-v0.4.0.json` — P4-A bench:webgpu 결과 (WebGPU 226×)
- `scripts/bench-set-baseline.mjs` 확장:
  - `--tag <version>`: 최신 bench:webgpu → `baseline-<version>.json`
  - `--compare <version>`: current vs tagged fps delta 출력

## Test plan

- [ ] `node scripts/bench-set-baseline.mjs --compare v0.4.0` 실행 시 비교 출력
- [ ] `baseline-v0.4.0.json` 내용이 P4-A 실측 결과와 동일 확인

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)