### PR TITLE
[#199] long-term-drift 테스트 타임아웃 30s 방어

### DIFF
--- a/packages/core/src/physics/long-term-drift.test.ts
+++ b/packages/core/src/physics/long-term-drift.test.ts
@@ -14,33 +14,45 @@ import { getSolarSystem } from '../ephemeris/solar-system-loader.js';
 const DAY = 86_400;
 const YEAR = 365.25 * DAY;
 
-describe('장기 드리프트 — 태양계 9체 Newton', () => {
-  it('100년 에너지 드리프트 < 0.5% (dt=1h 서브스텝)', () => {
-    const system = getSolarSystem();
-    const state = buildInitialState(system, system.epoch);
-    const engine = new NBodyEngine(state, { maxSubstepSeconds: 3600 });
-    const e0 = engine.totalEnergy();
-    engine.advance(100 * YEAR);
-    const e1 = engine.totalEnergy();
-    const drift = Math.abs((e1 - e0) / e0);
-    // 실측치 로그 (CI에서 확인)
-    console.log(`100년 에너지 드리프트: ${drift.toExponential(3)}`);
-    expect(drift).toBeLessThan(5e-3);
-    engine.dispose();
-  });
+// 100년 9체 적분은 단독 실행 시 ~1.3s 이나 병렬 테스트/CI 부하 시 5s 초과 가능 (#199).
+// 안정성 확보를 위해 30s 타임아웃을 지정한다.
+const LONG_INTEGRATION_TIMEOUT_MS = 30_000;
 
-  it('100년 후 위치가 유한값 — 시스템 이탈 없음', () => {
-    const system = getSolarSystem();
-    const state = buildInitialState(system, system.epoch);
-    const engine = new NBodyEngine(state, { maxSubstepSeconds: 3600 });
-    engine.advance(100 * YEAR);
-    const pos = engine.positions();
-    for (let i = 0; i < state.ids.length; i += 1) {
-      const r = Math.hypot(pos[3 * i]!, pos[3 * i + 1]!, pos[3 * i + 2]!);
-      expect(Number.isFinite(r)).toBe(true);
-      // Eris 원일점(~98 AU) 수준을 고려한 상한 — 카오스 이탈 방지 검증
-      expect(r / 1.496e11).toBeLessThan(150);
-    }
-    engine.dispose();
-  });
+describe('장기 드리프트 — 태양계 9체 Newton', () => {
+  it(
+    '100년 에너지 드리프트 < 0.5% (dt=1h 서브스텝)',
+    () => {
+      const system = getSolarSystem();
+      const state = buildInitialState(system, system.epoch);
+      const engine = new NBodyEngine(state, { maxSubstepSeconds: 3600 });
+      const e0 = engine.totalEnergy();
+      engine.advance(100 * YEAR);
+      const e1 = engine.totalEnergy();
+      const drift = Math.abs((e1 - e0) / e0);
+      // 실측치 로그 (CI에서 확인)
+      console.log(`100년 에너지 드리프트: ${drift.toExponential(3)}`);
+      expect(drift).toBeLessThan(5e-3);
+      engine.dispose();
+    },
+    LONG_INTEGRATION_TIMEOUT_MS,
+  );
+
+  it(
+    '100년 후 위치가 유한값 — 시스템 이탈 없음',
+    () => {
+      const system = getSolarSystem();
+      const state = buildInitialState(system, system.epoch);
+      const engine = new NBodyEngine(state, { maxSubstepSeconds: 3600 });
+      engine.advance(100 * YEAR);
+      const pos = engine.positions();
+      for (let i = 0; i < state.ids.length; i += 1) {
+        const r = Math.hypot(pos[3 * i]!, pos[3 * i + 1]!, pos[3 * i + 2]!);
+        expect(Number.isFinite(r)).toBe(true);
+        // Eris 원일점(~98 AU) 수준을 고려한 상한 — 카오스 이탈 방지 검증
+        expect(r / 1.496e11).toBeLessThan(150);
+      }
+      engine.dispose();
+    },
+    LONG_INTEGRATION_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary
- `long-term-drift.test.ts`의 두 `it()`에 `testTimeout: 30_000ms` 명시
- 이유 주석 + 상수 `LONG_INTEGRATION_TIMEOUT_MS` 추출

## 배경
P6-E PR 작업 중 `pnpm test` 전체 실행에서 100년 9체 적분 테스트 2건이 9.1~11.6s로 vitest 기본 5s 타임아웃 초과 보고 (#199). 100년 적분은 원래 부하가 큰 테스트라 병렬 실행/CI 경합 시 재발 가능.

## 재현 결과
- **main 단일 실행**: 1.32s PASS (재현 실패)
- **main core 전체 실행**: 1.66s, 163/163 PASS (재현 실패)
- 결론: **선재 회귀 아님 + 환경 부하 유발**. 안정성 확보를 위한 방어적 조치.

## 변경
`packages/core/src/physics/long-term-drift.test.ts`
- 두 `it()`에 세 번째 인자로 `LONG_INTEGRATION_TIMEOUT_MS = 30_000` 전달
- 선택 근거 주석: 단독 ~1.3s / 기본 5s / 30s 여유 확보

## Test plan
- [x] `pnpm --filter @astro-simulator/core exec vitest run src/physics/long-term-drift.test.ts` — 2/2 PASS (1.31s)
- [x] `pnpm --filter @astro-simulator/core test` — 163/163 PASS (회귀 없음)
- [x] U+FFFD 검증 통과
- [x] duplicate-function-guard 통과

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)