### PR TITLE
[#180] P5-D — 중력렌즈 MVP 구조 + shader Draft

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -120,6 +120,20 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           });
         }
 
+        // P5-D #180 — ?bh=1 옵트인 시 중력렌즈 PostProcess + 블랙홀 메쉬 추가.
+        const bhParam = new URLSearchParams(window.location.search).get('bh');
+        if (bhParam === '1' && instance.scene) {
+          const lensing = sceneApi.createGravitationalLensing(instance.scene, camera, {
+            position: [3, 0, 0],
+            lensStrength: 3,
+            visualRadius: 0.3,
+          });
+          const bhx = Number(new URLSearchParams(window.location.search).get('bhx')) || 3;
+          const bhy = Number(new URLSearchParams(window.location.search).get('bhy')) || 0;
+          const bhz = Number(new URLSearchParams(window.location.search).get('bhz')) || 0;
+          lensing.setPosition(bhx, bhy, bhz);
+        }
+
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));
 
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)

--- a/docs/decisions/20260417-gravitational-lensing-pipeline.md
+++ b/docs/decisions/20260417-gravitational-lensing-pipeline.md
@@ -1,0 +1,58 @@
+# ADR: 중력렌즈 시각화 — PostProcess fragment shader 접근
+
+- 일자: 2026-04-17
+- 상태: Draft (shader 패스스루 이슈 미해결)
+- 관련: P5-D #180
+
+## 배경
+
+블랙홀 근처에서 빛의 휘어짐(gravitational lensing)을 시각화한다.
+P4 WebGPU compute 인프라 재활용 가능성 검토 후, **PostProcess fragment shader**가
+이 케이스에 더 적합하다고 판단.
+
+## 후보
+
+| 항목         | A: PostProcess fragment | B: Compute shader → 렌더 텍스처 | C: 3D ray marching |
+| ------------ | ----------------------- | ------------------------------- | ------------------ |
+| 구현 복잡도  | 낮음                    | 중간 (텍스처 복사 필요)         | 높음               |
+| 픽셀별 처리  | 자연스러움              | 간접 (storage buffer → 복사)    | 자연스러움         |
+| Babylon 통합 | PostProcess API 표준    | Compute API 비표준 용법         | 커스텀             |
+| 물리 정확도  | 화면 공간 근사          | 화면 공간                       | 3D geodesic        |
+
+## 결정
+
+**A (PostProcess fragment shader) 채택.**
+
+이유:
+
+1. Babylon PostProcess API가 카메라에 자동 바인딩 — 라이프사이클 관리 단순
+2. 픽셀별 UV 왜곡은 fragment shader의 자연스러운 용법
+3. Compute shader → 렌더 텍스처 복사는 불필요한 오버헤드
+
+## 구현 (MVP)
+
+- `packages/core/src/scene/gravitational-lensing.ts` — PostProcess + 블랙홀 메쉬
+- GLSL fragment shader: `Effect.ShadersStore`에 인라인 등록
+- Schwarzschild weak-field deflection: `α = 2Rs/b`
+- Einstein ring 하이라이트 (smoothstep)
+- URL `?bh=1&bhx=N&bhy=N&bhz=N` 옵트인
+
+## 미해결
+
+**shader 패스스루 이슈**: Babylon WebGPU 엔진에서 GLSL PostProcess의 `textureSampler`
+바인딩이 올바르게 동작하지 않아 원래 씬이 렌더되지 않음. 원인 후보:
+
+1. GLSL → WGSL 자동 변환 시 `texture2D` → `textureSample` 매핑 실패
+2. WebGPU에서 PostProcess 입력 텍스처 바인딩 경로 차이
+3. `vUV` varying이 WebGPU PostProcess에서 자동 제공되지 않을 가능성
+
+**후속 작업**:
+
+- [ ] WebGL2 경로(`engine=kepler`, WebGPU 미사용)에서 동일 shader 테스트
+- [ ] Babylon WebGPU PostProcess 예제 코드 참조 (WGSL 직접 작성 가능성)
+- [ ] `textureSampler` 대신 Babylon의 `textureSampler` auto-binding 규약 확인
+
+## 재검토 조건
+
+- shader 디버깅 완료 후 본 ADR을 **Accepted**로 전환
+- WebGPU 전용 WGSL shader가 필요하다면 dual shader path 추가

--- a/packages/core/src/scene/gravitational-lensing.ts
+++ b/packages/core/src/scene/gravitational-lensing.ts
@@ -1,0 +1,192 @@
+/**
+ * P5-D #180 — 중력렌즈 시각화 (Schwarzschild 블랙홀).
+ *
+ * Babylon PostProcess fragment shader로 화면 공간에서 광선 편향을 시뮬레이트.
+ * 블랙홀 스크린 좌표 기준으로 각 프래그먼트의 UV를 radial deflection하여
+ * Einstein ring + event horizon 시각화.
+ *
+ * 물리:
+ *   deflection angle α = 2 Rs / b  (weak-field 근사)
+ *   Rs = 2GM/c² (Schwarzschild 반경)
+ *   b = impact parameter (프래그먼트 ↔ 블랙홀 스크린 거리)
+ *
+ * 한계:
+ *   - 화면 공간 근사 (3D ray tracing 아님)
+ *   - 단일 블랙홀만 지원
+ *   - thin-lens 근사 (블랙홀 앞뒤 거리 무시)
+ */
+import { Effect } from '@babylonjs/core/Materials/effect.js';
+import { PostProcess } from '@babylonjs/core/PostProcesses/postProcess.js';
+import {
+  MeshBuilder,
+  StandardMaterial,
+  Color3,
+  Vector3,
+  type Camera,
+  type Mesh,
+  type Scene,
+  type Viewport,
+} from '@babylonjs/core';
+
+const LENSING_SHADER_NAME = 'gravitationalLensing';
+
+// GLSL fragment shader — WebGL2 + WebGPU 양쪽에서 Babylon이 자동 변환.
+const LENSING_FRAGMENT = /* glsl */ `
+precision highp float;
+
+varying vec2 vUV;
+uniform sampler2D textureSampler;
+
+// 블랙홀 스크린 좌표 (0~1 UV space)
+uniform vec2 bhScreenPos;
+// Schwarzschild 반경 (스크린 space 단위)
+uniform float bhScreenRs;
+// 렌즈 강도 배율 (시각적 과장용, 기본 1.0)
+uniform float lensStrength;
+
+void main(void) {
+  vec2 dir = vUV - bhScreenPos;
+  float dist = length(dir);
+
+  // event horizon 내부 → 순수 흑색
+  if (dist < bhScreenRs * 0.5) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    return;
+  }
+
+  // weak-field deflection: 이미지를 radially outward로 밀어냄
+  // α = 2 Rs / b → UV offset = α * normalized direction
+  float alpha = lensStrength * 2.0 * bhScreenRs / max(dist, 0.001);
+
+  // 안쪽으로 당기는 왜곡 (배경이 블랙홀 뒤에서 감싸듯)
+  vec2 deflectedUV = vUV + dir / dist * alpha * 0.1;
+
+  // 클램프 (화면 밖 참조 방지)
+  deflectedUV = clamp(deflectedUV, vec2(0.0), vec2(1.0));
+
+  vec4 color = texture2D(textureSampler, deflectedUV);
+
+  // Einstein ring 하이라이트 — Rs 근처에서 밝기 증폭
+  float ringDist = abs(dist - bhScreenRs * 1.5);
+  float ring = smoothstep(bhScreenRs * 0.3, 0.0, ringDist);
+  color.rgb += vec3(0.3, 0.5, 0.9) * ring * 0.5;
+
+  gl_FragColor = color;
+}
+`;
+
+export interface BlackHoleOptions {
+  /** 블랙홀 위치 — 씬 단위 (AU 변환된 좌표). 기본: 태양 위치(0,0,0). */
+  position?: [number, number, number];
+  /** 블랙홀 질량 (kg). 기본: 태양 질량 × 10 (시각적 과장). */
+  mass?: number;
+  /** 렌즈 강도 배율. 1.0 = 물리 정확, >1 = 시각적 과장. 기본 50. */
+  lensStrength?: number;
+  /** 블랙홀 시각 크기 (씬 단위). 기본 0.3. */
+  visualRadius?: number;
+}
+
+export interface LensingHandles {
+  /** 블랙홀 메쉬 */
+  mesh: Mesh;
+  /** PostProcess (dispose 필요) */
+  postProcess: PostProcess;
+  /** 블랙홀 위치 갱신 */
+  setPosition: (x: number, y: number, z: number) => void;
+  /** 렌즈 강도 갱신 */
+  setLensStrength: (s: number) => void;
+  dispose: () => void;
+}
+
+/**
+ * 중력렌즈 PostProcess + 블랙홀 메쉬 생성.
+ *
+ * `?bh=1` URL 옵트인 시 sim-canvas에서 호출. 기본값은 비활성 (프로덕션 회귀 없음).
+ */
+export function createGravitationalLensing(
+  scene: Scene,
+  camera: Camera,
+  options: BlackHoleOptions = {},
+): LensingHandles {
+  const pos = options.position ?? [0, 0, 0];
+  let lensStrength = options.lensStrength ?? 3;
+  const visualRadius = options.visualRadius ?? 0.3;
+
+  // 블랙홀 메쉬 — 순수 흑색 구
+  const bhMesh = MeshBuilder.CreateSphere(
+    'blackhole',
+    { diameter: visualRadius * 2, segments: 16 },
+    scene,
+  );
+  const mat = new StandardMaterial('bh-mat', scene);
+  mat.diffuseColor = new Color3(0, 0, 0);
+  mat.specularColor = new Color3(0, 0, 0);
+  mat.emissiveColor = new Color3(0, 0, 0);
+  mat.disableLighting = true;
+  bhMesh.material = mat;
+  bhMesh.position.set(pos[0], pos[1], pos[2]);
+  bhMesh.isPickable = false;
+
+  // fragment shader 등록 (1회)
+  if (!Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader']) {
+    Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader'] = LENSING_FRAGMENT;
+  }
+
+  const pp = new PostProcess(
+    'gravitational-lensing',
+    LENSING_SHADER_NAME,
+    ['bhScreenPos', 'bhScreenRs', 'lensStrength'],
+    null,
+    1.0,
+    camera,
+  );
+
+  pp.onApply = (effect) => {
+    // 블랙홀 월드 → 스크린 좌표 변환
+    const engine = scene.getEngine();
+    const viewMatrix = scene.getViewMatrix();
+    const projMatrix = scene.getProjectionMatrix();
+    const vp = camera.viewport;
+    const width = engine.getRenderWidth() * vp.width;
+    const height = engine.getRenderHeight() * vp.height;
+
+    const worldPos = bhMesh.position;
+    const screenCoord = Vector3.Project(worldPos, viewMatrix, projMatrix, {
+      x: 0,
+      y: 0,
+      width,
+      height,
+    } as Viewport);
+
+    // UV space (0~1)
+    const screenU = screenCoord.x / width;
+    const screenV = 1 - screenCoord.y / height;
+
+    // 스크린 공간 Rs 근사 — 카메라 거리 기반
+    const camPos = camera.globalPosition;
+    const dx = worldPos.x - camPos.x;
+    const dy = worldPos.y - camPos.y;
+    const dz = worldPos.z - camPos.z;
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    // 시각 반경 = atan(visualRadius / dist) * (height / FOV) / height → 대략 visualRadius / dist
+    const screenRs = Math.max(0.005, visualRadius / Math.max(dist, 0.01));
+
+    effect.setFloat2('bhScreenPos', screenU, screenV);
+    effect.setFloat('bhScreenRs', screenRs);
+    effect.setFloat('lensStrength', lensStrength);
+  };
+
+  return {
+    mesh: bhMesh,
+    postProcess: pp,
+    setPosition: (x, y, z) => bhMesh.position.set(x, y, z),
+    setLensStrength: (s) => {
+      lensStrength = s;
+    },
+    dispose: () => {
+      pp.dispose();
+      mat.dispose();
+      bhMesh.dispose();
+    },
+  };
+}

--- a/packages/core/src/scene/gravitational-lensing.ts
+++ b/packages/core/src/scene/gravitational-lensing.ts
@@ -16,7 +16,9 @@
  *   - thin-lens 근사 (블랙홀 앞뒤 거리 무시)
  */
 import { Effect } from '@babylonjs/core/Materials/effect.js';
+import { ShaderStore } from '@babylonjs/core/Engines/shaderStore.js';
 import { PostProcess } from '@babylonjs/core/PostProcesses/postProcess.js';
+import { ShaderLanguage } from '@babylonjs/core/Materials/shaderLanguage.js';
 import {
   MeshBuilder,
   StandardMaterial,
@@ -31,46 +33,80 @@ import {
 const LENSING_SHADER_NAME = 'gravitationalLensing';
 
 // GLSL fragment shader — WebGL2 + WebGPU 양쪽에서 Babylon이 자동 변환.
-const LENSING_FRAGMENT = /* glsl */ `
-precision highp float;
+// WGSL PostProcess shader — WebGPU 엔진에서 직접 실행.
+// Babylon의 PostProcess는 `input.vUV`와 `textureSampler`/`textureSamplerSampler`를 자동 제공.
+const LENSING_FRAGMENT_WGSL = /* wgsl */ `
+varying vUV: vec2f;
+var textureSamplerSampler: sampler;
+var textureSampler: texture_2d<f32>;
+uniform bhScreenPos: vec2f;
+uniform bhScreenRs: f32;
+uniform lensStrength: f32;
 
-varying vec2 vUV;
-uniform sampler2D textureSampler;
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+  let dir = input.vUV - uniforms.bhScreenPos;
+  let dist = length(dir);
+  let rs = uniforms.bhScreenRs;
 
-// 블랙홀 스크린 좌표 (0~1 UV space)
+  // UV 왜곡 계산 — 분기 없이 (WGSL textureSample uniform control flow 제약)
+  let alpha = uniforms.lensStrength * 2.0 * rs / max(dist, 0.001);
+  let offset = normalize(dir) * alpha * 0.02;
+  let deflectedUV = clamp(input.vUV + offset, vec2f(0.0), vec2f(1.0));
+
+  // textureSample은 분기 밖에서 1회만 호출 (WGSL 제약)
+  let originalColor = textureSample(textureSampler, textureSamplerSampler, input.vUV);
+  let lensedColor = textureSample(textureSampler, textureSamplerSampler, deflectedUV);
+
+  // 영향 밖 → 패스스루, event horizon → 흑색, 그 외 → 왜곡
+  let outsideInfluence = step(rs * 5.0, dist) + step(0.001, -rs + 0.001);
+  let insideHorizon = step(dist, rs * 0.5) * step(0.001, rs);
+
+  // Einstein ring
+  let ringDist = abs(dist - rs * 1.5);
+  let ring = smoothstep(rs * 0.3, 0.0, ringDist);
+  let ringColor = vec3f(0.3, 0.5, 0.9) * ring * 0.4;
+
+  // mix: outside → original, horizon → black, lensing zone → deflected + ring
+  var result = mix(
+    mix(
+      vec4f(lensedColor.rgb + ringColor, lensedColor.a),
+      vec4f(0.0, 0.0, 0.0, 1.0),
+      clamp(insideHorizon, 0.0, 1.0)
+    ),
+    originalColor,
+    clamp(outsideInfluence, 0.0, 1.0)
+  );
+
+  fragmentOutputs.color = result;
+  return fragmentOutputs;
+}
+`;
+
+// GLSL 폴백 (WebGL2 경로용)
+const LENSING_FRAGMENT_GLSL = /* glsl */ `
 uniform vec2 bhScreenPos;
-// Schwarzschild 반경 (스크린 space 단위)
 uniform float bhScreenRs;
-// 렌즈 강도 배율 (시각적 과장용, 기본 1.0)
 uniform float lensStrength;
 
 void main(void) {
   vec2 dir = vUV - bhScreenPos;
   float dist = length(dir);
-
-  // event horizon 내부 → 순수 흑색
+  if (dist > bhScreenRs * 5.0 || bhScreenRs < 0.001) {
+    gl_FragColor = texture2D(textureSampler, vUV);
+    return;
+  }
   if (dist < bhScreenRs * 0.5) {
     gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
     return;
   }
-
-  // weak-field deflection: 이미지를 radially outward로 밀어냄
-  // α = 2 Rs / b → UV offset = α * normalized direction
   float alpha = lensStrength * 2.0 * bhScreenRs / max(dist, 0.001);
-
-  // 안쪽으로 당기는 왜곡 (배경이 블랙홀 뒤에서 감싸듯)
-  vec2 deflectedUV = vUV + dir / dist * alpha * 0.1;
-
-  // 클램프 (화면 밖 참조 방지)
-  deflectedUV = clamp(deflectedUV, vec2(0.0), vec2(1.0));
-
+  vec2 offset = normalize(dir) * alpha * 0.02;
+  vec2 deflectedUV = clamp(vUV + offset, vec2(0.0), vec2(1.0));
   vec4 color = texture2D(textureSampler, deflectedUV);
-
-  // Einstein ring 하이라이트 — Rs 근처에서 밝기 증폭
   float ringDist = abs(dist - bhScreenRs * 1.5);
   float ring = smoothstep(bhScreenRs * 0.3, 0.0, ringDist);
-  color.rgb += vec3(0.3, 0.5, 0.9) * ring * 0.5;
-
+  color.rgb += vec3(0.3, 0.5, 0.9) * ring * 0.4;
   gl_FragColor = color;
 }
 `;
@@ -127,11 +163,20 @@ export function createGravitationalLensing(
   bhMesh.position.set(pos[0], pos[1], pos[2]);
   bhMesh.isPickable = false;
 
-  // fragment shader 등록 (1회)
-  if (!Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader']) {
-    Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader'] = LENSING_FRAGMENT;
+  // 엔진 종류에 따라 WGSL(WebGPU) 또는 GLSL(WebGL2) shader 등록.
+  const isWebGpu = (scene.getEngine() as { isWebGPU?: boolean }).isWebGPU === true;
+
+  if (isWebGpu) {
+    if (!ShaderStore.ShadersStoreWGSL[LENSING_SHADER_NAME + 'FragmentShader']) {
+      ShaderStore.ShadersStoreWGSL[LENSING_SHADER_NAME + 'FragmentShader'] = LENSING_FRAGMENT_WGSL;
+    }
+  } else {
+    if (!Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader']) {
+      Effect.ShadersStore[LENSING_SHADER_NAME + 'FragmentShader'] = LENSING_FRAGMENT_GLSL;
+    }
   }
 
+  const shaderLang = isWebGpu ? ShaderLanguage.WGSL : ShaderLanguage.GLSL;
   const pp = new PostProcess(
     'gravitational-lensing',
     LENSING_SHADER_NAME,
@@ -139,6 +184,16 @@ export function createGravitationalLensing(
     null,
     1.0,
     camera,
+    undefined, // samplingMode
+    undefined, // engine
+    undefined, // reusable
+    undefined, // defines
+    undefined, // textureType
+    undefined, // vertexUrl
+    undefined, // indexParameters
+    undefined, // blockCompilation
+    undefined, // textureFormat
+    shaderLang,
   );
 
   pp.onApply = (effect) => {

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -22,3 +22,5 @@ export type {
 } from './solar-system-scene.js';
 export { createAsteroidBelt } from './asteroid-belt.js';
 export type { AsteroidBeltHandles, AsteroidBeltOptions } from './asteroid-belt.js';
+export { createGravitationalLensing } from './gravitational-lensing.js';
+export type { LensingHandles, BlackHoleOptions } from './gravitational-lensing.js';


### PR DESCRIPTION
## 요약

Schwarzschild 블랙홀 중력렌즈 시각화. PostProcess WGSL fragment shader로
화면 공간 광선 편향 + Einstein ring + event horizon 렌더.

## 시각적 결과

블랙홀(화성 궤도 근처, `?bh=1&bhx=3`) 주위로:
- **궤도선 왜곡** — 블랙홀 근처에서 radial deflection 관찰 가능
- **Einstein ring** — 블랙홀 Rs × 1.5 거리에서 파란 글로우
- **Event horizon** — 내부 순수 흑색
- **패스스루** — 영향 반경 밖은 원본 씬 그대로

## 핵심 디버깅

**WGSL uniform control flow 제약**: `textureSample()`은 if/else 분기 안에서 호출 불가.
→ 분기 밖에서 2회 호출 후 `step()/mix()`로 branchless 조합.

## 변경

- `packages/core/src/scene/gravitational-lensing.ts` — dual shader (WGSL + GLSL 폴백)
- `packages/core/src/scene/index.ts` — export
- `apps/web/src/components/sim-canvas.tsx` — `?bh=1&bhx=N&bhy=N&bhz=N` 옵트인
- `docs/decisions/20260417-gravitational-lensing-pipeline.md` — ADR

## Test plan

- [x] shader compilation 에러 0 확인
- [x] 블랙홀 주위 궤도선 왜곡 시각적 확인
- [x] `?bh=1` 없이 진입 시 기존 씬 정상 (프로덕션 회귀 없음)
- [ ] 3단계 브라우저 검증 (후속)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)