### PR TITLE
release: v0.6.1 — long-term-drift 테스트 타임아웃 방어

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 모든 중요한 변경사항은 이 파일에 기록된다.
 Semantic Versioning을 따른다.
 
+## [0.6.1] — 2026-04-18
+
+### 테스트 안정화
+
+**long-term-drift 타임아웃 방어** (#203, closes #199)
+
+- `packages/core/src/physics/long-term-drift.test.ts` — 두 `it()`에 `testTimeout: 30_000ms` 명시
+- 재현 조사: main 단일 실행 1.31s / core 전체 163/163 PASS — **선재 회귀 아님**
+- 100년 9체 Newton 적분은 단독 ~1.3s이나 병렬/CI 부하 시 vitest 기본 5s 초과 가능 → 안정성 확보 목적의 방어 조치
+- `LONG_INTEGRATION_TIMEOUT_MS` 상수 추출 + 이유 주석
+
 ## [0.6.0-p6] — 2026-04-17
 
 ### P6 물리 심화 — 중력렌즈 고도화 + EIH 1PN 다체

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/physics-wasm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Shared types, constants, and event definitions for astro-simulator",
   "type": "module",


### PR DESCRIPTION
## Summary
- PATCH 릴리스 — 코드/기능 변경 없음, 테스트 안정성만 보강
- 5 package.json: `0.6.0` → `0.6.1`
- CHANGELOG `[0.6.1]` 섹션 추가 (#203, closes #199)

## 포함 변경
| # | 주제 |
|---|---|
| #203 | `long-term-drift.test.ts` `testTimeout: 30_000ms` 방어 (병렬/CI 부하 대비) |

## 재현 조사 요약 (#199)
- main 단일 실행: 1.31s PASS
- main core 전체: 163/163 PASS (1.66s)
- 선재 회귀 아님 — 안정성 확보 목적의 방어 조치

## 분리 유지 정책
- `packages/physics-wasm/Cargo.toml` v0.3.0 유지 (v0.6.0 릴리스에서도 bump 안 했던 정책 그대로)

## Test plan
- [x] `pnpm test` — 225/225 PASS
  - shared 4/4 / physics-wasm 1/1 / core 163/163 / web 57/57
- [x] U+FFFD 검증 통과
- [x] duplicate-function-guard 통과

## 머지 후
- 태그 `v0.6.1` 생성
- `gh release create v0.6.1` (CHANGELOG 섹션 본문)

🤖 Generated with [Claude Code](https://claude.com/claude-code)