### PR TITLE
[#179] P5-C — GPU compute shader별 세분화 측정 (force/integrator)

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -108,6 +108,14 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           asteroidNbody,
         });
 
+        // P5-C #179 — shader별 GPU ms 노출 (bench 폴링용). solar 생성 후 등록.
+        if (gpuTimerParam === '1') {
+          Object.defineProperty(window, '__gpuShaderTimings', {
+            configurable: true,
+            get: () => solar.readShaderTimings(),
+          });
+        }
+
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));
 
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -72,6 +72,12 @@ export class SimulationCore {
     if (!hasTimerCap) return false;
     const instrumentation = new EngineInstrumentation(this.#created.engine);
     instrumentation.captureGPUFrameTime = true;
+    // P5-C #179 — ComputeShader별 gpuTimeInFrame 활성화. 이 플래그가 없으면
+    // ComputeShader 인스턴스에 WebGPUPerfCounter가 생성되지 않는다.
+    const eng = this.#created.engine as { enableGPUTimingMeasurements?: boolean };
+    if ('enableGPUTimingMeasurements' in eng) {
+      eng.enableGPUTimingMeasurements = true;
+    }
     this.#instrumentation = instrumentation;
     return true;
   }

--- a/packages/core/src/physics/webgpu-nbody-engine.ts
+++ b/packages/core/src/physics/webgpu-nbody-engine.ts
@@ -148,8 +148,24 @@ export class WebGpuNBodyEngine {
   }
 
   totalEnergy(): number {
-    // GPU 측 reduce가 필요 — #147 정확도 검증 시점에 추가. 현재는 미지원.
     return Number.NaN;
+  }
+
+  /**
+   * P5-C #179 — force/integrator 셰이더별 GPU ms. enableGPUTimingMeasurements 필요.
+   * 미활성 시 null. ns → ms 변환.
+   */
+  readShaderTimings(): { forceMs: number | null; integratorMs: number | null } {
+    const readMs = (shader: ComputeShader): number | null => {
+      const counter = shader.gpuTimeInFrame?.counter;
+      if (!counter) return null;
+      const ns = counter.lastSecAverage || counter.average || counter.current;
+      return Number.isFinite(ns) && ns > 0 ? ns / 1_000_000 : null;
+    };
+    return {
+      forceMs: readMs(this.forceShader),
+      integratorMs: readMs(this.vvShader),
+    };
   }
 
   dispose(): void {

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -47,6 +47,8 @@ export interface SolarSystemSceneHandles {
   setBodyMassMultiplier: (bodyId: string, multiplier: number) => void;
   /** 모든 배수를 1.0으로 리셋 + Newton 재빌드. */
   resetMassMultipliers: () => void;
+  /** P5-C #179 — force/integrator 셰이더별 GPU ms. WebGPU 엔진 + gpuTimer 활성 시만. */
+  readShaderTimings: () => { forceMs: number | null; integratorMs: number | null } | null;
   dispose: () => void;
 }
 
@@ -399,6 +401,12 @@ export function createSolarSystemScene(
     getPhysicsEngine,
     setBodyMassMultiplier,
     resetMassMultipliers,
+    readShaderTimings: () => {
+      if (newtonEngine && 'readShaderTimings' in newtonEngine) {
+        return (newtonEngine as WebGpuNBodyEngine).readShaderTimings();
+      }
+      return null;
+    },
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();

--- a/scripts/bench-webgpu.mjs
+++ b/scripts/bench-webgpu.mjs
@@ -83,6 +83,13 @@ const readGpuMs = () =>
     () => /** @type {number | null} */ (/** @type {any} */ (window).__gpuFrameTimeMs ?? null),
   );
 
+// P5-C #179 — shader별 GPU ms 읽기.
+const readShaderTimings = () =>
+  page.evaluate(() => {
+    const t = /** @type {any} */ (window).__gpuShaderTimings;
+    return t ?? null;
+  });
+
 // P4-A #165 — beltNbody=1 모드로 측정. 소행성대가 N-body 엔진에 편입되어
 // engine 선택(newton/barnes-hut/webgpu)이 실제 N=행성+belt 전체에 대해 적용된다.
 //
@@ -105,17 +112,21 @@ for (const engine of ['newton', 'barnes-hut', 'webgpu']) {
     await page.click('[data-testid="time-play"]').catch(() => {});
     await page.waitForTimeout(500);
     const fps = await measureFps(DURATION_MS);
-    // 측정 직후 읽기 — lastSecAverage는 최근 1초 평균. 측정 윈도우와 정렬.
     const gpuMs = await readGpuMs();
+    const shaderT = await readShaderTimings();
     rows.push({
       engine,
       belt,
       fps: Number(fps.toFixed(2)),
       gpuMs: gpuMs === null ? null : Number(gpuMs.toFixed(3)),
+      forceMs: shaderT?.forceMs != null ? Number(shaderT.forceMs.toFixed(3)) : null,
+      integratorMs: shaderT?.integratorMs != null ? Number(shaderT.integratorMs.toFixed(3)) : null,
     });
     const gpuStr = gpuMs === null ? 'n/a' : `${gpuMs.toFixed(3)}ms`;
+    const forceStr = shaderT?.forceMs != null ? `${shaderT.forceMs.toFixed(3)}ms` : 'n/a';
+    const intStr = shaderT?.integratorMs != null ? `${shaderT.integratorMs.toFixed(3)}ms` : 'n/a';
     console.log(
-      `${engine.padEnd(11)} N=${String(belt).padEnd(5)}: ${fps.toFixed(2).padStart(7)} fps · gpu ${gpuStr}`,
+      `${engine.padEnd(11)} N=${String(belt).padEnd(5)}: ${fps.toFixed(2).padStart(7)} fps · gpu ${gpuStr} · force ${forceStr} · integrator ${intStr}`,
     );
   }
 }


### PR DESCRIPTION
## 요약

Babylon v9 `ComputeShader.gpuTimeInFrame` API로 force shader / integrator shader의
GPU ms를 **분리 측정**. 이전(P4-D)에는 전체 GPU frame time만 가능했다.

## 변경

- `simulation-core.ts` — `engine.enableGPUTimingMeasurements = true` 추가
- `webgpu-nbody-engine.ts` — `readShaderTimings()` → `{forceMs, integratorMs}`
- `solar-system-scene.ts` — `SolarSystemSceneHandles.readShaderTimings()` 추가
- `sim-canvas.tsx` — `?gpuTimer=1` 시 `window.__gpuShaderTimings` getter 노출
- `bench-webgpu.mjs` — bench 출력 + JSON에 `force_ms`, `integrator_ms` 컬럼

## 동작 원리

```
engine.enableGPUTimingMeasurements = true
  → ComputeShader 생성 시 gpuTimeInFrame: WebGPUPerfCounter 자동 부여
  → dispatch 시 timestamp write 삽입
  → readShaderTimings()로 ns 값을 ms로 변환해 반환
```

## 검증

- [x] 156/156 core 테스트 통과
- [x] 빌드 통과
- [x] 미지원 환경 graceful fallback (전부 null)
- [ ] `pnpm bench:webgpu` 실행 시 force/integrator 컬럼 값 확인 (headless Chromium)

## Test plan

- [ ] `pnpm bench:webgpu` → force ms / integrator ms 값이 양수 (webgpu 엔진)
- [ ] newton/barnes-hut 행 → force/integrator = n/a

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)