### PR TITLE
[#207] P7-B 적분기 선택 API + URL 옵트인 (Yoshida4)

### DIFF
--- a/apps/web/src/components/layout/hud-corners.tsx
+++ b/apps/web/src/components/layout/hud-corners.tsx
@@ -15,9 +15,15 @@ export function HudCorners() {
   const julianDate = useSimStore((s) => s.julianDate);
   const selected = useSimStore((s) => s.selectedBodyId);
   const fps = useSimStore((s) => s.fps);
+  const integrator = useSimStore((s) => s.integrator);
   // P5-B #177 — ?fps=1 URL 옵트인 시 실시간 fps 카운터 표시 (실기기 측정용).
   const showFps =
     typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('fps') === '1';
+  // P7-B #207 — ?integrator 옵트인 감지 (URL 존재 여부). 기본값 VV 이면 배지 숨김.
+  // URL 에 명시적으로 지정된 경우에만 표시 (디버그 가시성 + 사용자 신뢰 확보).
+  const showIntegratorBadge =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('integrator') !== null;
 
   return (
     <>
@@ -51,6 +57,14 @@ export function HudCorners() {
             className="bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle"
           >
             {Math.round(fps)} fps
+          </div>
+        )}
+        {showIntegratorBadge && (
+          <div
+            data-testid="integrator-badge"
+            className="bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle"
+          >
+            integrator · {integrator}
           </div>
         )}
       </div>

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -2,6 +2,7 @@
 
 import { SimulationCore, scene as sceneApi, gpu as gpuApi } from '@astro-simulator/core';
 import { attachCoreToStore } from '@/core/core-adapter';
+import { parseIntegratorKind } from '@/core/parse-integrator';
 import { SimCommandProvider } from '@/core/sim-context';
 import { useSimStore } from '@/store/sim-store';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
@@ -117,11 +118,23 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           console.warn(`[sim-canvas] 알 수 없는 ?gr=${grParam} — 'off'로 폴백`);
           return 'off';
         })();
+        // P7-B #207 — ?integrator=yoshida4 / velocity-verlet(verlet 별칭) 파싱.
+        // 실험적 옵트인 — 기본값 VV 유지, 디버그/검증 목적의 URL 파라미터.
+        const integratorParam = new URLSearchParams(window.location.search).get('integrator');
+        const integrator = parseIntegratorKind(integratorParam);
+        // HUD 배지 + browser-verify 스크립트용 전역 노출.
+        Object.defineProperty(window, '__simIntegrator', {
+          configurable: true,
+          value: integrator,
+          writable: false,
+        });
+        useSimStore.getState().setIntegrator(integrator);
         const solar = sceneApi.createSolarSystemScene(instance.scene, {
           physicsEngine: resolveEngine(useSimStore.getState().physicsEngine),
           asteroidBeltN: beltN,
           asteroidNbody,
           grMode,
+          integrator,
         });
 
         // P5-C #179 — shader별 GPU ms 노출 (bench 폴링용). solar 생성 후 등록.

--- a/apps/web/src/core/parse-integrator.test.ts
+++ b/apps/web/src/core/parse-integrator.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { parseIntegratorKind } from './parse-integrator';
+
+describe('parseIntegratorKind', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('공식값 velocity-verlet 은 그대로 통과', () => {
+    expect(parseIntegratorKind('velocity-verlet')).toBe('velocity-verlet');
+  });
+
+  it('공식값 yoshida4 는 그대로 통과', () => {
+    expect(parseIntegratorKind('yoshida4')).toBe('yoshida4');
+  });
+
+  it("별칭 'verlet' 은 'velocity-verlet' 으로 정규화", () => {
+    expect(parseIntegratorKind('verlet')).toBe('velocity-verlet');
+  });
+
+  it('대소문자 무시 — YOSHIDA4 → yoshida4', () => {
+    expect(parseIntegratorKind('YOSHIDA4')).toBe('yoshida4');
+    expect(parseIntegratorKind('Velocity-Verlet')).toBe('velocity-verlet');
+  });
+
+  it('null/undefined/빈 문자열은 기본값 velocity-verlet', () => {
+    expect(parseIntegratorKind(null)).toBe('velocity-verlet');
+    expect(parseIntegratorKind(undefined)).toBe('velocity-verlet');
+    expect(parseIntegratorKind('')).toBe('velocity-verlet');
+  });
+
+  it('알 수 없는 값은 velocity-verlet 폴백 + console.warn 1회 호출', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseIntegratorKind('rk4')).toBe('velocity-verlet');
+    expect(parseIntegratorKind('yoshida2')).toBe('velocity-verlet');
+    expect(parseIntegratorKind('invalid')).toBe('velocity-verlet');
+    // 별칭 `vv` 는 도입하지 않았으므로 폴백 경로.
+    expect(parseIntegratorKind('vv')).toBe('velocity-verlet');
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/apps/web/src/core/parse-integrator.ts
+++ b/apps/web/src/core/parse-integrator.ts
@@ -1,0 +1,35 @@
+/**
+ * P7-B #207 — `?integrator=` URL 파라미터 → `IntegratorKind` 파싱 순수 함수.
+ *
+ * 선례: `apps/web/src/components/sim-canvas.tsx`의 `?gr=` IIFE 파서 (P6-C).
+ *
+ * 정책:
+ * - 공식값: `velocity-verlet` · `yoshida4`
+ * - 별칭(정확히 1개): `verlet` → `velocity-verlet`
+ *   (약어 `vv`/`yo4` 는 도입하지 않음 — 문서화 비용/사용자 혼란 최소화)
+ * - 미지정(null/undefined/'') → `'velocity-verlet'` (기본값)
+ * - 알 수 없는 값 → `'velocity-verlet'` 폴백 + `console.warn`
+ * - 대소문자 무시 (URL 사용자 편의)
+ *
+ * 런타임 핫스왑은 비지원. 이 파서는 초기화 시점에 1회만 호출된다.
+ */
+import type { physics } from '@astro-simulator/core';
+
+type IntegratorKind = physics.IntegratorKind;
+
+export function parseIntegratorKind(urlParam: string | null | undefined): IntegratorKind {
+  if (urlParam === null || urlParam === undefined || urlParam === '') {
+    return 'velocity-verlet';
+  }
+  const normalized = urlParam.toLowerCase();
+  if (normalized === 'velocity-verlet' || normalized === 'verlet') {
+    return 'velocity-verlet';
+  }
+  if (normalized === 'yoshida4') {
+    return 'yoshida4';
+  }
+  // 알 수 없는 값 — GrMode 패턴과 동일한 폴백 + warn.
+  // eslint-disable-next-line no-console
+  console.warn(`[parse-integrator] 알 수 없는 ?integrator=${urlParam} — 'velocity-verlet'로 폴백`);
+  return 'velocity-verlet';
+}

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -1,5 +1,8 @@
+import type { physics } from '@astro-simulator/core';
 import type { SimMode } from '@astro-simulator/shared';
 import { create } from 'zustand';
+
+type IntegratorKind = physics.IntegratorKind;
 
 export type UnitSystem = 'si' | 'astro' | 'natural';
 /**
@@ -42,6 +45,11 @@ export interface SimStoreState {
   fps: number | null;
   unitSystem: UnitSystem;
   physicsEngine: PhysicsEngineKind;
+  /**
+   * P7-B #207 — 현재 활성 적분기 (URL ?integrator=에서 결정, 초기화 시점 고정).
+   * HUD 배지 표시 + 디버그 가시성 용도. 런타임 스위치는 비지원 (계약상).
+   */
+  integrator: IntegratorKind;
   /** 바디 id → 질량 배수 (#107). 1.0 또는 부재는 원래 질량. */
   massMultipliers: Record<string, number>;
 
@@ -66,6 +74,11 @@ export interface SimStoreState {
   setFps: (fps: number) => void;
   setUnitSystem: (unit: UnitSystem) => void;
   setPhysicsEngine: (kind: PhysicsEngineKind) => void;
+  /**
+   * P7-B #207 — 초기화 시점에 URL 파라미터로 결정된 적분기를 스토어에 기록.
+   * 런타임 스위치는 비지원이지만 HUD 배지 렌더링을 위해 setter 는 필요.
+   */
+  setIntegrator: (kind: IntegratorKind) => void;
   setMassMultiplier: (bodyId: string, multiplier: number) => void;
   resetMassMultipliers: () => void;
   setBlackHoleDiskParam: <K extends keyof BlackHoleDiskParams>(
@@ -109,6 +122,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   fps: null,
   unitSystem: 'astro',
   physicsEngine: 'kepler',
+  integrator: 'velocity-verlet',
   massMultipliers: {},
   blackHoleDisk: { ...DEFAULT_BLACK_HOLE_DISK },
   pingCount: 0,
@@ -124,6 +138,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   setFps: (fps) => set({ fps }),
   setUnitSystem: (unit) => set({ unitSystem: unit }),
   setPhysicsEngine: (kind) => set({ physicsEngine: kind }),
+  setIntegrator: (kind) => set({ integrator: kind }),
   setMassMultiplier: (bodyId, multiplier) =>
     set((state) => {
       const next = { ...state.massMultipliers };

--- a/docs/architecture/integrator-selection.md
+++ b/docs/architecture/integrator-selection.md
@@ -1,0 +1,93 @@
+# 적분기 선택 아키텍처 (P7-B #207)
+
+## 배경
+
+P7-A (#206) 에서 Yoshida 1990 4차 심플렉틱 적분기를 WASM 코어에 추가했다.
+P7-B 에서는 사용자/QA 가 Velocity-Verlet ↔ Yoshida4 를 **초기화 시점**에 선택할 수 있는
+API 와 URL 파라미터를 도입한다.
+
+기본값 전환(VV → Yoshida4)은 P7-D 벤치 (에너지 드리프트 개선 % + 비용 3× 수용 여부) 결과 후
+별도 ADR Amendment 로 결정한다. 현 시점 기본값은 VV 유지 (후방 호환).
+
+## 선택지 (`IntegratorKind`)
+
+TS 타입(`packages/core/src/physics/nbody-engine.ts`):
+
+```ts
+export type IntegratorKind = 'velocity-verlet' | 'yoshida4';
+```
+
+WASM 매핑(`packages/physics-wasm/src/integrator.rs::IntegratorKind`):
+
+| IntegratorKind    | u8  | 차수 | kick/step | 비용 (VV 대비) |
+| ----------------- | --- | ---- | --------- | -------------- |
+| `velocity-verlet` | 0   | 2    | 1         | 1.0× (기본)    |
+| `yoshida4`        | 1   | 4    | 3         | ≈3.0×          |
+
+향후 추가 후보(현재 미구현, `2` 예약): RK8 passive · PEFRL · Blanes-Moan 6차.
+
+## URL 파라미터
+
+- `?integrator=velocity-verlet` — 공식명
+- `?integrator=verlet` — 별칭 (정확히 1개)
+- `?integrator=yoshida4` — 공식명
+- 미지정 / `?integrator=` — `velocity-verlet` (기본값)
+- 알 수 없는 값 — `velocity-verlet` 폴백 + `console.warn` (토스트 비표시)
+- 대소문자 무시
+
+파서: `apps/web/src/core/parse-integrator.ts` (Vitest 단위 테스트 동반).
+
+> 약어(`vv`/`yo4`)는 도입하지 않는다. 문서화 비용 + 사용자 혼란 최소화.
+
+## 런타임 핫스왑 — 비지원
+
+`NBodyEngine` 은 생성자에서만 `integrator` 를 받는다. 다음은 **의도된 제약**이다:
+
+- `setIntegrator(kind)` 같은 public 메서드를 노출하지 않는다.
+- UI 토글 버튼도 제공하지 않는다 (`?integrator=` 는 디버그 파라미터 성격).
+- 런타임 전환이 필요하면 페이지 reload (URL 변경) 경로를 사용한다.
+
+이유:
+
+1. **심플렉틱 적분기 전환은 에너지 오프셋을 유발**한다 — 중간 스위치 시 궤도가 점프한다.
+2. **Yoshida4 + EIH 1PN 조합의 장기 안정성은 보장되지 않음** (속도의존력). 런타임 스위치를 허용하면
+   디버그 과정에서 의도치 않게 비수렴 경로에 진입할 수 있다. 초기화 시점 고정으로 회피.
+3. WASM 쪽은 `set_integrator(u8)` 를 노출하지만 TS 계약상 생성 직후 1회만 호출한다.
+
+## HUD 배지 가시성
+
+`?integrator=` URL 이 **명시된 경우에만** HUD 우상단에 배지가 표시된다:
+
+```
+integrator · yoshida4
+```
+
+- `data-testid="integrator-badge"` — E2E 선택자.
+- `window.__simIntegrator: IntegratorKind` — 스크립트 폴링용 전역 노출 (read-only).
+- 기본값(VV, URL 미지정) 시 배지 숨김 — 일반 사용자 노출 UX 간섭 방지.
+
+## 조합 — `?gr=eih&integrator=yoshida4`
+
+- 파서 2개는 독립이라 자동 성립.
+- P7-B DoD: 단기 (1 주기) NaN 미발생 + perihelion ±5% 만 검증.
+- **장기 (수년+) 안정성 미검증** — 심플렉틱은 위치-운동량 분리 해밀토니안을 가정하는데
+  1PN/EIH 는 속도의존 가속도라 이론적 보장 없음. P7-D 벤치에서 정량 측정 예정.
+
+## 재검토 조건
+
+- P7-D 벤치 결과 Yoshida4 에너지 드리프트 개선 ≥ 10× (고정 dt 동일 조건) 확인 시 기본값 전환 검토.
+- 장기 perihelion 회귀(예: 수성 1000년) ±5% 유지 재측정 결과 후 ADR Amendment.
+- 기존 사용자/자동화 스크립트 호환 영향도 조사 (URL 파라미터 확산 정도).
+
+## 관련 문서
+
+- ADR: `docs/decisions/20260418-p7-integrator-upgrade.md` (P7-A 에서 작성)
+- 이슈: #206 (P7-A Yoshida4 구현), #207 (P7-B API/URL), #211 (P7 마스터)
+- 소스:
+  - `packages/physics-wasm/src/integrator.rs`
+  - `packages/core/src/physics/nbody-engine.ts`
+  - `packages/core/src/scene/solar-system-scene.ts`
+  - `apps/web/src/core/parse-integrator.ts`
+  - `apps/web/src/components/sim-canvas.tsx`
+  - `apps/web/src/components/layout/hud-corners.tsx`
+  - `scripts/browser-verify-integrator.mjs`

--- a/packages/core/src/physics/index.ts
+++ b/packages/core/src/physics/index.ts
@@ -18,6 +18,8 @@ export { orbitalStateAt, type StateVector } from './state-vector.js';
 export {
   NBodyEngine,
   buildInitialState,
+  type GrMode,
+  type IntegratorKind,
   type NBodyEngineOptions,
   type NBodyState,
 } from './nbody-engine.js';

--- a/packages/core/src/physics/nbody-engine.ts
+++ b/packages/core/src/physics/nbody-engine.ts
@@ -28,6 +28,26 @@ const GR_MODE_TO_U8: Record<GrMode, number> = {
   eih: 2,
 };
 
+/**
+ * P7-B #207 — 적분기 종류. WASM `IntegratorKind` (0=VV, 1=Yoshida4)와 1:1 매핑.
+ *
+ * - `'velocity-verlet'`: 2차 심플렉틱, 기본값. 기존 동작 유지.
+ * - `'yoshida4'`: Yoshida 1990 4차 심플렉틱 (3-stage). 장기 궤도 정밀도 우위, 비용 ~3×.
+ *
+ * 런타임 핫스왑은 비지원. 생성자에서만 설정한다 (#207 DoD).
+ */
+export type IntegratorKind = 'velocity-verlet' | 'yoshida4';
+
+/**
+ * TS → WASM u8 매핑. 향후 2=RK8 passive 예약 (Rust 측에서 추가되면 여기도 확장).
+ * 별칭(`verlet`)은 URL 파서(apps/web/src/core/parse-integrator.ts)에서 정규화하므로
+ * 여기에는 포함하지 않는다.
+ */
+const INTEGRATOR_TO_U8: Record<IntegratorKind, number> = {
+  'velocity-verlet': 0,
+  yoshida4: 1,
+};
+
 export interface NBodyEngineOptions {
   /** 서브스텝 최대 dt(초). 기본 1일. */
   maxSubstepSeconds?: number;
@@ -42,6 +62,11 @@ export interface NBodyEngineOptions {
    * @deprecated P6-C부터 `grMode` 사용 권장. 호환성을 위해 유지.
    */
   enableGR?: boolean;
+  /**
+   * P7-B #207 — 적분기 종류. 미지정 시 `'velocity-verlet'` (기존 동작 유지).
+   * 생성자 시점에만 반영되며 런타임 스위치는 비지원.
+   */
+  integrator?: IntegratorKind;
 }
 
 export interface NBodyState {
@@ -125,6 +150,11 @@ export class NBodyEngine {
     const mode: GrMode = options.grMode ?? (options.enableGR ? 'single-1pn' : 'off');
     if (mode !== 'off') {
       this.wasm.set_gr_mode(GR_MODE_TO_U8[mode]);
+    }
+    // P7-B #207 — 적분기 옵션. 기본값(velocity-verlet) 이면 WASM 호출 생략 (GrMode 패턴).
+    const integrator: IntegratorKind = options.integrator ?? 'velocity-verlet';
+    if (integrator !== 'velocity-verlet') {
+      this.wasm.set_integrator(INTEGRATOR_TO_U8[integrator]);
     }
   }
 

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -13,7 +13,12 @@ import { AU, GRAVITATIONAL_CONSTANT, J2000_JD } from '@astro-simulator/shared';
 import { getSolarSystem, type LoadedCelestialBody } from '../ephemeris/solar-system-loader.js';
 import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
-import { NBodyEngine, buildInitialState, type GrMode } from '../physics/nbody-engine.js';
+import {
+  NBodyEngine,
+  buildInitialState,
+  type GrMode,
+  type IntegratorKind,
+} from '../physics/nbody-engine.js';
 import { BarnesHutNBodyEngine } from '../physics/barnes-hut-engine.js';
 import { WebGpuNBodyEngine } from '../physics/webgpu-nbody-engine.js';
 import { isWebGpuEngine, WebGpuUnavailableError } from '../gpu/index.js';
@@ -81,6 +86,12 @@ export interface SolarSystemSceneOptions {
    * Newton 엔진에만 적용 (Barnes-Hut/WebGPU 미지원).
    */
   grMode?: GrMode;
+  /**
+   * P7-B #207 — 적분기 종류. `'velocity-verlet'` (기본) 또는 `'yoshida4'`.
+   * Newton 엔진에만 적용 (Barnes-Hut/WebGPU 는 자체 적분기 사용).
+   * 런타임 스위치는 비지원 — 초기화 시점만 결정.
+   */
+  integrator?: IntegratorKind;
 }
 
 /**
@@ -101,6 +112,7 @@ export function createSolarSystemScene(
     asteroidNbody = false,
     enableGR = false,
     grMode,
+    integrator = 'velocity-verlet',
   } = options;
   // grMode 우선 — 미지정 시 enableGR (호환) 반영.
   const resolvedGrMode: GrMode = grMode ?? (enableGR ? 'single-1pn' : 'off');
@@ -228,7 +240,7 @@ export function createSolarSystemScene(
     } else if (kind === 'barnes-hut') {
       newtonEngine = new BarnesHutNBodyEngine(initial);
     } else {
-      newtonEngine = new NBodyEngine(initial, { grMode: resolvedGrMode });
+      newtonEngine = new NBodyEngine(initial, { grMode: resolvedGrMode, integrator });
     }
     newtonIdIndex = new Map(initial.ids.map((id, i) => [id, i]));
     newtonLastJd = jd;

--- a/scripts/browser-verify-integrator.mjs
+++ b/scripts/browser-verify-integrator.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * P7-B #207 브라우저 3단계 검증 — ?integrator= URL 옵트인.
+ *
+ * 선례: scripts/browser-verify-engine-toggle.mjs (Playwright chromium 모듈 재사용,
+ * 테스트 러너 도입 없음).
+ *
+ * 1. 정적:  ?integrator=yoshida4 진입 시 HUD 배지 + window.__simIntegrator 확인
+ * 2. URL 전환: ?integrator=velocity-verlet 재진입 시 배지 텍스트 전환
+ * 3. 흐름:   ?gr=eih&integrator=yoshida4 조합 재생 5초 — NaN/WASM 콘솔 에러 0건
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3001';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shotDir = join(__dirname, '..', '.verify-screenshots', 'integrator');
+mkdirSync(shotDir, { recursive: true });
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on('console', (m) => {
+  if (m.type() === 'error') consoleErrors.push(m.text());
+});
+
+const results = [];
+const check = (name, pass, detail = '') => {
+  results.push({ name, pass, detail });
+  const mark = pass ? '✓' : '✗';
+  console.log(`  ${mark} ${name}${detail ? ' — ' + detail : ''}`);
+};
+
+// ---- 1. 정적 ----
+console.log('\n[1/3] 정적 — ?integrator=yoshida4 진입');
+await page.goto(`${baseUrl}/ko?integrator=yoshida4`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+const badge = page.locator('[data-testid="integrator-badge"]');
+check('integrator-badge 렌더', (await badge.count()) === 1);
+const badgeText = (await badge.textContent()) ?? '';
+check('배지 텍스트 yoshida4 포함', badgeText.includes('yoshida4'), badgeText.trim());
+const winIntegratorYoshida = await page.evaluate(() => window.__simIntegrator);
+check(
+  'window.__simIntegrator === yoshida4',
+  winIntegratorYoshida === 'yoshida4',
+  String(winIntegratorYoshida),
+);
+await page.screenshot({ path: join(shotDir, '1-static-yoshida4.png') });
+
+// ---- 2. URL 전환 ----
+console.log('\n[2/3] URL 전환 — ?integrator=velocity-verlet');
+await page.goto(`${baseUrl}/ko?integrator=velocity-verlet`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+const badge2 = page.locator('[data-testid="integrator-badge"]');
+const badge2Text = (await badge2.textContent()) ?? '';
+check(
+  '배지 텍스트 velocity-verlet 포함',
+  badge2Text.includes('velocity-verlet'),
+  badge2Text.trim(),
+);
+const winIntegratorVV = await page.evaluate(() => window.__simIntegrator);
+check(
+  'window.__simIntegrator === velocity-verlet',
+  winIntegratorVV === 'velocity-verlet',
+  String(winIntegratorVV),
+);
+await page.screenshot({ path: join(shotDir, '2-url-verlet.png') });
+
+// ---- 3. 흐름 — ?gr=eih&integrator=yoshida4 조합 ----
+console.log('\n[3/3] 흐름 — ?gr=eih&integrator=yoshida4 5초 재생');
+consoleErrors.length = 0;
+await page.goto(`${baseUrl}/ko?gr=eih&integrator=yoshida4`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1500);
+const badge3 = page.locator('[data-testid="integrator-badge"]');
+const badge3Text = (await badge3.textContent()) ?? '';
+check('조합 URL — 배지 yoshida4', badge3Text.includes('yoshida4'), badge3Text.trim());
+// 시간 재생 시도 (버튼이 없으면 스킵, 기본 시뮬은 시간 진행).
+await page.click('[data-testid="time-play"]').catch(() => {});
+await page.waitForTimeout(5000);
+const hasNaNOrWasm = consoleErrors.some((e) => /NaN|nbody|wasm|NBodyEngine|integrator/i.test(e));
+check('5초 재생 중 WASM/NaN 관련 에러 0건', !hasNaNOrWasm);
+await page.screenshot({ path: join(shotDir, '3-eih-yoshida4.png') });
+
+await browser.close();
+
+console.log('\n========================================');
+const pass = results.filter((r) => r.pass).length;
+const fail = results.length - pass;
+console.log(`결과: ${pass}/${results.length} PASS`);
+if (consoleErrors.length) {
+  console.log(`콘솔 에러 ${consoleErrors.length}건 (전체):`);
+  consoleErrors.slice(0, 10).forEach((e) => console.log('  ', e));
+}
+if (fail > 0) process.exit(1);
+console.log(`스크린샷: ${shotDir}`);


### PR DESCRIPTION
## Summary
P7-A에서 Rust/WASM에 구현된 Yoshida4 심플렉틱 적분기를 TS/JS 계층에 노출. URL `?integrator=yoshida4` 옵트인, 기본값은 velocity-verlet 유지. **Rust 본체 변경 없음** — P7-A bindgen export 재사용.

- 설계: [Architect #207 설계안](https://github.com/coseo12/astro-simulator/issues/207#issuecomment-4273276655)
- 선행 머지: P7-A #206 (PR #212, main `67a8695`) · #213 후속 (PR #214, main `409817f`)

## 변경

**core / scene**
- `packages/core/src/physics/nbody-engine.ts` — `IntegratorKind` union literal + `INTEGRATOR_TO_U8` const + `NBodyEngineOptions.integrator`, 생성자에서 Yoshida4 일 때만 `set_integrator` 호출 (GrMode 패턴)
- `packages/core/src/physics/index.ts` — `IntegratorKind` export
- `packages/core/src/scene/solar-system-scene.ts` — 옵션 전파

**web / URL 파서**
- `apps/web/src/core/parse-integrator.ts` (신규) — 순수 함수 `parseIntegratorKind`, invalid/null → VV 폴백 + `console.warn` (P6-C GrMode 패턴 복제)
- `apps/web/src/core/parse-integrator.test.ts` (신규) — Vitest 6건 (정상 3 / 별칭 / invalid / null / 대소문자)
- `apps/web/src/components/sim-canvas.tsx` — URL 파싱 연결
- `apps/web/src/store/sim-store.ts` — `integrator` 상태
- `apps/web/src/components/layout/hud-corners.tsx` — `data-testid="integrator-badge"` 렌더

**E2E / 문서**
- `scripts/browser-verify-integrator.mjs` (신규) — `browser-verify-engine-toggle.mjs` 선례 복제, 3단계 검증
- `docs/architecture/integrator-selection.md` (신규) — 선택 기준/기본값 근거

## 별칭 규칙 (정확히 3개)
`velocity-verlet` / `verlet` / `yoshida4`. `vv`/`yo4` 등 약어 미도입.

## Test plan
- [x] **pnpm test**: **231/231 PASS** (기존 225 + 신규 파서 6건)
- [x] **pnpm build**: SUCCESS (next build)
- [x] **E2E browser-verify-integrator.mjs**: **7/7 PASS**
  - [x] 정적: `?integrator=yoshida4` 진입 — 배지 렌더 + `window.__simIntegrator === 'yoshida4'`
  - [x] URL 전환: `?integrator=velocity-verlet` 재진입 — 배지 텍스트 전환
  - [x] 조합: `?gr=eih&integrator=yoshida4` 5초 재생 — WASM/NaN 에러 0건
- [x] U+FFFD 0건
- [x] Rust 본체 무수정 — `verify-and-rust` CI 시간 영향 없어야 함

## 브라우저 3단계 검증 (CRITICAL #3)
`.verify-screenshots/integrator/` 에 스크린샷 박제. E2E 출력 로그는 커밋 메시지에 포함.

## DoD (이슈 #207)
- [x] **B1**: IntegratorKind TS 타입 + 엔진 옵션 (VV 기본, Yoshida4 옵트인)
- [x] **B2**: URL 파서 + invalid 폴백 + Vitest 6건 + E2E
- [x] **B3**: `?gr=eih&integrator=yoshida4` NaN 미발생 (5초 재생)

## 의존 관계
- 선행 완료: P7-A #206
- 후속: P7-D #209 (모바일 best-effort), P7-E #210 (bench/회고) 에서 조합 장기 안정성·bench 컬럼 처리

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)