### PR TITLE
[#177] P5-B — 실기기 iPhone 12 mini 측정 + fps HUD 카운터

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -5,6 +5,7 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  allowedDevOrigins: ['192.168.0.12'],
   webpack: (config) => {
     config.experiments = {
       ...config.experiments,

--- a/apps/web/src/components/layout/hud-corners.tsx
+++ b/apps/web/src/components/layout/hud-corners.tsx
@@ -14,6 +14,10 @@ export function HudCorners() {
   const setEngineNotice = useSimStore((s) => s.setEngineNotice);
   const julianDate = useSimStore((s) => s.julianDate);
   const selected = useSimStore((s) => s.selectedBodyId);
+  const fps = useSimStore((s) => s.fps);
+  // P5-B #177 — ?fps=1 URL 옵트인 시 실시간 fps 카운터 표시 (실기기 측정용).
+  const showFps =
+    typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('fps') === '1';
 
   return (
     <>
@@ -41,6 +45,14 @@ export function HudCorners() {
               ? `renderer · ${renderer}`
               : 'initializing…'}
         </div>
+        {showFps && fps !== null && (
+          <div
+            data-testid="hud-fps"
+            className="bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle"
+          >
+            {Math.round(fps)} fps
+          </div>
+        )}
       </div>
 
       {/* 상단 중앙 — 비-fatal 알림 (P3-0 #124, dismissible) */}

--- a/docs/reports/p4c-mobile-실기기-20260417.md
+++ b/docs/reports/p4c-mobile-실기기-20260417.md
@@ -1,0 +1,51 @@
+# P5-B 실기기 iPhone Safari 측정 — 2026-04-17
+
+## 환경
+
+- **기종**: iPhone 12 mini (A14 Bionic)
+- **OS**: iOS 26.3.1(a)
+- **브라우저**: Safari (iOS 내장)
+- **네트워크**: 로컬 Wi-Fi → Next.js dev server (`192.168.0.12:3000`)
+- **측정 방법**: HUD fps 카운터 (`?fps=1` URL 옵트인)
+
+## 결과
+
+| 시나리오            | URL                             | 결과          | 측정값                      |
+| ------------------- | ------------------------------- | ------------- | --------------------------- |
+| N=200 60fps 유지    | `?belt=200&fps=1`               | ✅ **통과**   | **60 fps** 유지 (vsync cap) |
+| N=10000 크래시 없음 | `?belt=10000&fps=1`             | ✅ **통과**   | **40~50 fps** (best-effort) |
+| WebGPU 경로 확인    | `?engine=webgpu&belt=200&fps=1` | ⚠️ **미지원** | renderer = **webgl2**       |
+
+## 분석
+
+### N=200 @ 60fps ✅
+
+vsync cap(60fps)에 도달. A14 Bionic + Kepler 해석해 경로에서 소행성 200개는 충분히 가벼움. DoD 충족.
+
+### N=10000 크래시 없음 ✅
+
+40~50 fps로 부드러운 인터랙션 가능. 10000개 ThinInstance + Kepler 해석해가 iPhone 12 mini에서도 실용적 성능. DoD "크래시 없음" 충족 + best-effort fps도 우수.
+
+### WebGPU 미지원 ⚠️
+
+iPhone 12 mini(A14 Bionic)에서 iOS 26.3.1 Safari가 WebGPU를 노출하지 않음. `renderer · webgl2`로 정상 폴백. 가능한 원인:
+
+- **하드웨어 제약**: A14 Bionic은 Apple GPU 4세대. WebGPU는 A15(iPhone 13) 이상에서만 지원될 가능성
+- **Safari 설정**: Safari → 설정 → 고급 → Feature Flags에서 WebGPU를 수동 활성화해야 할 수 있음
+- **iOS 버전**: iOS 17.4+(2024-03)부터 WebGPU 기본 활성이라고 알려져 있으나 실제 A14 하드웨어에서의 지원 범위는 미확인
+
+**폴백 동작은 정상** — WebGPU 미지원 시 capability notice 표시 없이 WebGL2 Barnes-Hut 경로로 동작.
+
+## DoD 충족 여부
+
+| 기준                     | 충족                                           |
+| ------------------------ | ---------------------------------------------- |
+| N=200 @ 60fps (5초 평균) | ✅                                             |
+| N=10000 크래시 없음      | ✅                                             |
+| WebGPU 경로 활성         | ⚠️ 미지원 (A14 하드웨어 또는 Safari 설정 제약) |
+
+## 후속
+
+- iPhone 13+(A15)에서 재측정 → WebGPU 활성 여부 확인
+- Safari Feature Flags에서 WebGPU 수동 활성화 후 재시도
+- P5-A(일반상대론)는 CPU f64 경로이므로 WebGPU 유무와 무관하게 진행 가능

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -27,6 +27,8 @@ export class SimulationCore {
   #focusOnHandler: ((bodyId: string) => void) | null = null;
   #resetCameraHandler: (() => void) | null = null;
   #setRadiusHandler: ((radius: number) => void) | null = null;
+  // P5-B #177 — fps emit 주기 제어. 매 프레임 emit하면 store 갱신 과다 → 0.5초 간격.
+  #lastFpsEmitTime = 0;
   // P4-D #166 — GPU frame time (ms 단위) 직접 측정. 미지원 환경에서는 null.
   #instrumentation: EngineInstrumentation | null = null;
 
@@ -231,6 +233,12 @@ export class SimulationCore {
       }
 
       scene.render();
+
+      // P5-B #177 — 0.5초마다 fps emit (Babylon engine.getFps() 사용).
+      if (now - this.#lastFpsEmitTime > 500) {
+        this.#lastFpsEmitTime = now;
+        this.#emitter.emit('performance', { fps: engine.getFps() });
+      }
     });
 
     this.#resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## 요약

P4-C 인계. iPhone 12 mini(A14/iOS 26.3.1) 실기기에서 직접 측정.

## 실기기 결과

| 시나리오 | 결과 | 측정값 |
|---|---|---|
| N=200 60fps | ✅ | **60 fps** (vsync cap) |
| N=10000 크래시 없음 | ✅ | **40~50 fps** |
| WebGPU 경로 | ⚠️ 미지원 | renderer = webgl2 (A14 하드웨어 제약) |

## 변경

- `SimulationCore` — `engine.getFps()`를 0.5초마다 `performance` 이벤트 emit (기존 타입 정의만 있고 emit 미구현이었음)
- `hud-corners.tsx` — `?fps=1` URL 옵트인 시 fps 카운터 HUD 표시
- `next.config.mjs` — `allowedDevOrigins` 추가 (iPhone 로컬 네트워크 접근)
- `docs/reports/p4c-mobile-실기기-20260417.md` — 실기기 리포트

## WebGPU 미지원 분석

iPhone 12 mini(A14)에서 Safari가 `navigator.gpu`를 노출하지 않음. 원인 후보:
- A14 = Apple GPU 4세대 → WebGPU는 A15(iPhone 13)+ 전용일 가능성
- Safari Feature Flags 수동 활성화 필요 가능성

**폴백 정상 동작** — WebGL2 경로로 40~50fps 유지.

## Test plan

- [x] N=200 @ 60fps 실기기 확인 ✅
- [x] N=10000 크래시 없음 실기기 확인 ✅
- [ ] iPhone 13+(A15) 재측정 (후속)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)