### PR TITLE
[#235] bench-scene-real-gpu.mjs vsync 페그 해소

### DIFF
--- a/docs/benchmarks/p2d-real-gpu.json
+++ b/docs/benchmarks/p2d-real-gpu.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-04-14T15:58:27.750Z",
+  "timestamp": "2026-04-19T05:33:26.923Z",
   "env": "chromium --use-angle=metal + rasterization",
   "gpu": {
     "vendor": "Google Inc. (Apple)",
@@ -8,15 +8,23 @@
   "scenarios": [
     {
       "path": "/ko",
-      "fps": 120.05
+      "fps": 1141.19
     },
     {
       "path": "/ko?belt=200",
-      "fps": 120.08
+      "fps": 1007.98
     },
     {
       "path": "/ko?belt=1000",
-      "fps": 120.07
+      "fps": 813.13
+    },
+    {
+      "path": "/ko?belt=5000",
+      "fps": 363.58
+    },
+    {
+      "path": "/ko?belt=10000",
+      "fps": 223.79
     }
   ]
 }

--- a/scripts/bench-scene-real-gpu.mjs
+++ b/scripts/bench-scene-real-gpu.mjs
@@ -18,7 +18,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const outDir = join(__dirname, '..', 'docs', 'benchmarks');
 mkdirSync(outDir, { recursive: true });
 
-// Chromium GPU 활성 플래그 — 환경별 동작 편차 있음
+// Chromium GPU 활성 플래그 — 환경별 동작 편차 있음.
+// #235: vsync 우회(`--disable-frame-rate-limit` + `--disable-gpu-vsync`) 추가.
+// 실 GPU 성능 측정 목적인 이 스크립트에서 RAF 가 60/120Hz 에 페그되면 실제 GPU
+// 한계가 아니라 vsync 상한을 측정하게 된다. #234 (bench-p7-lens3d) 동일 교훈.
 const browser = await chromium.launch({
   headless: true,
   args: [
@@ -27,6 +30,8 @@ const browser = await chromium.launch({
     '--enable-gpu-rasterization',
     '--ignore-gpu-blocklist',
     '--enable-features=Vulkan',
+    '--disable-frame-rate-limit',
+    '--disable-gpu-vsync',
   ],
 });
 const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });


### PR DESCRIPTION
## Summary

#235 (vsync 플래그 확산) DoD "케이스별 판단" 조항 하에 **범위 축소 실행**. 실 GPU 측정이 목적인 `bench-scene-real-gpu.mjs` 에만 플래그 추가. 다른 후보는 검토 결과 본 PR 범위 밖으로 분류.

## 수정 (1 파일 + 데이터 1)

- `scripts/bench-scene-real-gpu.mjs` launch args 에 `--disable-frame-rate-limit` + `--disable-gpu-vsync` 추가
- `docs/benchmarks/p2d-real-gpu.json` 재측정 (M1 Pro Metal ANGLE)

## 실측 변화 (M1 Pro Metal ANGLE)

| path | 기존 (페그) | 신규 | 변화 |
|---|---|---|---|
| /ko | 120.05 | **1141.19** | 9.5× |
| /ko?belt=200 | 120.08 | **1007.98** | 8.4× |
| /ko?belt=1000 | 120.07 | **813.13** | 6.8× |
| /ko?belt=5000 | (누락) | 363.58 | — |
| /ko?belt=10000 | (누락) | 223.79 | — |

페그 상태에서는 모든 시나리오가 120fps 균일 → **N 증가 효과 측정 불가**. 신규 측정은 N 에 반비례하는 실제 GPU 한계 관찰 가능.

## 범위 밖 분류 (검토 완료)

| 스크립트 | 판정 | 근거 |
|---|---|---|
| `bench-scene.mjs` | **후속 #242 분리** | PR #241 로 baseline 정립 직후. 플래그 추가 = baseline 재재측정 유발. 3 옵션(A 즉시/B 지연/C 옵트인) 결정 대기 |
| `browser-verify-black-hole-ray3d.mjs` | 플래그 불필요 | fps > 1 게이트 판정용 (분산/N 반응 측정 아님) |
| `bench-scene-mobile.mjs` | 이미 보유 | 플래그 2 hits 확인 |
| `bench-webgpu.mjs` | 이미 보유 | 플래그 2 hits 확인 |
| `browser-verify-mobile-p4c.mjs` / `p7d.mjs` | 이미 보유 | 각 2 hits |
| `bench-p7-lens3d.mjs` | PR #234 완료 | — |

## Behavior Changes

- `pnpm` script 매핑 없음. 이 스크립트는 직접 `node scripts/bench-scene-real-gpu.mjs` 로 수동 실행 (dev 서버 3001 기동 전제)
- `p2d-real-gpu.json` 은 수동 참조용 (CI 회귀 판정 사용 안 함). baseline 로서의 의미는 제한적

## Test plan

- [x] 실측 bench 실행 — vsync 페그 해소 확인 (위 표)
- [x] prettier / encoding 통과
- [x] dev 서버 정리
- [ ] CI 통과
- [ ] Reviewer / QA

## 관련

- Partially closes #235 (범위 축소 실행, 후속 #242 로 분리)
- 후속: #242 (bench-scene.mjs 처리 의사결정)
- 선례: PR #234 (bench-p7-lens3d 동일 교훈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)