### PR TITLE
[P10-A] #268 Fact-First 원칙 + 로드맵 v2 + 모바일 보류 ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,10 @@ sub-agent에 적응적 질답·설계 같은 multi-turn 세션을 위임할 때,
 
 > 위 `real-lessons` managed-block 은 harness upstream 이 관리하며 업데이트 시 자동 동기화된다. 본 섹션은 프로젝트 고유 해결책/가드를 별도로 박제한다 (block 외부이므로 upstream 업그레이드에 영향받지 않음).
 
+### 프로젝트 원칙 — Fact-First, Visual-Second
+
+모든 데이터/시각/UI 설계 결정은 [`docs/principles/fact-first.md`](docs/principles/fact-first.md) 를 1차 참조. 사실(fact)이 1차 SSoT, 시각 과장은 2차 overlay. 디폴트 `educational` 모드 + 1-클릭/1-URL (`?mode=scientific`) 사실 모드 접근 보장. IAU 2015 ±0.01% / J2000.0 epoch / `uncertainty` 필드. 현행 로드맵은 [`docs/phases/roadmap-v2-solar-precision.md`](docs/phases/roadmap-v2-solar-precision.md) (P10-A #268 박제, 2026-04-20).
+
 ### prettier 컨벤션 충돌 — 프로젝트 고유 해결책 (astro-simulator)
 
 상위 "다운스트림 formatter 재포맷 경계 drift" 교훈의 프로젝트 구현:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ v0.3.0 종합 회귀 287/287 통과 — `docs/benchmarks/p3d-comprehensive-verif
 - **P7 — 관측가능우주**
 - **P8 — 물리 샌드박스 확장**
 
-상세: [`docs/phases/roadmap.md`](./docs/phases/roadmap.md)
+상세: [`docs/phases/roadmap-v2-solar-precision.md`](./docs/phases/roadmap-v2-solar-precision.md) (현행, 진행 중). 초기 구상은 [`roadmap-v1-cosmic-scale.md`](./docs/phases/roadmap-v1-cosmic-scale.md) (archived) 참조.
 
 ---
 
@@ -168,7 +168,9 @@ v0.3.0 종합 회귀 287/287 통과 — `docs/benchmarks/p3d-comprehensive-verif
 - [아키텍처 결정서](./docs/phases/architecture.md)
 - [디자인 토큰](./docs/phases/design-tokens.md)
 - [UI 아키텍처](./docs/phases/ui-architecture.md)
-- [확장 로드맵](./docs/phases/roadmap.md)
+- [확장 로드맵 v2 — 태양계 정밀화 (현행)](./docs/phases/roadmap-v2-solar-precision.md)
+- [확장 로드맵 v1 — 관측가능우주 (archived)](./docs/phases/roadmap-v1-cosmic-scale.md)
+- [Fact-First 원칙](./docs/principles/fact-first.md)
 
 ### Phase별
 

--- a/docs/decisions/20260420-mobile-support-suspension.md
+++ b/docs/decisions/20260420-mobile-support-suspension.md
@@ -1,0 +1,122 @@
+# ADR: 모바일 지원 무기한 보류 (Suspended, Not Deprecated)
+
+- **상태**: Accepted
+- **날짜**: 2026-04-20
+- **결정자**: architect / PM (P10-A #268)
+- **관련**: P10 계약 #266, 원칙 `docs/principles/fact-first.md`, 로드맵 v2 `docs/phases/roadmap-v2-solar-precision.md`, 선행 이슈 #219 (iOS Yoshida4 bench — close 하지 않음), 구현 파일 `apps/web/src/core/is-mobile.ts` (P7-E #210/#220)
+
+## 배경
+
+P1~P9 구현 과정에서 모바일(iOS/Android) 지원은 다음 3단계를 거쳤다:
+
+1. **P1~P3**: 모바일 best-effort — WebGL2 fallback 으로 기본 렌더링만 보장.
+2. **P4~P6**: WebGPU 확산과 함께 "고성능 기능은 데스크톱 전용" 분기 누적. `isMobile && !cap.webgpu` 분기로 경고 배너 표시 (`apps/web/src/components/sim-canvas.tsx`).
+3. **P7~P9**: 렌더 복잡도 (중력렌즈 3D, Yoshida 4차 장기 적분, 고리 shader 3층) 가 모바일 한계를 초과. #219 (iOS Safari 17.4+ 실기기 Yoshida4 벤치 수동 측정) 가 수개월 open 상태로 방치.
+
+P10 착수 시점(2026-04-20)에 PM 계약에서 모바일 경로의 전략적 재정의가 제기되었다. **"영구 폐기"** 로 프레이밍할 경우:
+
+- 기술 성숙도는 시간 함수 — 모바일 GPU (Apple M-series, Snapdragon 8 Gen 4+) 는 빠르게 향상 중.
+- 코드상 `is-mobile.ts` / 경고 분기 / `mobile-webgpu-best-effort` 알림 키 등은 유지하면서 실제 지원은 제공하지 않는 **죽은 코드 부채화** 위험.
+- 재도전 조건이 박제되지 않으면 "왜 보류했는지" 자체가 drift.
+
+Gemini 교차검증(2026-04-20) 에서 "영구 폐기" 프레이밍이 기술 성숙도 가변성 / 죽은 코드 부채화 리스크에 비추어 부적절하다는 지적을 받았고, Claude 설계에서 **"무기한 보류 + 재도전 조건 ADR"** 로 프레이밍 변경을 수용했다 (P10 계약 이견 수용 4건 중 하나).
+
+## 후보 비교
+
+### 축 — 모바일 경로의 전략적 위치
+
+| 축 / 후보               | (a) **영구 폐기** (Deprecated)                                 | (b) **무기한 보류** (Suspended, 본 ADR 채택)                                   | (c) **best-effort 유지** (현 상태 지속)          |
+| ----------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| **코드 정책**           | `is-mobile.ts` 삭제 / 모바일 분기 전부 제거 / 모바일 접속 차단 | `is-mobile.ts` 유지 / 분기 단순화 / 진입 시 **Graceful Degradation 모달** 표시 | 현재 분기 유지 (경고 배너 + WebGL fallback 시도) |
+| **사용자 경험**         | 모바일 접속 시 "데스크톱 브라우저 사용" 오류 페이지            | 모바일 접속 시 명시 안내 + 제한된 기능 진입 가능 (`?mode=scientific` 등)       | 현 상태 — 경고 + 일부 기능 누락 + 성능 저하      |
+| **재도전 비용**         | 폐기 코드 복구 비용 고 — 전체 재설계 필요                      | 낮음 — tier preset (`tier-c`) 경로에 재진입                                    | 이미 경로 있음 (단, 품질 관리 부담)              |
+| **죽은 코드 부채**      | 즉시 해소                                                      | **단순화** 후 유지. 명시 가드 문서화                                           | 누적 (가장 나쁨)                                 |
+| **기술 트렌드 민감도**  | 기술 성숙 후에도 재진입 모멘텀 약함                            | ADR 재도전 조건 트리거 감지 시 재평가 자연스러움                               | 자동 재평가 없음 — drift                         |
+| **현재 기능 범위 영향** | scope 감소 (순수 데스크톱)                                     | scope 유지 (모바일 Graceful Degradation 경로만 축소)                           | scope 유지 (고비용)                              |
+
+**결정**: **(b) 무기한 보류** 채택.
+
+## 결정
+
+### 1. 보류 선언
+
+모바일(iOS/Android, 태블릿 포함) **공식 지원** 은 P10 ~ P16 범위에서 **보류**한다.
+
+- "공식 지원" = 품질 게이트 (CI 성능 벤치, 시각 검증, 회귀 테스트) 대상에 포함하는 것.
+- 보류 기간 동안 모바일 사용자는 **best-effort 경로** 로 접속 가능하되, 기능·성능·정확도 DoD 는 보장되지 않는다.
+
+### 2. 코드 정책 — 단순화 후 유지
+
+- `apps/web/src/core/is-mobile.ts` — **유지**. iPadOS 13+ desktop UA 우회 로직 포함.
+- `apps/web/src/components/sim-canvas.tsx` 의 모바일 분기 — **단순화**. 현재 WebGPU-mobile 분기가 `?tier=c` 프리셋으로 일반화되기 전까지는 현 구조 유지.
+- `mobile-webgpu-best-effort` 알림 키 — **유지**. `tier-c` 프리셋 도입(P11) 시 `tier-c-graceful-degradation` 키로 대체 검토.
+- 모바일 테스트 (`is-mobile.test.ts`) — **유지**. 감지 로직 회귀 방지.
+
+### 3. Graceful Degradation UX
+
+모바일 접속 시 아래를 **명시적으로 안내**한다:
+
+1. **진입 모달** (최초 접속 시 1회, dismissable):
+   - "현재 모바일 환경은 공식 지원 대상이 아닙니다. 일부 기능과 성능이 제한됩니다."
+   - 옵션: `[그대로 계속]` / `[데스크톱에서 방문하기 (링크 복사)]`
+   - `localStorage.astro:mobile-degradation-dismissed` 로 재표시 제어.
+2. **기능 제한 표시**:
+   - `educational` 모드 → 파티클 축소, LOD 공격적
+   - `scientific` 모드 → 권장 (sub-pixel 렌더가 모바일에서도 큰 문제 없음)
+   - 중력렌즈 3D / 고리 shader 3층 → 기본 비활성화 (`?features=advanced` 로 옵트인)
+3. **재접속 시**: 배너 없음. 사용자가 이미 인지.
+
+### 4. tier preset 전략 초안 (P11 에서 1급 설계 — 본 ADR 스케치)
+
+P11 Visual Foundation 에서 `is-mobile.ts` 를 `detect-gpu-tier.ts` 로 **승격 리팩토링** 한다. 모바일 감지는 tier 입력 중 하나로 흡수.
+
+| Tier       | GPU 감지 기준                          | 프로파일                                                | 모바일 처리                             |
+| ---------- | -------------------------------------- | ------------------------------------------------------- | --------------------------------------- |
+| **tier-a** | discrete GPU + WebGPU + VRAM > 4GB     | LOD 보수적 / 파티클 50k+ / Shadow 2048² / MSAA 8×       | 해당 없음 (데스크톱 전용)               |
+| **tier-b** | integrated GPU + WebGPU, 또는 M1+ iPad | LOD 중간 / 파티클 20k / Shadow 1024² / MSAA 4×          | **M1+ iPad 만 진입 허용**               |
+| **tier-c** | WebGL2 fallback, 또는 저전력 모바일    | LOD 공격적 / 파티클 5k / Shadow 512² 또는 비활성 / FXAA | **대부분 모바일 (Android/구형 iPhone)** |
+
+- tier 감지 조합: `navigator.gpu` + `GPUAdapter.requestAdapterInfo()` + `devicePixelRatio` + `hardwareConcurrency` + `detectIsMobile()`.
+- **사용자 override**: `?tier=a|b|c` URL 파라미터 (디버깅 + 사용자 자율성).
+- `tier-c` 진입 시 Graceful Degradation 모달 자동 표시 (본 ADR §3 구현).
+- 상세 설계 및 구현은 **P11 착수 시 별도 ADR** (`docs/decisions/<YYYYMMDD>-tier-preset-design.md`).
+
+### 5. 관련 이슈 처리
+
+- **#219** (iOS Safari 17.4+ 실기기 Yoshida4 bench 수동 측정) — **close 하지 않음**. 보류 기간 중에도 향후 재도전 시 baseline 으로 활용.
+- **우선순위 하향**: 기존 `priority:low` 유지. 재도전 트리거 발생 시 `priority:medium` 으로 승격.
+- **라벨**: `status:suspended` (신규 라벨 도입 검토 — P10-A 범위 외, 후속 이슈).
+
+## 결과 및 재검토 조건
+
+### 결과 (즉시)
+
+- 모바일 지원은 "best-effort + Graceful Degradation" 으로 고정.
+- 모바일 성능/기능 회귀 리포트는 본 보류 해제 전까지 **non-blocking**. 관찰 목적으로만 수집.
+- P11 에서 `tier-c` 프리셋 구현 시 본 ADR §3 Graceful Degradation 을 구체 UI 로 실현.
+
+### 재도전 트리거 (아래 중 2개 이상 충족 시 재평가)
+
+1. **기술 성숙**: WebGPU 지원 모바일 브라우저 점유율 > 50% (Caniuse baseline 기준).
+2. **하드웨어 성숙**: 주력 모바일 GPU (Apple A-series 최신, Snapdragon 8 Gen 5+) 에서 WebGPU compute 성능 > 현재 데스크톱 integrated GPU 수준.
+3. **사용자 수요**: 모바일 접속 비율 > 20% (Vercel Analytics 또는 자체 telemetry 기준 — P16 배포 이후 측정 가능).
+4. **경쟁 도구 레퍼런스**: Solar System Scope / Universe Sandbox / NASA's Eyes 등 주요 경쟁 도구가 모바일 정식 지원을 선언.
+
+### 재검토 시 체크리스트
+
+- [ ] 현재 `tier-c` 프리셋 실측 성능 (fps, memory, power) 을 모바일 실기기 (최소 5종) 에서 측정
+- [ ] P11 Floating Origin / LOD / distance scale 모드가 모바일에서 정상 동작하는지 검증
+- [ ] 모바일 UX 리뷰 — `educational` 디폴트 vs `scientific` 디폴트 중 모바일 첫 인상에 적합한 쪽 선택
+- [ ] 신규 ADR 작성 — `docs/decisions/<YYYYMMDD>-mobile-support-resumption.md` 로 본 ADR supersede
+
+## 참조
+
+- P10 계약: [../phases/p10-plan.md](../phases/p10-plan.md) (#266 merged)
+- 원칙: [../principles/fact-first.md](../principles/fact-first.md)
+- 로드맵 v2: [../phases/roadmap-v2-solar-precision.md](../phases/roadmap-v2-solar-precision.md)
+- P7-E 모바일 감지 도입: `apps/web/src/core/is-mobile.ts` (#210, #220)
+- 보류 상태 이슈: #219 (iOS Yoshida4 실기기 bench — 유지)
+
+## §Amendments
+
+(없음 — 초판)

--- a/docs/phases/product-spec.md
+++ b/docs/phases/product-spec.md
@@ -123,7 +123,7 @@
 
 ## 5. 로드맵
 
-상세: `docs/phases/roadmap.md` 참조.
+상세: `docs/phases/roadmap-v2-solar-precision.md` 참조 (초기 구상은 `roadmap-v1-cosmic-scale.md` archived).
 
 | Phase | 범위                 | 완결 제품                   |
 | ----- | -------------------- | --------------------------- |
@@ -286,7 +286,9 @@ type: feat | fix | refactor | test | docs | chore
 ## 부록
 
 - 아키텍처 결정: `docs/phases/architecture.md`
-- 확장 로드맵: `docs/phases/roadmap.md`
+- 확장 로드맵 (현행 v2): `docs/phases/roadmap-v2-solar-precision.md`
+- 확장 로드맵 (원안 v1, archived): `docs/phases/roadmap-v1-cosmic-scale.md`
+- 프로젝트 원칙: `docs/principles/fact-first.md`
 - P1 스프린트 계약: `docs/phases/P1-solar-system-mvp.md`
 - 프로젝트 원칙: `CLAUDE.md`
 

--- a/docs/phases/roadmap-v1-cosmic-scale.md
+++ b/docs/phases/roadmap-v1-cosmic-scale.md
@@ -1,4 +1,43 @@
-# 확장 로드맵
+# 확장 로드맵 v1 — 관측가능우주 (Cosmic Scale)
+
+> **Status**: Archived (v2 에 의해 P8 이후 범위 보류)
+> **박제일 (v1)**: P1 착수 시점
+> **v2 로 이관일**: 2026-04-20 (P10-A #268)
+> **Successor**: [roadmap-v2-solar-precision.md](roadmap-v2-solar-precision.md)
+
+## v2 안내
+
+본 문서는 프로젝트 **초기 로드맵 (P1~P8)** 을 박제한다. "태양계 (P1) → 근거리 항성 (P4) → 은하 (P6) → 관측가능우주 (P7) → 가상 천체 (P8)" 의 스케일 확장 경로를 원안으로 삼았다.
+
+**P1~P9 구현 과정에서 다음 현실이 누적**되어 후속 방향을 재조정했다 (상세: [roadmap-v2-solar-precision.md](roadmap-v2-solar-precision.md) §재조정 배경):
+
+- 태양계 내부 정밀도 부채 (IAU 2015 대조 미수행)
+- 시각 원칙 부재 (`educational` / `scientific` 토글 없음)
+- 모바일 경로 경직
+- 상위 원칙 박제 선행 필요
+
+**v2 범위** (2026-04-20 박제, 32~47 영업일):
+
+- P10 Fact Audit + 시각 원칙 정비 (진행 중)
+- P11 Visual Foundation (Floating Origin + LOD + tier preset)
+- P12 Texture Pipeline
+- P13 토성계 / P14 천·해계 / P15 소행성대·카이퍼대
+- P16 배포 + 기술 부채 청산
+
+**v1 의 다음 항목은 본 프로젝트 생애주기 내에서 보류** (v3 후보):
+
+- 근거리 100광년 항성 카탈로그 (Gaia DR3)
+- 외계행성 / 성운·성단
+- 은하 / 은하단 / 우주거대구조
+- 가상/이론 천체 (웜홀 등)
+
+보류 결정은 원칙 [Fact-First, Visual-Second](../principles/fact-first.md) 박제와 함께 이뤄졌다. v2 완료 후 사용자 수요 / 기술 성숙도 / 프로젝트 포지셔닝을 재평가하여 v3 진입 여부를 결정한다.
+
+---
+
+> **이하 내용은 v1 원안 (역사 박제)**. 실제 진행 중인 Phase 는 [roadmap-v2-solar-precision.md](roadmap-v2-solar-precision.md) 참조.
+
+---
 
 프로젝트: 웹 기반 천체물리 시뮬레이터
 지향: 교육 + 연구 시각화 + 몰입 탐험 + 물리 샌드박스 (모두)

--- a/docs/phases/roadmap-v2-solar-precision.md
+++ b/docs/phases/roadmap-v2-solar-precision.md
@@ -1,0 +1,176 @@
+# 로드맵 v2 — 태양계 정밀화 (Solar Precision)
+
+> **Status**: Active
+> **박제일**: 2026-04-20 (P10-A #268)
+> **Supersedes**: `roadmap-v1-cosmic-scale.md` 의 P8 이후 (관측가능우주 확장) 는 **보류**
+> **Precedes**: P10 Fact Audit 완료 후 P11~P16 순차 진행
+
+---
+
+## 재조정 배경
+
+v1 로드맵은 "관측가능우주 확장"(P1 → P7) 을 최종 목표로 설정했다. P1~P9 구현 과정에서 다음 현실이 누적되었다:
+
+1. **태양계 내부 정밀도 부채** — IAU 2015 대조 미수행, 과장 배수 암묵 상수, 공식 uncertainty 부재.
+2. **시각 원칙 부재** — 과장 모드와 사실 모드 토글 없음. 사용자는 과장된 화면만 접근 가능.
+3. **모바일 경로 경직** — 모바일 감지 후 단순 폐기/경고 → 재도전 기회 차단.
+4. **신규 Phase 확장 이전의 basis 정비 필요** — 상위 원칙("Fact-First, Visual-Second") 박제가 선행되어야 후속 Phase 가 일관.
+
+v2 는 **태양계 정밀도·시각 원칙·기술 부채**를 먼저 정리한 뒤 위성·고리·소행성·배포로 확장한다. v1 의 은하/우주거대구조 확장은 본 프로젝트 생애주기 내에서는 **보류** (재검토는 v3 범주).
+
+---
+
+## Phase 개요
+
+| Phase   | 테마                        | 규모  | 상태        | 비고                                                                         |
+| ------- | --------------------------- | ----- | ----------- | ---------------------------------------------------------------------------- |
+| **P10** | Fact Audit + 시각 원칙 정비 | 9~13d | **진행 중** | 상위 원칙 박제 + 데이터 감사 + `educational`/`scientific` 토글 + 정확도 이슈 |
+| **P11** | Visual Foundation           | 6~10d | 계획 중     | Floating Origin + LOD 3단계 + distance scale + **tier preset 1급 설계**      |
+| **P12** | Texture Pipeline            | 5~8d  | 계획 중     | 30+ body PBR + normalMap + cloud layer + ring detail (Cassini 간극 등)       |
+| **P13** | 토성계                      | 5~7d  | 계획 중     | 주요 위성 9 (Titan/Enceladus 등) + 고리 정밀화 + 공명 구조                   |
+| **P14** | 천왕성·해왕성계             | 4~6d  | 계획 중     | 주요 위성 각 5~6 + 자전축 기울기 특성 + 고리 암고리                          |
+| **P15** | 소행성대 + 카이퍼대         | 5~8d  | 계획 중     | JPL SBDB 수십만 샘플 + BH N-body 폴백 + GPU compute 통합                     |
+| **P16** | 배포 + 기술 부채 청산       | 3~5d  | 계획 중     | Vercel/Netlify 공식 배포 + CI 성능 게이트 + `docs/reports/` 자동 갱신        |
+
+**총: 32~47 영업일**
+
+---
+
+## 의존 관계
+
+```
+P10 (Fact Audit)
+   ↓
+P11 (Visual Foundation)
+   ↓
+P12 (Texture Pipeline)
+   ↓
+P13 (토성계) ─┐
+P14 (천/해계) ─┼── 병렬 가능 (P12 까지 선행 필수)
+P15 (소행성) ─┘
+   ↓
+P16 (배포 + 부채 청산)
+```
+
+---
+
+## P10 — Fact Audit + 시각 원칙 정비 (진행 중)
+
+**계약 문서**: [p10-plan.md](p10-plan.md) (#266 merged)
+
+핵심 산출물:
+
+- `docs/principles/fact-first.md` — 상위 원칙 박제 (P10-A #268)
+- `docs/decisions/20260420-mobile-support-suspension.md` — 모바일 보류 + 재도전 조건 (P10-A)
+- `packages/shared/src/types/celestial.ts` — `dataSource`/`lastVerified`/`uncertainty`/`epoch`/`colorSource` 필드 추가 (P10-B)
+- `packages/shared/src/constants/solar-system.ts` — IAU 2015 전수 대조 + 수정 (P10-B)
+- 뷰 모드 스토어 + URL sync + 배지 UI + 온보딩 + 크레딧 뷰 (P10-C)
+- #261 / #263 / #255 정확도 이슈 소화 (P10-D)
+- P9 baseline 대비 벤치 회귀율 < 5% (P10-D.5)
+
+---
+
+## P11 — Visual Foundation (계획)
+
+**핵심 산출물**:
+
+- **Floating Origin** — 카메라 원점을 주변 body 에 동적으로 이동시켜 float32 좌표 정밀도 유지. 태양계 + 위성 뷰에서 jitter 해소.
+- **LOD 3단계** — `high` (근거리, full mesh + PBR) / `mid` (중거리, impostor 텍스처) / `low` (원거리, billboard). 카메라 거리 기준 자동 전환.
+- **Distance Scale 모드** — `log-distance` / `linear-distance` / `uniform-distance` 3종 모드. `scientific` 모드에서 특히 유용.
+- **Tier Preset 1급 설계** — `tier-a`(데스크톱 고성능 GPU) / `tier-b`(데스크톱 중급 또는 고성능 모바일) / `tier-c`(모바일 또는 저전력). `is-mobile.ts` 를 `detect-gpu-tier.ts` 로 리팩토링. 각 tier 는 (LOD 임계, 파티클 상한, shadow 해상도, AA) 프로파일.
+
+### Tier Preset 스케치 (P10-A 박제 — P11 구현 시 참조)
+
+| Tier       | GPU 조건 (detect 기준)                   | LOD 임계 | 파티클 상한 | Shadow 해상도    | AA      | 대상                       |
+| ---------- | ---------------------------------------- | -------- | ----------- | ---------------- | ------- | -------------------------- |
+| **tier-a** | discrete GPU, WebGPU, VRAM > 4GB         | 보수적   | 50k+        | 2048²            | MSAA 8× | 데스크톱 고성능            |
+| **tier-b** | integrated GPU + WebGPU, 또는 M1+ 태블릿 | 중간     | 20k         | 1024²            | MSAA 4× | 데스크톱 중급, 고급 모바일 |
+| **tier-c** | WebGL2 fallback, 또는 저전력 모바일      | 공격적   | 5k          | 512² 또는 비활성 | FXAA    | 모바일, 저전력 데스크톱    |
+
+tier 감지는 `navigator.gpu` + `GPUAdapter.requestAdapterInfo()` + `devicePixelRatio` + `hardwareConcurrency` 조합. 명시 override (`?tier=c`) 지원으로 사용자가 강제 전환 가능. 상세 설계는 P11 착수 시 ADR 작성.
+
+- **모바일 Graceful Degradation 모달** — `tier-c` 진입 시 자동 안내 + `scientific` 디폴트 + 파티클 축소 안내 (모바일 보류 ADR §"Graceful Degradation UX" 상세).
+
+**관련 이슈**: #256 (에너지 보존 DoD), #247 (Osculating 동기화 — P9 흡수되었으나 LOD 전환 시 재검증 필요).
+
+---
+
+## P12 — Texture Pipeline (계획)
+
+**핵심 산출물**:
+
+- **PBR 머티리얼** — 30+ body (태양/행성/주요 위성) albedo + roughness + metalness 맵.
+- **Normal 맵** — 지형 디테일 (화성 올림푸스 화산, 달 크레이터, Iapetus 이분경계).
+- **Cloud Layer** — 지구/금성/목성/토성 투명 cloud shell (자전 속도 차등).
+- **Ring Detail** — 토성 Cassini 간극 + 목성 Halo/Main/Gossamer 세분화 (P9 기반 확장).
+- **텍스처 라이선스 감사** — NASA/ESA/JAXA public domain 확인, attribution JSON 에 박제.
+
+**관련 이슈**: #257 (고리 shader 섀도우 매핑 — 본 Phase 로 이관).
+
+---
+
+## P13 — 토성계 (계획)
+
+**핵심 산출물**:
+
+- **주요 위성 9**: Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus, Phoebe.
+- **공명 구조**: Mimas-Tethys 4:2, Enceladus-Dione 2:1, Titan-Hyperion 4:3.
+- **고리 정밀화**: A/B/C/F 고리 세분화, Cassini 간극, Encke 간극, 양치기 위성(Prometheus/Pandora).
+- **궤도 정확도**: 주기 ±1%, 공명 잔차 ±1% (P9 Galilean 기준 계승).
+
+---
+
+## P14 — 천왕성·해왕성계 (계획)
+
+**핵심 산출물**:
+
+- **천왕성 위성 5**: Miranda, Ariel, Umbriel, Titania, Oberon. 자전축 97.8° 기울기 특성 반영.
+- **해왕성 위성 2**: Triton (역행 궤도), Nereid (고이심률 0.75).
+- **고리**: 천왕성 13고리 (암고리 중심), 해왕성 5고리 (아크 구조).
+- **해왕성 트로이 소행성**: L4/L5 대표 샘플 10+ (P15 선행 연동).
+
+---
+
+## P15 — 소행성대 + 카이퍼대 (계획)
+
+**핵심 산출물**:
+
+- **JPL SBDB (Small-Body Database) 샘플**: 수십만 급 N-body. BH (Barnes-Hut) + WebGPU compute.
+- **Kirkwood 간극** 시각화: 주기 2:1, 3:1, 5:2, 7:3 공명.
+- **카이퍼대 객체**: Pluto, Eris, Makemake, Haumea + Plutinos/cubewanos 샘플.
+- **GPU compute 폴백**: WebGPU 미지원 시 WASM BH N-body + tier-c 자동 축소.
+
+**관련 이슈**: v1 로드맵 P3 의 카이퍼대·오르트 구름을 본 Phase 로 승격 (규모 축소 — 오르트 구름은 보류).
+
+---
+
+## P16 — 배포 + 기술 부채 청산 (계획)
+
+**핵심 산출물**:
+
+- **Vercel/Netlify 공식 배포**: `main=production` / `develop=staging` / PR=preview (CLAUDE.md 브랜치 전략 완성).
+- **CI 성능 게이트**: `bench-scene*.mjs` 회귀율 ≥ 5% 시 자동 차단.
+- **`docs/reports/` 자동 갱신**: 각 Phase 완료 시 성능·정확도 리포트 자동 생성.
+- **기술 부채 청산**: TODO 주석 → 이슈 승격, unused export 제거, 타입 strict 강화.
+
+---
+
+## 비-범위 (v2 에서 다루지 않음)
+
+- ❌ 항성 카탈로그 (Gaia DR3) → v1 P4 의 근거리 100광년 확장. **보류** (v3 후보).
+- ❌ 외계행성 → v1 P5. **보류**.
+- ❌ 은하/은하단/우주거대구조 → v1 P6/P7. **보류**.
+- ❌ 가상/이론 천체 (웜홀 등) → v1 P8. **보류**.
+
+---
+
+## 참조
+
+- v1 로드맵: [roadmap-v1-cosmic-scale.md](roadmap-v1-cosmic-scale.md) — 초기 설계 및 은하/우주거대구조 확장 원안
+- P10 계약: [p10-plan.md](p10-plan.md) (#266 merged)
+- 원칙: [../principles/fact-first.md](../principles/fact-first.md)
+- 모바일 보류 ADR: [../decisions/20260420-mobile-support-suspension.md](../decisions/20260420-mobile-support-suspension.md)
+
+## §Amendments
+
+(없음 — 초판)

--- a/docs/principles/fact-first.md
+++ b/docs/principles/fact-first.md
@@ -1,0 +1,114 @@
+# Fact-First, Visual-Second — 프로젝트 원칙
+
+> **Status**: Active
+> **박제일**: 2026-04-20 (P10-A #268)
+> **적용 범위**: 모든 Phase 의 데이터/시각/UI 설계 결정
+
+---
+
+## 선언
+
+> **사실(fact) 기반이 1차, 시각적 표현(visual)은 2차 overlay.**
+> 디폴트 UX 는 교육용 관례(`educational` 모드, 과장 + 명시 배지)를 유지하되,
+> 사용자는 **항상 1-클릭/1-URL 로 사실 모드(`scientific`)에 접근 가능**해야 한다.
+> 모든 과장은 **명시적으로 표시**되어야 하고, 사용자가 인지할 수 있어야 한다.
+
+본 프로젝트(astro-simulator)는 "**교육 + 연구 시각화 + 몰입 탐험 + 물리 샌드박스**"를 동시에 지향한다([docs/phases/roadmap-v1-cosmic-scale.md](../phases/roadmap-v1-cosmic-scale.md) 참조). 서로 다른 청중을 한 시스템이 수용하려면 **사실 데이터는 단일 진실 원천(SSoT)** 으로 유지하고, **시각적 과장은 인지 가능한 overlay** 로 한정해야 한다.
+
+---
+
+## 원칙 상세
+
+### 1. 데이터 무결성 — 사실은 수정 가능한 overlay 의 아래에 박제
+
+- 모든 천체(행성·위성·왜소행성·소행성 등)는 `packages/shared/src/constants/solar-system.ts` 에 **실측값** 으로 기록한다.
+- 과장(크기 ×N, 거리 ×M)은 **렌더 타임** 에 적용하며, **데이터 파일을 수정하지 않는다**.
+- 시각 효과(고리 두께, glow halo, ring shader tint 등) 는 `educational` 모드에서 과장되어도 **원본 치수는 JSON 에 보존**.
+
+### 2. 정밀도 기준 — IAU 2015 ±0.01%
+
+| 기준     | 내용                                                             |
+| -------- | ---------------------------------------------------------------- |
+| **1차**  | IAU 2015 Nominal Values for Stars, Planets, and Planetary Bodies |
+| **2차**  | NASA JPL Horizons / Planetary Fact Sheet                         |
+| **3차**  | Peer-reviewed 최신 관측 논문 (IAU 공식값 없는 body 한정)         |
+| **공차** | ±0.01% (IAU 공식값 대비)                                         |
+
+**±0.01% 초과 발견 시 즉시 JSON 수정** (P10-B DoD). 과거 값은 git history 에 보존된다.
+
+### 3. 불확실성 명시 — "우리가 얼마나 모르는가" 도 과학적 사실
+
+- IAU 공식값이 없는 body (소행성·혜성·외곽 위성 등) 는 `uncertainty` 필드로 오차 범위를 기록한다.
+- 예: `{ mass: 1.25e20, uncertainty: { mass: 0.15 } }` — 질량 15% 오차 표시.
+- UI 에서 `scientific` 모드일 때 오차 막대(error bar)로 시각화할 수 있도록 데이터 단계에서 구조화한다.
+
+### 4. 시간 기준 — J2000.0 Epoch 명시
+
+- **공간 좌표만큼 시간 기준도 사실이다**. 궤도 요소·위상각·각속도는 모두 J2000.0 (TDB = 2000-01-01 12:00:00) 을 epoch 으로 기록한다.
+- 각 body 에 `epoch: "J2000.0"` 필드(또는 `epoch: "2451545.0 TDB"`)를 박제.
+- 비-J2000.0 데이터(최신 관측 등) 는 변환 후 기록하거나, 원본 epoch 을 명시 + 계산 엔진에서 변환.
+
+### 5. 출처 추적 — `dataSource` / `lastVerified`
+
+- 각 body JSON 에 아래 2개 필드 필수:
+  - `dataSource`: 문자열 또는 배열 (예: `"IAU 2015"` / `["IAU 2015", "JPL Horizons (2024-06)"]`)
+  - `lastVerified`: ISO 날짜 (예: `"2026-04-22"`) — P10-B 감사일 이후 업데이트
+- `uncertainty` 필드 사용 시 `dataSource` 에 "IAU 공식값 부재 — NASA JPL 2024 관측" 등 대안 출처 명시.
+
+### 6. 색상 감사 — 관측 기반 vs 아티스트 선택
+
+- `colorHint.hex` 필드는 **렌더링 편의** 용. 다음 2가지를 구분한다:
+  - `colorSource: "observed"` — Cassini/Voyager 등 실제 관측 기반
+  - `colorSource: "artistic"` — 시각적 구분을 위한 아티스트 선택
+- `scientific` 모드에서는 관측 기반 색상만 사용하거나, 아티스트 색상임을 배지로 표시한다.
+
+---
+
+## 과장 표시 규약 (Explicit Exaggeration)
+
+모든 과장은 **사용자가 인지할 수 있어야** 한다. `educational` 디폴트 모드에서도 다음을 만족한다:
+
+1. **상수 박제**: 과장 배수(`sunScale × 20`, `planetScale × 200` 등)는 **단일 파일**에 상수로 박제하고, 렌더 타임 시 JSON 실측값과 곱한다.
+2. **Hover/Focus 배지**: 각 body 에 마우스/포커스 시 "태양 ×20 과장 중" 등 **현재 스케일 표시**.
+3. **첫 진입 온보딩**: 첫 방문 시 툴팁 — "시각적 이해를 위해 크기가 과장되어 있습니다. [실제 비율로 보기]"
+4. **크레딧 뷰**: About 모달 또는 설정 패널에 IAU / NASA JPL / Gaia DR3 등 데이터 출처 attribution + 현재 적용된 과장 요약 ("크기 ×20 / 거리 ×1.0").
+5. **모드 토글**: 헤더 또는 설정 패널에서 `educational` ↔ `scientific` 1-클릭 전환. 키보드 단축키 `m` 권고.
+6. **URL 동기화**: `?mode=scientific` 로 북마크/공유 가능. 링크로 방문 시 해당 모드로 진입.
+
+구현 상세 DoD: [docs/phases/p10-plan.md](../phases/p10-plan.md) P10-C.
+
+---
+
+## `scientific` 모드 UX 보호
+
+`scientific` 모드에서는 대부분의 body 가 sub-pixel 로 표시되어 **빈 화면 이탈 리스크**가 있다 (Gemini 교차검증 지적, 2026-04-20). 이를 방어하기 위해:
+
+- 최초 `?mode=scientific` 진입 시 **안내 배너** 자동 표시 — "실제 비율에서는 대부분 천체가 매우 작게 보입니다. 줌 인/검색으로 특정 천체에 초점 맞추세요."
+- 사용자 dismiss 가능 (`localStorage.astro:scientific-notice-dismissed`).
+- 뷰포트에 `data-testid="scientific-mode-notice"` 노드 존재 (E2E 검증).
+
+---
+
+## 예외 — 시각 원칙이 사실을 이기는 경우
+
+다음 3가지는 **시각적 가독성** 이 우선한다. 단, 원본 사실은 JSON 에 보존한다:
+
+1. **궤도선 두께** — 실제 두께 0. 렌더는 1~2px 고정.
+2. **위성 점 표시 (줌 아웃 시)** — sub-pixel 위성에 최소 가시 크기(~3px) 적용. `?satellites=zoomed` 옵트인으로 실측 모드 접근 가능 (#245).
+3. **glow halo / corona** — 항성·태양 표면의 시각 효과. 광도 측정 데이터는 별도 필드.
+
+각 예외는 `scientific` 모드에서 해제되거나 명시 배지가 붙는다.
+
+---
+
+## 참조
+
+- 상위 계약: [docs/phases/p10-plan.md](../phases/p10-plan.md)
+- 로드맵 v2: [docs/phases/roadmap-v2-solar-precision.md](../phases/roadmap-v2-solar-precision.md)
+- 모바일 보류 ADR: [docs/decisions/20260420-mobile-support-suspension.md](../decisions/20260420-mobile-support-suspension.md)
+- CLAUDE.md: 프로젝트 루트 `CLAUDE.md` 프로젝트 고유 섹션에서 본 문서 참조
+- 교차검증 근거: Gemini 2026-04-20 — 합의 4건 / 이견 수용 4건 / 고유 발견 6건
+
+## §Amendments
+
+(없음 — 초판)


### PR DESCRIPTION
## Summary

- **상위 원칙 박제**: `docs/principles/fact-first.md` — Fact-First, Visual-Second. 디폴트 `educational` + 1-클릭 `scientific` 접근, IAU 2015 ±0.01%, J2000.0 epoch, `dataSource`/`lastVerified`/`uncertainty`/`colorSource` 필드 규약, 과장 표시 6규약, `scientific` 모드 UX 보호, 3건 예외.
- **로드맵 재조정**: v1 (`roadmap.md` → `roadmap-v1-cosmic-scale.md` rename + v2 안내 블록) / v2 (`roadmap-v2-solar-precision.md` 신규, P10~P16 32~47d).
- **모바일 보류 ADR**: `docs/decisions/20260420-mobile-support-suspension.md` — Gemini 이견 수용 ("영구 폐기" → "무기한 보류"), 재도전 4트리거, Graceful Degradation UX, tier-a/b/c 초안.
- **CLAUDE.md**: 프로젝트 섹션(managed-block 외부)에 fact-first.md 참조 한 줄 추가.

## Behavior Changes

본 PR 은 **문서만** 변경 — 코드 행동 변화 없음 (PATCH 성격). 단, 로드맵 v2 는 후속 Phase(P11~P16) 의 설계 기준이 되므로 **릴리스 시 `Behavior Changes: None — 문서/문구만` 명시 예정**.

## DoD 체크리스트

- [x] `docs/principles/fact-first.md` 생성 — 원칙·정밀도·epoch·과장 규약
- [x] `docs/phases/roadmap-v2-solar-precision.md` 재작성 — P10~P16 번호 재조정 + P11 tier preset 스케치
- [x] `docs/decisions/20260420-mobile-support-suspension.md` — 보류 결정 + 재도전 조건 + Graceful Degradation UX + tier preset 전략 초안
- [x] `CLAUDE.md` 프로젝트 섹션(managed-block 외부) 에 fact-first.md 참조 링크 한 줄
- [x] ADR 작성 규약 준수 — 배경 / 후보 비교 / 결정 / 결과·재검토 조건 / 재도입 트리거 / Graceful Degradation UX
- [x] 기존 `docs/phases/roadmap.md` → `roadmap-v1-cosmic-scale.md` rename + 상단 v2 안내 블록 + 양방향 링크
- [x] 한글 인코딩 검증 (`grep -rn '�'` → 없음)
- [x] prettier `--check` 통과

## 교차검증 이견 수용 반영

- "영구 폐기" → "무기한 보류" 프레이밍 (모바일 ADR §배경)
- 디폴트 `educational` + 1-URL `scientific` 접근 보장 (원칙 §선언)
- `uncertainty` 필드 / J2000.0 epoch 명시 / 라이선스 크레딧 UI (원칙 §2~§5, §과장 규약)
- C→D 직렬화 명시 (로드맵 v2 §의존 관계)

## Test plan

- [x] 문서 생성 및 인코딩 검증 (grep U+FFFD → 없음)
- [x] prettier 포맷 적용
- [x] sync:prettierignore --check 통과
- [ ] 리뷰어 승인 → develop 머지 → P10-B (데이터 감사) 착수

## 관련 이슈

- Close: #268 (P10-A)
- 선행: #266 (P10 계약, merged)
- 보류 상태 유지: #219 (iOS Yoshida4 bench — 재도전 시 baseline)
- 후속 소화 예정 (P10-D): #261 / #263 / #255
- 이관: #257 → P12 / #256 → P11

🤖 Generated with [Claude Code](https://claude.com/claude-code)