### PR TITLE
[#236 #237] pre-existing typecheck/lint 2건 해소

### DIFF
--- a/apps/web/src/components/panels/black-hole-disk-panel.tsx
+++ b/apps/web/src/components/panels/black-hole-disk-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { parseAsString, useQueryState } from 'nuqs';
 import { useSimStore } from '@/store/sim-store';
 
 /**
@@ -10,16 +10,18 @@ import { useSimStore } from '@/store/sim-store';
  * sim-canvas useEffect가 createBlackHoleRendering handles의 setDisk* 메서드를 호출.
  *
  * LUT 재생성 0회 — eccentricity/thickness/tilt/inner/outer 모두 셰이더 uniform만 갱신.
+ *
+ * #237 — `useQueryState` 로 URL 파라미터 구독 (`url-sync.tsx` 일관). 이전의
+ * useState+useEffect+window.location 조합은 SSR-safe 목적이었으나 react-hooks
+ * lint 규칙 위반 + 수동 파싱 부채가 있었다. nuqs 는 SSR 에서 null 반환하므로
+ * 동일 hydration 안전성 유지.
  */
 export function BlackHoleDiskPanel() {
   const params = useSimStore((s) => s.blackHoleDisk);
   const setParam = useSimStore((s) => s.setBlackHoleDiskParam);
   const reset = useSimStore((s) => s.resetBlackHoleDisk);
 
-  const [bhMode, setBhMode] = useState<string | null>(null);
-  useEffect(() => {
-    setBhMode(new URLSearchParams(window.location.search).get('bh'));
-  }, []);
+  const [bhMode] = useQueryState('bh', parseAsString.withOptions({ history: 'replace' }));
 
   // ?bh=2 옵트인일 때만 패널 표시 (P5-D `?bh=1`은 별도 PostProcess).
   if (bhMode !== '2') return null;

--- a/packages/core/src/gpu/nbody-force-shader.test.ts
+++ b/packages/core/src/gpu/nbody-force-shader.test.ts
@@ -36,9 +36,10 @@ describe('computeForcesF32 (CPU 참조)', () => {
     const positions = new Float32Array([-1, 0, 0, 1, 0, 0]);
     const masses = new Float32Array([1e10, 1e10]);
     const acc = computeForcesF32(positions, masses, 0, G);
-    expect(acc[0]).toBeCloseTo(-acc[3], 5);
-    expect(Math.sign(acc[0])).toBe(1); // -1에 있는 입자는 +x 방향으로 끌림
-    expect(Math.sign(acc[3])).toBe(-1);
+    // Float32Array 길이 6 보장 (N=2 × 3 컴포넌트). noUncheckedIndexedAccess 가드 해소.
+    expect(acc[0]!).toBeCloseTo(-acc[3]!, 5);
+    expect(Math.sign(acc[0]!)).toBe(1); // -1에 있는 입자는 +x 방향으로 끌림
+    expect(Math.sign(acc[3]!)).toBe(-1);
   });
 
   it('softening_sq가 close-encounter 발산 방지', () => {


### PR DESCRIPTION
## Summary

PR #233 / #234 QA 에서 **범위 밖 pre-existing** 으로 판정된 2 건의 정적 에러를 일괄 해소.

- **#236**: `packages/core/src/gpu/nbody-force-shader.test.ts` L39-41 TS2532/TS2345 (`noUncheckedIndexedAccess` 가드)
- **#237**: `apps/web/src/components/panels/black-hole-disk-panel.tsx` L19-22 `react-hooks/set-state-in-effect`

## 변경 내용

### #236 — non-null assertion (이슈 권고 a)
\`\`\`diff
- expect(acc[0]).toBeCloseTo(-acc[3], 5);
- expect(Math.sign(acc[0])).toBe(1);
- expect(Math.sign(acc[3])).toBe(-1);
+ // Float32Array 길이 6 보장 (N=2 × 3 컴포넌트).
+ expect(acc[0]!).toBeCloseTo(-acc[3]!, 5);
+ expect(Math.sign(acc[0]!)).toBe(1);
+ expect(Math.sign(acc[3]!)).toBe(-1);
\`\`\`

### #237 — `nuqs` `useQueryState` 전환 (이슈 권고 c, `url-sync.tsx` 일관)
\`\`\`diff
- import { useEffect, useState } from 'react';
+ import { parseAsString, useQueryState } from 'nuqs';

- const [bhMode, setBhMode] = useState<string | null>(null);
- useEffect(() => {
-   setBhMode(new URLSearchParams(window.location.search).get('bh'));
- }, []);
+ const [bhMode] = useQueryState('bh', parseAsString.withOptions({ history: 'replace' }));
\`\`\`

## 선택 근거

- **#236 (a) vs (b) vs (c)**: non-null assertion 선택 — Float32Array 길이가 테스트 컨텍스트에서 정적으로 보장. `?? 0` 폴백은 의도(부호 검증)를 흐리게 함. 같은 파일 L66-68 의 loop 에서 쓰인 `?? 0` 과는 컨텍스트 다름
- **#237 (a) vs (c)**: `useQueryState` 전환 선택 — `url-sync.tsx` 가 이미 nuqs 사용 + `<NuqsAdapter>` provider 가 `app/[locale]/layout.tsx:51` 에 존재. 의존성 추가 없음. `eslint-disable` 보다 구조적 해결

## Behavior Changes

**None** — 양쪽 모두 동일 기능 유지. 단 #237 의 nuqs 전환은 SSR-safe 동작이 기존 `useEffect` 로 null → setBhMode('2') 플로우와 동일하나 내부 구현이 다름 (브라우저 smoke 로 회귀 없음 확인).

## Test plan

- [x] `pnpm -r typecheck` — `packages/core` TS2532/TS2345 해소 확인 (PASS)
- [x] `pnpm -r test` — **apps/web 84/84 + core 163/163 PASS**
- [x] `pnpm prettier --check` — 2 파일 통과
- [x] U+FFFD 0건
- [x] 브라우저 smoke — `http://localhost:3001/ko?bh=2&mode=research` 에서 `[data-testid="bh-disk-panel"]` visible=true, 콘솔 에러 0
  - (`SidePanels` 가 `mode=research|sandbox` 에서만 마운트되는 pre-existing 구조이므로 `?bh=2` 단독 로드는 panel 렌더 대상이 아님 — 일반 `?bh=2` 단독 smoke 가 false 인 것은 회귀 아님)
- [ ] Reviewer 정적 리뷰 통과
- [ ] QA 동적 검증

## 관련

- Closes #236
- Closes #237
- 연관 PR: #233 #234 (QA 에서 pre-existing 분리 권고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)