### PR TITLE
chore(ci): Rust 빌드 캐시 + wasm-pack prebuilt 도입 (Phase 1)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,8 +38,17 @@ jobs:
           toolchain: '1.94.1'
           targets: wasm32-unknown-unknown
 
+      # Rust 빌드 캐시 — cargo registry + target/ 재사용 (pnpm build 산하 wasm-pack 빌드 단축)
+      - name: Rust 빌드 캐시
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      # wasm-pack: cargo install(≈60s) → prebuilt 바이너리로 대체
       - name: wasm-pack 설치
-        run: cargo install wasm-pack --version 0.14.0 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
 
       - name: 의존성 설치
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-physics-wasm.yml
+++ b/.github/workflows/ci-physics-wasm.yml
@@ -30,9 +30,19 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
+      # Rust 빌드 캐시 — cargo registry + target/ 재사용 (cargo test --release 단축)
+      - name: Rust 빌드 캐시
+        if: hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      # wasm-pack: cargo install(≈60~70s) → prebuilt 바이너리로 대체
       - name: wasm-pack 설치
         if: hashFiles('packages/physics-wasm/Cargo.toml') != ''
-        run: cargo install wasm-pack --version 0.14.0 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
 
       # 1000년 심플렉틱 적분(365250 step)은 release 모드에서만 빠름.
       - name: Rust 테스트 (physics-wasm)


### PR DESCRIPTION
## Summary
CI 병목 두 잡(verify-and-rust 6m42s / bench 6m45s)의 **Rust 공통 비용**을 캐시 + prebuilt로 단축.
**실행 명령 · 툴 버전 · 산출물은 전부 불변** — 정합성 영향 없음.

## 변경

### `.github/workflows/ci-physics-wasm.yml` (verify-and-rust)
- `Swatinem/rust-cache@v2` 추가 (`workspaces: packages/physics-wasm`)
- `cargo install wasm-pack --version 0.14.0 --locked` → `taiki-e/install-action@v2 with: tool: wasm-pack@0.14.0`

### `.github/workflows/bench.yml` (bench)
- 동일하게 `Swatinem/rust-cache@v2` + `taiki-e/install-action@v2` 도입

## 불변 (정합성 보장)
| 항목 | 값 |
|---|---|
| Rust 툴체인 | `1.94.1` |
| WASM 타깃 | `wasm32-unknown-unknown` |
| rustfmt / clippy | 유지 (ci-physics-wasm) |
| wasm-pack 버전 | `0.14.0` |
| Rust 테스트 명령 | `cargo test --release --manifest-path packages/physics-wasm/Cargo.toml -- --nocapture` |
| bench 명령 | `pnpm bench:scene:sweep` (BENCH_PHASE/SUMMARY_OUT/REGRESSION_FPS 유지) |
| Playwright | `chromium --with-deps` |

## 예상 효과 (두 번째 실행 이후, 캐시 warm)

| 잡 | Before | After (추정) |
|---|---|---|
| verify-and-rust | 6m42s | **~3~4m** (-2~3m) |
| bench | 6m45s | **~4~5m** (-1~2m) |

- 첫 실행(이 PR 자체)은 캐시 miss라 효과 제한적 — 주요 측정 지표는 **머지 후 다음 PR**의 수치
- cargo registry + `packages/physics-wasm/target/` 캐시로 `cargo test --release` 점진 컴파일 전환
- wasm-pack prebuilt로 `cargo install` 빌드 시간(≈60~70s) 제거

## Test plan (정합성 확인)
- [ ] CI `verify-and-rust` SUCCESS (동일 1000년 적분 테스트 통과 = 결과 동일 증거)
- [ ] CI `bench` SUCCESS + bench-summary.md 생성
- [ ] GitHub Actions cache 탭에 `Linux-rust-cargo-packages/physics-wasm-*` 항목 생성 확인
- [ ] 머지 후 다음 PR에서 before/after 실측 수치 확인 후 Phase 2 판단

## 정합성 리스크 평가
- **산출물**: 동일 — `cargo test --release`는 같은 바이너리, `wasm-pack build`도 동일 출력
- **툴 버전**: 모두 pinned (1.94.1 / 0.14.0)
- **테스트 의미**: 변경 없음 — 캐시 hit/miss 여부와 테스트 결과는 무관
- **rust-cache@v2**: 업계 표준 action, cargo lockfile 기반 해시 키로 재사용 결정
- **taiki-e/install-action@v2**: wasm-pack 공식 prebuilt 제공, 같은 버전 바이너리

🤖 Generated with [Claude Code](https://claude.com/claude-code)