### PR TITLE
[#225] bench baseline 재측정 workflow + median aggregator (설계 PR)

### DIFF
--- a/.github/workflows/bench-baseline-remeasure.yml
+++ b/.github/workflows/bench-baseline-remeasure.yml
@@ -43,7 +43,8 @@ jobs:
             echo "::error::sample_count 는 최소 3 이상이어야 한다 (현재: $COUNT)"
             exit 1
           fi
-          ARR=$(python3 -c "import json, sys; print(json.dumps(list(range(1, ${COUNT}+1))))")
+          # node 런타임으로 통일 (Reviewer 권고 3, SHA=62d9323)
+          ARR=$(node -e "console.log(JSON.stringify(Array.from({length: ${COUNT}}, (_,i) => i+1)))")
           echo "matrix=$ARR" >> "$GITHUB_OUTPUT"
           echo "sample_count=$COUNT"
 
@@ -109,8 +110,12 @@ jobs:
       - name: 리포트 JSON 수거
         run: |
           mkdir -p /tmp/bench-run-${{ matrix.run }}
-          # 이 회차에서 갱신된 JSON 만 분리 (git status 기준 새 파일)
-          git ls-files --others --exclude-standard docs/benchmarks/ | xargs -I{} cp {} /tmp/bench-run-${{ matrix.run }}/ || true
+          # 이 회차에서 갱신된 JSON 만 분리 (git status 기준 새 파일).
+          # `.json` 확장자 필터로 향후 BENCH_SUMMARY_OUT 류 부산물 오수거 방어
+          # (Reviewer 권고 1).
+          git ls-files --others --exclude-standard docs/benchmarks/ \
+            | grep -E '\.json$' \
+            | xargs -I{} cp {} /tmp/bench-run-${{ matrix.run }}/ || true
           ls -la /tmp/bench-run-${{ matrix.run }}
 
       - name: 아티팩트 업로드

--- a/.github/workflows/bench-baseline-remeasure.yml
+++ b/.github/workflows/bench-baseline-remeasure.yml
@@ -1,0 +1,198 @@
+name: bench:baseline-remeasure
+
+# #225 — GH Actions ubuntu headless 환경에서 bench:scene:sweep 를 N 회 실행하고
+# 각 scenario/nBody 의 중앙값으로 `docs/benchmarks/baseline.json` 을 갱신하는 PR 을
+# 자동 생성한다. `workflow_dispatch` 로 수동 트리거.
+#
+# 근거: PR #222 CI 에서 focus-earth/focus-neptune 이 -33.7%/-37.7% 경고 반복 — 환경
+#       격차(헤드리스 swiftshader vs 원본 baseline 환경) 흡수가 목적. #225 DoD 매핑.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sample_count:
+        description: '집계할 회차 수 (기본 10, 최소 3)'
+        default: '10'
+        type: string
+      phase_label:
+        description: 'baseline.phase 필드 값'
+        default: 'remeasure'
+        type: string
+      target_branch:
+        description: 'PR base 브랜치 (기본 develop)'
+        default: 'develop'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - name: 회차 배열 생성
+        id: build
+        env:
+          SAMPLE_COUNT: ${{ inputs.sample_count }}
+        run: |
+          COUNT="${SAMPLE_COUNT:-10}"
+          if [ "$COUNT" -lt 3 ]; then
+            echo "::error::sample_count 는 최소 3 이상이어야 한다 (현재: $COUNT)"
+            exit 1
+          fi
+          ARR=$(python3 -c "import json, sys; print(json.dumps(list(range(1, ${COUNT}+1))))")
+          echo "matrix=$ARR" >> "$GITHUB_OUTPUT"
+          echo "sample_count=$COUNT"
+
+  bench:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Rust 툴체인 설정
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+
+      - name: Playwright 브라우저 설치
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 앱 빌드
+        run: pnpm build
+
+      - name: 웹 서버 기동 (백그라운드)
+        run: |
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          echo "WEB_PID=$!" >> $GITHUB_ENV
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+
+      - name: bench:scene:sweep (run ${{ matrix.run }})
+        env:
+          BENCH_PHASE: remeasure-run-${{ matrix.run }}
+        run: pnpm bench:scene:sweep
+
+      - name: 리포트 JSON 수거
+        run: |
+          mkdir -p /tmp/bench-run-${{ matrix.run }}
+          # 이 회차에서 갱신된 JSON 만 분리 (git status 기준 새 파일)
+          git ls-files --others --exclude-standard docs/benchmarks/ | xargs -I{} cp {} /tmp/bench-run-${{ matrix.run }}/ || true
+          ls -la /tmp/bench-run-${{ matrix.run }}
+
+      - name: 아티팩트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-run-${{ matrix.run }}
+          path: /tmp/bench-run-${{ matrix.run }}/*.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: 서버 종료
+        if: always()
+        run: kill $WEB_PID || true
+
+  aggregate:
+    needs: bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: 전체 아티팩트 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/bench-artifacts
+          pattern: bench-run-*
+          merge-multiple: true
+
+      - name: aggregate 실행 → baseline.json 갱신
+        env:
+          PHASE_LABEL: ${{ inputs.phase_label }}
+        run: |
+          ls -la /tmp/bench-artifacts
+          node scripts/bench-aggregate-median.mjs \
+            --input-dir /tmp/bench-artifacts \
+            --phase "${PHASE_LABEL}" \
+            --environment "gh-actions-ubuntu-chromium-headless" \
+            --output docs/benchmarks/baseline.json
+
+      - name: aggregate 단위 테스트 (회귀 가드)
+        run: node scripts/bench-aggregate-median.test.mjs
+
+      - name: baseline 갱신 PR 생성
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ inputs.target_branch }}
+          branch: chore/baseline-remeasure-${{ github.run_id }}
+          commit-message: |
+            chore(bench): #225 GH Actions ubuntu baseline 재측정 (median N=${{ inputs.sample_count }})
+
+            source_count=${{ inputs.sample_count }} · phase=${{ inputs.phase_label }}
+            집계 근거: scripts/bench-aggregate-median.mjs
+            트리거: run_id=${{ github.run_id }}
+          title: 'chore(bench): #225 baseline 재측정 (ubuntu median N=${{ inputs.sample_count }})'
+          body: |
+            ## Summary
+
+            `bench-baseline-remeasure` workflow 가 ubuntu-latest × ${{ inputs.sample_count }} 회 `bench:scene:sweep` 실측을 집계해
+            각 scenario / nBody 의 **중앙값** 으로 `docs/benchmarks/baseline.json` 을 갱신.
+
+            - trigger: `workflow_dispatch`
+            - run_id: ${{ github.run_id }}
+            - phase: `${{ inputs.phase_label }}`
+            - sample_count: ${{ inputs.sample_count }}
+            - environment: `gh-actions-ubuntu-chromium-headless`
+
+            ## Test plan
+
+            - [ ] 새 baseline 대비 `bench.yml` (PR 이벤트) 회귀 경고 0건 확인
+            - [ ] diff 검토 — scenario 별 변동률이 환경 격차 범위 내 (±10% 권장)
+            - [ ] Reviewer / QA 통과 후 머지
+
+            Closes #225
+          labels: |
+            type:infra
+            priority:low
+          delete-branch: true

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -54,3 +54,23 @@ git add docs/benchmarks/baseline.json && git commit -m "bench: baseline 갱신 (
 ## CI 연동
 
 `.github/workflows/bench.yml` — PR 이벤트에서 sweep을 실행해 baseline 대비 diff를 sticky comment로 게시한다 (best-effort). 헤드리스 GitHub Actions runner의 GPU 변동성이 크므로 임계값을 `-10 fps`로 완화하며, 정식 성능 게이트는 로컬 실 GPU 측정(#116, `scripts/bench-scene-real-gpu.mjs`)을 기준으로 한다.
+
+### baseline 재측정 — `bench:baseline-remeasure` (#225)
+
+헤드리스 ubuntu 환경과 기존 baseline 사이의 구조적 편차로 `bench.yml` 이 특정 scenario(예: focus-earth/neptune) 에서 반복 경고를 띄우면, `.github/workflows/bench-baseline-remeasure.yml` 을 **수동 트리거** 하여 ubuntu 환경 median 으로 재설정한다.
+
+```
+GitHub → Actions → bench:baseline-remeasure → Run workflow
+  inputs:
+    sample_count: "10"     # 3 이상 권장
+    phase_label: "remeasure"
+    target_branch: "develop"
+```
+
+동작:
+
+1. `plan` job 이 `sample_count` 를 검증하고 matrix 배열을 생성
+2. `bench` job 이 matrix 로 **N 회 병렬** `bench:scene:sweep` 실행 → 각 회차 JSON 아티팩트 업로드
+3. `aggregate` job 이 모든 아티팩트 다운로드 → `scripts/bench-aggregate-median.mjs` 로 median 계산 → `baseline.json` 덮어쓰기 → `chore/baseline-remeasure-<run_id>` 브랜치에 PR 자동 생성
+
+새 baseline 에는 `source_count` 와 각 항목의 `samples` 필드가 추가되어 재측정 근거를 추적 가능.

--- a/scripts/bench-aggregate-median.mjs
+++ b/scripts/bench-aggregate-median.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * #225 — bench:scene:sweep 여러 회차 실측 JSON 을 받아 scenario/nBody 별 중앙값을
+ * 계산하고 `docs/benchmarks/baseline.json` 포맷으로 출력.
+ *
+ * 목적: GH Actions ubuntu headless 환경의 회차별 fps 변동을 10회 median 으로
+ *       흡수해 `bench:scene:sweep` 회귀 경고를 0 건에 수렴시킨다 (volt #25 참고).
+ *
+ * 사용:
+ *   node scripts/bench-aggregate-median.mjs \
+ *     --input-dir /tmp/bench-runs \
+ *     --phase "pr-225-median-10" \
+ *     --environment "gh-actions-ubuntu-chromium-headless" \
+ *     --output docs/benchmarks/baseline-candidate.json
+ *
+ * 규약:
+ *   - 입력 JSON 은 `scripts/bench-scene.mjs` 출력 스키마와 일치 (scenarios[]·nBody[])
+ *   - 최소 3 샘플 필요 (중앙값 신뢰성). 미달 시 exit 1
+ *   - 결측 시나리오(일부 회차에서 누락) 는 존재하는 회차만으로 median — 회차 수 필드 `samples` 에 명시
+ *   - 출력은 기존 baseline.json 과 동일 필드 + `samples` / `source_count` 메타 추가
+ *
+ * 의존성 없음. stand-alone Node 실행.
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function parseArgs(argv) {
+  const args = { inputDir: null, phase: 'remeasure', environment: null, output: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--input-dir') args.inputDir = next;
+    else if (arg === '--phase') args.phase = next;
+    else if (arg === '--environment') args.environment = next;
+    else if (arg === '--output') args.output = next;
+  }
+  return args;
+}
+
+export function readJsonFiles(dir) {
+  const entries = readdirSync(dir);
+  const jsons = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const full = join(dir, name);
+    if (!statSync(full).isFile()) continue;
+    const text = readFileSync(full, 'utf8');
+    try {
+      jsons.push({ path: full, data: JSON.parse(text) });
+    } catch (e) {
+      throw new Error(`[bench-aggregate-median] ${full} JSON 파싱 실패: ${e.message}`);
+    }
+  }
+  return jsons;
+}
+
+/** 숫자 배열의 중앙값. 짝수 개면 두 중앙 평균, 홀수 개면 중앙값. */
+export function median(values) {
+  if (values.length === 0) throw new Error('median: 빈 배열');
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * 여러 bench 리포트를 받아 scenario/nBody 의 회차별 fps 배열로 재구성.
+ * @returns {{ scenarios: Map<string, number[]>, nBody: Map<number, number[]>, sampleCount: number }}
+ */
+export function collectFps(reports) {
+  const scenarios = new Map();
+  const nBody = new Map();
+  for (const { data } of reports) {
+    if (Array.isArray(data.scenarios)) {
+      for (const s of data.scenarios) {
+        if (typeof s.fps !== 'number' || !Number.isFinite(s.fps)) continue;
+        const list = scenarios.get(s.name) ?? [];
+        list.push(s.fps);
+        scenarios.set(s.name, list);
+      }
+    }
+    if (Array.isArray(data.nBody)) {
+      for (const n of data.nBody) {
+        if (typeof n.fps !== 'number' || !Number.isFinite(n.fps)) continue;
+        const list = nBody.get(n.n) ?? [];
+        list.push(n.fps);
+        nBody.set(n.n, list);
+      }
+    }
+  }
+  return { scenarios, nBody, sampleCount: reports.length };
+}
+
+/** 회차별 fps 배열을 median 으로 축약 → baseline.json 스키마 생성. */
+export function buildBaseline({ scenarios, nBody, sampleCount }, meta) {
+  const firstReport = meta.firstReport ?? {};
+  return {
+    timestamp: new Date().toISOString(),
+    phase: meta.phase,
+    durationMs: firstReport.durationMs ?? null,
+    environment: meta.environment ?? firstReport.environment ?? 'unknown',
+    viewport: firstReport.viewport ?? null,
+    scenarios: Array.from(scenarios.entries()).map(([name, fpsList]) => ({
+      name,
+      fps: Number(median(fpsList).toFixed(2)),
+      samples: fpsList.length,
+    })),
+    nBody: Array.from(nBody.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([n, fpsList]) => ({
+        n,
+        fps: Number(median(fpsList).toFixed(2)),
+        samples: fpsList.length,
+      })),
+    source_count: sampleCount,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.inputDir) {
+    console.error(
+      'usage: bench-aggregate-median.mjs --input-dir <dir> [--phase <str>] [--environment <str>] [--output <path>]',
+    );
+    process.exit(2);
+  }
+  const reports = readJsonFiles(args.inputDir);
+  if (reports.length < 3) {
+    console.error(`[bench-aggregate-median] 최소 3 샘플 필요 — 실제 ${reports.length}개`);
+    process.exit(1);
+  }
+  const collected = collectFps(reports);
+  const baseline = buildBaseline(collected, {
+    phase: args.phase,
+    environment: args.environment,
+    firstReport: reports[0].data,
+  });
+  const json = JSON.stringify(baseline, null, 2) + '\n';
+  if (args.output) {
+    writeFileSync(args.output, json);
+    console.log(`[bench-aggregate-median] ${args.output} (source_count=${reports.length})`);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+// 직접 실행 시에만 main 실행 (테스트 import 시에는 부작용 없음).
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/bench-aggregate-median.test.mjs
+++ b/scripts/bench-aggregate-median.test.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * #225 — bench-aggregate-median.mjs 회귀 가드.
+ *
+ * stand-alone node 테스트 (check-duplicate-functions.test.mjs 선례 계승).
+ */
+import assert from 'node:assert/strict';
+import { median, collectFps, buildBaseline, parseArgs } from './bench-aggregate-median.mjs';
+
+let passed = 0;
+const run = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (e) {
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+    process.exitCode = 1;
+  }
+};
+
+console.log('bench-aggregate-median');
+
+run('median — 홀수 개 정렬 후 중앙', () => {
+  assert.equal(median([3, 1, 2]), 2);
+  assert.equal(median([90.81, 85.2, 92.0, 88.5, 86.3]), 88.5);
+});
+
+run('median — 짝수 개 중앙 평균', () => {
+  assert.equal(median([1, 2, 3, 4]), 2.5);
+  assert.equal(median([90, 91, 94, 97]), 92.5);
+});
+
+run('median — 빈 배열은 throw', () => {
+  assert.throws(() => median([]));
+});
+
+run('collectFps — scenarios / nBody 회차별 fps 누적', () => {
+  const reports = [
+    {
+      data: {
+        scenarios: [
+          { name: 'focus-earth', fps: 90 },
+          { name: 'focus-neptune', fps: 96 },
+        ],
+        nBody: [{ n: 100, fps: 23 }],
+      },
+    },
+    {
+      data: {
+        scenarios: [
+          { name: 'focus-earth', fps: 88 },
+          { name: 'focus-neptune', fps: 92 },
+        ],
+        nBody: [{ n: 100, fps: 24 }],
+      },
+    },
+    {
+      data: {
+        scenarios: [{ name: 'focus-earth', fps: 85 }],
+        nBody: [{ n: 100, fps: 22 }],
+      },
+    },
+  ];
+  const { scenarios, nBody, sampleCount } = collectFps(reports);
+  assert.equal(sampleCount, 3);
+  assert.deepEqual(scenarios.get('focus-earth'), [90, 88, 85]);
+  assert.deepEqual(scenarios.get('focus-neptune'), [96, 92]); // 3번째 회차 누락
+  assert.deepEqual(nBody.get(100), [23, 24, 22]);
+});
+
+run('collectFps — NaN/Infinity 는 제외', () => {
+  const { scenarios } = collectFps([
+    { data: { scenarios: [{ name: 'x', fps: NaN }] } },
+    { data: { scenarios: [{ name: 'x', fps: 10 }] } },
+    { data: { scenarios: [{ name: 'x', fps: Infinity }] } },
+  ]);
+  assert.deepEqual(scenarios.get('x'), [10]);
+});
+
+run('buildBaseline — 기존 baseline.json 스키마 호환', () => {
+  const collected = {
+    scenarios: new Map([
+      ['focus-earth', [90, 88, 85, 92, 87]],
+      ['focus-neptune', [96, 92, 94, 98, 90]],
+    ]),
+    nBody: new Map([
+      [100, [23, 24, 22, 25, 23]],
+      [1000, [7, 8, 6, 7, 7]],
+    ]),
+    sampleCount: 5,
+  };
+  const out = buildBaseline(collected, {
+    phase: 'pr-225',
+    environment: 'gh-actions-ubuntu',
+    firstReport: { durationMs: 3000, viewport: '1280x800' },
+  });
+  // 스키마 필드 존재
+  assert.ok(typeof out.timestamp === 'string');
+  assert.equal(out.phase, 'pr-225');
+  assert.equal(out.durationMs, 3000);
+  assert.equal(out.environment, 'gh-actions-ubuntu');
+  assert.equal(out.viewport, '1280x800');
+  assert.equal(out.source_count, 5);
+  // median 정확성 + nBody 오름차순 정렬
+  const earth = out.scenarios.find((s) => s.name === 'focus-earth');
+  assert.equal(earth.fps, 88); // median([85,87,88,90,92]) = 88
+  assert.equal(earth.samples, 5);
+  assert.equal(out.nBody[0].n, 100);
+  assert.equal(out.nBody[1].n, 1000);
+});
+
+run('parseArgs — 네 플래그 모두 파싱', () => {
+  const a = parseArgs([
+    '--input-dir',
+    '/tmp/runs',
+    '--phase',
+    'pr-225',
+    '--environment',
+    'gh-ubuntu',
+    '--output',
+    'out.json',
+  ]);
+  assert.equal(a.inputDir, '/tmp/runs');
+  assert.equal(a.phase, 'pr-225');
+  assert.equal(a.environment, 'gh-ubuntu');
+  assert.equal(a.output, 'out.json');
+});
+
+run('parseArgs — 기본 phase=remeasure', () => {
+  const a = parseArgs(['--input-dir', '/tmp/x']);
+  assert.equal(a.phase, 'remeasure');
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## Summary

#225 의 DoD "GH Actions ubuntu headless 환경 10회 실측 중앙값으로 baseline 재측정" 을 **재사용 가능한 워크플로우** 로 도입. 본 PR 은 **도구 도입만** 수행하고, 실제 baseline 갱신은 머지 후 사용자가 `workflow_dispatch` 로 수동 트리거 → 자동 PR 생성 (2-PR 흐름).

## 왜 분리 PR 인가

- (수동 10회 dispatch) 는 일회성이라 #225 재발 시 또 반복 작업 — 재사용성 0
- (bench.yml 에 matrix 10 추가) 는 모든 PR 의 CI 비용 10× 증가
- (본 PR, workflow_dispatch + aggregate) 는 **필요할 때만** 트리거, 집계/PR 자동화

## 변경 파일 (4개)

- `.github/workflows/bench-baseline-remeasure.yml` (198줄) — plan → bench (matrix N) → aggregate 3 job
- `scripts/bench-aggregate-median.mjs` (153줄) — stand-alone median aggregator
- `scripts/bench-aggregate-median.test.mjs` (135줄) — 8 케이스 회귀 가드
- `docs/benchmarks/README.md` — 재측정 절차 문서화

## 워크플로우 동작

\`\`\`
GitHub → Actions → bench:baseline-remeasure → Run workflow
  inputs:
    sample_count: "10"     (기본, 최소 3)
    phase_label: "remeasure"
    target_branch: "develop"
\`\`\`

1. **plan job**: `sample_count` 검증 + matrix 배열 생성
2. **bench job** (matrix N 병렬): `bench:scene:sweep` 각 회차 → JSON 아티팩트 업로드
3. **aggregate job**: 전체 아티팩트 다운로드 → `bench-aggregate-median.mjs` 실행 → `baseline.json` 갱신 → `chore/baseline-remeasure-<run_id>` 브랜치 PR 자동 생성

## aggregate 스크립트

- **의존성 0** (Node 내장 모듈만)
- 결측 시나리오 (일부 회차 누락) 는 존재 회차만으로 median, `samples` 필드에 회차 수 박제
- NaN/Infinity 입력 자동 제외, 최소 3 샘플 요구 (미달 시 exit 1)
- 출력 스키마: 기존 `baseline.json` + `source_count` · `scenarios[].samples` · `nBody[].samples` 메타

## Behavior Changes

- 신규 workflow 는 **수동 트리거만** — 기존 `bench.yml` (PR 이벤트) 동작 불변
- 기존 `baseline.json` 무변경 — 실제 갱신은 머지 후 별도 워크플로우 실행에서 발생

## Test plan

- [x] `node scripts/bench-aggregate-median.test.mjs` **8/8 PASS**
  - median 홀수/짝수/빈 배열 throw
  - collectFps 누락 회차 / NaN·Infinity 제외
  - buildBaseline 기존 스키마 호환 + nBody 오름차순
  - parseArgs 네 플래그 + 기본값
- [x] `pnpm prettier --check` 통과
- [x] U+FFFD 0건
- [ ] CI 기존 워크플로우 (`bench.yml`, `prettierignore-drift`, `ci-physics-wasm`) 회귀 없음
- [ ] Reviewer 정적 리뷰 통과
- [ ] (후속) 머지 후 `workflow_dispatch` 실 트리거 → 자동 PR 생성 → 새 baseline diff 검토 → 리뷰/QA/머지

## 관련

- Partially closes #225 (도구 도입; 실제 baseline 갱신은 후속 자동 PR 에서)
- 연관 PR: #222 (bench 경고 최초 관찰), #234 (#223 — `bench-p7-lens3d` vsync 페그 해소)
- 후속 이슈: #235 (vsync 플래그 확산), #236, #237 (pre-existing lint/TS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)