### PR TITLE
chore(bench): #225 baseline 재측정 (ubuntu median N=10)

### DIFF
--- a/docs/benchmarks/baseline.json
+++ b/docs/benchmarks/baseline.json
@@ -1,55 +1,67 @@
 {
-  "timestamp": "2026-04-15T06:42:40.750Z",
-  "phase": "p3-a-end",
+  "timestamp": "2026-04-19T05:22:30.710Z",
+  "phase": "remeasure",
   "durationMs": 3000,
-  "environment": "playwright-chromium-headless",
+  "environment": "gh-actions-ubuntu-chromium-headless",
   "viewport": "1280x800",
   "scenarios": [
     {
       "name": "idle",
-      "fps": 32.89
+      "fps": 26.09,
+      "samples": 10
     },
     {
       "name": "play-1d",
-      "fps": 30.5
+      "fps": 22.68,
+      "samples": 10
     },
     {
       "name": "play-1y",
-      "fps": 30.32
+      "fps": 27.64,
+      "samples": 10
     },
     {
       "name": "focus-earth",
-      "fps": 90.81
+      "fps": 60.23,
+      "samples": 10
     },
     {
       "name": "focus-neptune",
-      "fps": 96.67
+      "fps": 60.28,
+      "samples": 10
     }
   ],
   "nBody": [
     {
       "n": 10,
-      "fps": 28.59
+      "fps": 27.15,
+      "samples": 10
     },
     {
       "n": 100,
-      "fps": 23.01
+      "fps": 21.28,
+      "samples": 10
     },
     {
       "n": 200,
-      "fps": 18.59
+      "fps": 17.18,
+      "samples": 10
     },
     {
       "n": 1000,
-      "fps": 7.48
+      "fps": 6.97,
+      "samples": 10
     },
     {
       "n": 5000,
-      "fps": 2.07
+      "fps": 1.96,
+      "samples": 10
     },
     {
       "n": 10000,
-      "fps": 1.22
+      "fps": 1.13,
+      "samples": 10
     }
-  ]
+  ],
+  "source_count": 10
 }


### PR DESCRIPTION
## Summary

`bench:baseline-remeasure` workflow 의 ubuntu-latest × 10 회 `bench:scene:sweep` 실측을 `scripts/bench-aggregate-median.mjs` 로 median 집계해 `docs/benchmarks/baseline.json` 갱신.

- trigger: [`workflow_dispatch` run #24621714905](https://github.com/coseo12/astro-simulator/actions/runs/24621714905)
- phase: `remeasure`
- sample_count: 10 (전부 PASS)
- environment: `gh-actions-ubuntu-chromium-headless`

⚠️ **workflow aggregate job 의 PR 자동 생성 단계가 저장소 정책으로 차단**되어 수동 생성. branch push 및 baseline 계산 자체는 정상 완료.
> `GitHub Actions is not permitted to create or approve pull requests.`

## 주요 변화 (scenario fps)

| scenario | 기존 (2026-04-15) | 신규 (ubuntu median) | Δ | samples |
|---|---|---|---|---|
| idle | 32.89 | 26.09 | -20.7% | 10 |
| play-1d | 30.5 | 22.68 | -25.6% | 10 |
| play-1y | 30.32 | 27.64 | -8.8% | 10 |
| focus-earth | 90.81 | **60.23** | **-33.7%** | 10 |
| focus-neptune | 96.67 | **60.28** | **-37.7%** | 10 |

focus-earth/neptune 은 PR #222 CI 경고 수치(-33.7%/-37.7%)와 정확히 일치 → **환경 격차 수렴 확인**.

## 스키마 변경

기존 스키마 유지 + 신규 메타 필드 추가:
- `scenarios[].samples` · `nBody[].samples` (각 항목의 회차 수)
- `source_count: 10` (총 회차)
- `phase: "remeasure"` / `environment: "gh-actions-ubuntu-chromium-headless"`

## 기대 효과

향후 `bench.yml` (PR 이벤트) 의 `bench:scene:sweep` 회귀 경고 0건 유지 기대.

## Behavior Changes

**None** — 데이터 파일만 교체. 앱 런타임 / bench 로직 불변. 회귀 판정 threshold(`-10 fps`) 도 동일.

## 후속 개선 권고

저장소 Settings → Actions → General → **"Allow GitHub Actions to create and approve pull requests"** 체크 시 향후 workflow_dispatch 가 자동 PR 생성 가능. 수동 처리 불필요.

## Test plan

- [x] workflow run 성공 (bench matrix 10/10 PASS)
- [x] `bench-aggregate-median.mjs` 실행 성공 (12개 artifact 집계)
- [x] 스키마 보존 — 기존 bench-scene.mjs diff 비교 호환
- [ ] 머지 후 `bench.yml` (PR 이벤트) 회귀 경고 0건 확인
- [ ] Reviewer / QA 통과

## 관련

- Closes #225
- 자동 생성 시도: https://github.com/coseo12/astro-simulator/actions/runs/24621714905/job/74862654268
- 선행 PR: #238 (workflow 도입)

🤖 workflow_dispatch + 수동 PR 생성 (레포 정책 우회)