### PR TITLE
[P10-C-1] #278 뷰 모드 스토어 + URL sync + 토글 UI + 키보드 m

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -46,6 +46,7 @@ export default async function LocaleLayout({
       lang={locale}
       className={`${spaceGrotesk.variable} ${jetbrainsMono.variable}`}
       data-mode="observe"
+      data-view-mode="educational"
     >
       <body>
         <NuqsAdapter>

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -5,6 +5,7 @@ import { TimeBar } from './time-bar';
 import { HudCorners } from './hud-corners';
 import { FocusQuickButtons } from './focus-quick-buttons';
 import { ModeSwitcher } from './mode-switcher';
+import { ViewModeSwitcher } from './view-mode-switcher';
 import { SidePanels } from './side-panels';
 import { ScaleControl } from './scale-control';
 import { TimeControls } from './time-controls';
@@ -28,6 +29,7 @@ export function AppShell() {
           left={
             <div className="flex items-center gap-2">
               <ModeSwitcher />
+              <ViewModeSwitcher />
               <FocusQuickButtons />
             </div>
           }

--- a/apps/web/src/components/layout/view-mode-switcher.test.tsx
+++ b/apps/web/src/components/layout/view-mode-switcher.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { ViewModeSwitcher } from './view-mode-switcher';
+
+beforeEach(() => {
+  useSimStore.setState({
+    viewMode: 'educational',
+  });
+  document.documentElement.removeAttribute('data-view-mode');
+});
+
+describe('ViewModeSwitcher (P10-C #278)', () => {
+  it('2개 뷰 모드 버튼 렌더', () => {
+    render(<ViewModeSwitcher />);
+    expect(screen.getByTestId('view-mode-educational')).toBeInTheDocument();
+    expect(screen.getByTestId('view-mode-scientific')).toBeInTheDocument();
+  });
+
+  it('educational 이 초기 active 상태', () => {
+    render(<ViewModeSwitcher />);
+    expect(screen.getByTestId('view-mode-educational')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('view-mode-scientific')).toHaveAttribute('data-active', 'false');
+  });
+
+  it('scientific 클릭 시 store viewMode 갱신', () => {
+    render(<ViewModeSwitcher />);
+    fireEvent.click(screen.getByTestId('view-mode-scientific'));
+    expect(useSimStore.getState().viewMode).toBe('scientific');
+  });
+
+  it('뷰 모드 변경 시 html[data-view-mode] 속성 동기화', () => {
+    render(<ViewModeSwitcher />);
+    fireEvent.click(screen.getByTestId('view-mode-scientific'));
+    expect(document.documentElement.getAttribute('data-view-mode')).toBe('scientific');
+    fireEvent.click(screen.getByTestId('view-mode-educational'));
+    expect(document.documentElement.getAttribute('data-view-mode')).toBe('educational');
+  });
+
+  it('키보드 m 키로 educational ↔ scientific 토글', () => {
+    render(<ViewModeSwitcher />);
+    fireEvent.keyDown(window, { key: 'm' });
+    expect(useSimStore.getState().viewMode).toBe('scientific');
+    fireEvent.keyDown(window, { key: 'm' });
+    expect(useSimStore.getState().viewMode).toBe('educational');
+  });
+
+  it('input 포커스 중 m 키 입력은 무시 (사용자 타이핑 방해 방지)', () => {
+    render(
+      <>
+        <input data-testid="text-input" />
+        <ViewModeSwitcher />
+      </>,
+    );
+    const input = screen.getByTestId('text-input') as HTMLInputElement;
+    input.focus();
+    fireEvent.keyDown(input, { key: 'm' });
+    expect(useSimStore.getState().viewMode).toBe('educational');
+  });
+
+  it('modifier 키와 함께 입력된 m 키는 무시 (cmd+m 등)', () => {
+    render(<ViewModeSwitcher />);
+    fireEvent.keyDown(window, { key: 'm', metaKey: true });
+    expect(useSimStore.getState().viewMode).toBe('educational');
+  });
+
+  it('aria-checked 가 active 상태와 일치', () => {
+    render(<ViewModeSwitcher />);
+    expect(screen.getByTestId('view-mode-educational')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('view-mode-scientific')).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(screen.getByTestId('view-mode-scientific'));
+    expect(screen.getByTestId('view-mode-educational')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByTestId('view-mode-scientific')).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/apps/web/src/components/layout/view-mode-switcher.tsx
+++ b/apps/web/src/components/layout/view-mode-switcher.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSimStore, type ViewMode } from '@/store/sim-store';
+
+interface ViewModeDef {
+  id: ViewMode;
+  label: string;
+  tooltip: string;
+}
+
+const VIEW_MODES: ViewModeDef[] = [
+  {
+    id: 'educational',
+    label: '교육',
+    tooltip: '시각 이해를 위한 크기/거리 과장 (디폴트)',
+  },
+  {
+    id: 'scientific',
+    label: '사실',
+    tooltip: 'IAU 2015 실측 비율 1.0 — sub-pixel 이탈 주의',
+  },
+];
+
+/**
+ * P10-C #278 — 뷰 모드 토글 (Fact-First 원칙 §"모드 토글").
+ *
+ * 기존 `ModeSwitcher` (관찰/연구) 와 직교. 두 축이 독립적으로 동작한다.
+ *
+ * - 2-버튼 토글: educational ↔ scientific
+ * - 키보드 단축키 `m` — input/textarea 포커스 중에는 무시 (e.target.tagName 체크)
+ * - `data-view-mode` DOM 어트리뷰트 동기화 (E2E 셀렉터)
+ */
+export function ViewModeSwitcher() {
+  const viewMode = useSimStore((s) => s.viewMode);
+  const setViewMode = useSimStore((s) => s.setViewMode);
+
+  // viewMode → html[data-view-mode] 동기화
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-view-mode', viewMode);
+    }
+  }, [viewMode]);
+
+  // 키보드 단축키 `m` — educational ↔ scientific 토글
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'm' && e.key !== 'M') return;
+      // 입력 요소 포커스 중에는 무시 (사용자 타이핑 방해 방지)
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      e.preventDefault();
+      setViewMode(viewMode === 'educational' ? 'scientific' : 'educational');
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [viewMode, setViewMode]);
+
+  return (
+    <div
+      className="flex items-center gap-0.5 bg-bg-surface/80 backdrop-blur border border-border-subtle rounded-sm p-0.5"
+      data-testid="view-mode-switcher"
+      role="radiogroup"
+      aria-label="뷰 모드"
+    >
+      {VIEW_MODES.map((m) => {
+        const active = viewMode === m.id;
+        return (
+          <button
+            key={m.id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            data-testid={`view-mode-${m.id}`}
+            data-active={active}
+            title={m.tooltip}
+            onClick={() => setViewMode(m.id)}
+            className={`num text-caption px-2 py-1 rounded-xs transition-colors ${
+              active ? 'bg-primary/25 text-fg-primary' : 'text-fg-secondary hover:bg-bg-elevated'
+            }`}
+            style={{ transitionDuration: 'var(--duration-fast)' }}
+          >
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/core/url-sync.tsx
+++ b/apps/web/src/core/url-sync.tsx
@@ -3,10 +3,12 @@
 import type { SimMode } from '@astro-simulator/shared';
 import { parseAsFloat, parseAsString, parseAsStringEnum, useQueryState } from 'nuqs';
 import { useEffect, useRef } from 'react';
-import { useSimStore } from '@/store/sim-store';
+import { useSimStore, type ViewMode } from '@/store/sim-store';
 import { useSimCommand } from './sim-context';
 
 const MODE_VALUES: SimMode[] = ['observe', 'research', 'education', 'sandbox'];
+// P10-C #278 — 뷰 모드 (Fact-First 원칙). 기존 ?mode= 와 URL key 분리 (?view=)
+const VIEW_MODE_VALUES: ViewMode[] = ['educational', 'scientific'];
 // P3-0 #126 — barnes-hut/webgpu/auto는 URL로는 받지만 런타임은 미구현 폴백.
 // 후방호환: 기존 newton/kepler URL은 그대로 동작.
 const ENGINE_VALUES = ['kepler', 'newton', 'barnes-hut', 'webgpu', 'auto'] as const;
@@ -37,12 +39,19 @@ export function UrlSync() {
     'engine',
     parseAsStringEnum<PhysicsEngineUrl>([...ENGINE_VALUES]).withOptions({ history: 'replace' }),
   );
+  // P10-C #278 — 뷰 모드 URL sync. 디폴트 educational 은 URL 에서 생략.
+  const [urlViewMode, setUrlViewMode] = useQueryState(
+    'view',
+    parseAsStringEnum<ViewMode>(VIEW_MODE_VALUES).withOptions({ history: 'replace' }),
+  );
 
   const mode = useSimStore((s) => s.mode);
+  const viewMode = useSimStore((s) => s.viewMode);
   const selectedBodyId = useSimStore((s) => s.selectedBodyId);
   const timeScale = useSimStore((s) => s.timeScale);
   const physicsEngine = useSimStore((s) => s.physicsEngine);
   const setMode = useSimStore((s) => s.setMode);
+  const setViewMode = useSimStore((s) => s.setViewMode);
   const setPhysicsEngine = useSimStore((s) => s.setPhysicsEngine);
 
   const sendCommand = useSimCommand();
@@ -69,6 +78,9 @@ export function UrlSync() {
     if (urlEngine) {
       setPhysicsEngine(urlEngine);
     }
+    if (urlViewMode) {
+      setViewMode(urlViewMode);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -92,6 +104,12 @@ export function UrlSync() {
     if (!initialized.current) return;
     setUrlEngine(physicsEngine === 'kepler' ? null : physicsEngine);
   }, [physicsEngine, setUrlEngine]);
+
+  // P10-C #278 — viewMode store → URL. 디폴트 educational 은 URL 생략.
+  useEffect(() => {
+    if (!initialized.current) return;
+    setUrlViewMode(viewMode === 'educational' ? null : viewMode);
+  }, [viewMode, setUrlViewMode]);
 
   return null;
 }

--- a/apps/web/src/store/sim-store.test.ts
+++ b/apps/web/src/store/sim-store.test.ts
@@ -9,6 +9,7 @@ beforeEach(() => {
     engineNotice: null,
     dismissedNoticeKeys: new Set<string>(),
     mode: 'observe',
+    viewMode: 'educational',
     julianDate: null,
     selectedBodyId: null,
     timeScale: 86_400,
@@ -38,6 +39,27 @@ describe('useSimStore', () => {
   it('setMode', () => {
     useSimStore.getState().setMode('research');
     expect(useSimStore.getState().mode).toBe('research');
+  });
+
+  // P10-C #278 — viewMode (educational/scientific) 직교 축
+  describe('viewMode (P10-C #278)', () => {
+    it('초기 상태 — educational 디폴트', () => {
+      expect(useSimStore.getState().viewMode).toBe('educational');
+    });
+
+    it('setViewMode — educational ↔ scientific 토글', () => {
+      useSimStore.getState().setViewMode('scientific');
+      expect(useSimStore.getState().viewMode).toBe('scientific');
+      useSimStore.getState().setViewMode('educational');
+      expect(useSimStore.getState().viewMode).toBe('educational');
+    });
+
+    it('viewMode 와 mode 직교 — 한쪽 변경이 다른 쪽에 영향 없음', () => {
+      useSimStore.getState().setMode('research');
+      useSimStore.getState().setViewMode('scientific');
+      expect(useSimStore.getState().mode).toBe('research');
+      expect(useSimStore.getState().viewMode).toBe('scientific');
+    });
   });
 
   it('setTime', () => {

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -7,6 +7,17 @@ type IntegratorKind = physics.IntegratorKind;
 export type UnitSystem = 'si' | 'astro' | 'natural';
 
 /**
+ * P10-C #278 — 뷰 모드 (Fact-First 원칙).
+ *
+ * - `educational` (디폴트): 시각 이해를 위한 크기/거리 과장 + 명시 배지
+ * - `scientific`: IAU 2015 실측 비율 1.0 스케일 (sub-pixel 리스크 있으나 안내 배너로 보호)
+ *
+ * 기존 `SimMode` (관찰/연구) 와 **직교 축**. URL key 충돌 회피를 위해 `?view=` 사용
+ * (기존 `?mode=observe|research` 와 분리). 이슈 #278 및 CRITICAL #6 재조정 근거.
+ */
+export type ViewMode = 'educational' | 'scientific';
+
+/**
  * P7-D #209 — 비-fatal 알림 객체.
  * 키 분리 dismiss 관리 목적 (예: 사용자가 WebGPU 폴백 알림을 닫은 상태에서
  * 모바일 best-effort 경고가 후속 표시될 때 서로 간섭하지 않도록 한다).
@@ -60,6 +71,8 @@ export interface SimStoreState {
 
   // 시뮬레이션 상태
   mode: SimMode;
+  /** P10-C #278 — 뷰 모드 (과장 on=educational / off=scientific). 디폴트 educational. */
+  viewMode: ViewMode;
   julianDate: number | null;
   selectedBodyId: string | null;
   timeScale: number;
@@ -99,6 +112,8 @@ export interface SimStoreState {
    */
   dismissEngineNotice: () => void;
   setMode: (mode: SimMode) => void;
+  /** P10-C #278 — 뷰 모드 전환 (educational ↔ scientific). */
+  setViewMode: (viewMode: ViewMode) => void;
   setTime: (julianDate: number) => void;
   setSelectedBody: (id: string | null) => void;
   setTimeScale: (scale: number) => void;
@@ -148,6 +163,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   engineNotice: null,
   dismissedNoticeKeys: new Set<string>(),
   mode: 'observe',
+  viewMode: 'educational',
   julianDate: null,
   selectedBodyId: null,
   timeScale: 86_400,
@@ -178,6 +194,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
       return { engineNotice: null, dismissedNoticeKeys: next };
     }),
   setMode: (mode) => set({ mode }),
+  setViewMode: (viewMode) => set({ viewMode }),
   setTime: (julianDate) => set({ julianDate }),
   setSelectedBody: (id) => set({ selectedBodyId: id }),
   setTimeScale: (scale) => set({ timeScale: scale }),

--- a/docs/phases/p10-plan.md
+++ b/docs/phases/p10-plan.md
@@ -70,12 +70,12 @@
 ### P10-C — 사실 모드 + UI 정비
 
 - [ ] 뷰 모드 스토어 — `educational` (디폴트) / `scientific` 2종
-- [ ] URL sync — `?mode=educational` / `?mode=scientific`
+- [ ] URL sync — `?view=educational` / `?view=scientific` (P10-C-1 재조정: 기존 `?mode=observe|research` 와 key 충돌 회피. 근거: 이슈 #278 + CRITICAL #6)
 - [ ] 과장 배지 UI — 각 body hover/focus 시 "태양 ×20 과장 중" 등 현재 스케일 표시
 - [ ] 모드 토글 UI — 헤더 또는 설정 패널, 키보드 단축키 (권고: `m`)
 - [ ] 첫 진입 온보딩 툴팁 — "현재 시각적 이해를 위해 천체 크기가 N배 과장되어 있습니다. [실제 비율로 보기]"
 - [ ] 데이터 출처/라이선스 크레딧 뷰 — IAU/NASA attribution 고지 (`About` 모달 또는 설정 패널)
-- [ ] `scientific` 모드 빈 화면 이탈 방지 안내 — 뷰포트에 `data-testid="scientific-mode-notice"` 노드 존재 + `?mode=scientific` 최초 진입 시 자동 표시 + 사용자 dismiss 가능 (localStorage 키 `astro:scientific-notice-dismissed`)
+- [ ] `scientific` 모드 빈 화면 이탈 방지 안내 — 뷰포트에 `data-testid="scientific-mode-notice"` 노드 존재 + `?view=scientific` 최초 진입 시 자동 표시 + 사용자 dismiss 가능 (localStorage 키 `astro:scientific-notice-dismissed`)
 - [ ] 3단계 브라우저 검증 (CRITICAL #3) — 정적 / 인터랙션 / 흐름
 
 ### P10-D — 정확도 이슈 소화

--- a/docs/principles/fact-first.md
+++ b/docs/principles/fact-first.md
@@ -80,7 +80,7 @@
 3. **첫 진입 온보딩**: 첫 방문 시 툴팁 — "시각적 이해를 위해 크기가 과장되어 있습니다. [실제 비율로 보기]"
 4. **크레딧 뷰**: About 모달 또는 설정 패널에 IAU / NASA JPL / Gaia DR3 등 데이터 출처 attribution + 현재 적용된 과장 요약 ("크기 ×20 / 거리 ×1.0").
 5. **모드 토글**: 헤더 또는 설정 패널에서 `educational` ↔ `scientific` 1-클릭 전환. 키보드 단축키 `m` 권고.
-6. **URL 동기화**: `?mode=scientific` 로 북마크/공유 가능. 링크로 방문 시 해당 모드로 진입.
+6. **URL 동기화**: `?view=scientific` 로 북마크/공유 가능. 링크로 방문 시 해당 모드로 진입.
 
 구현 상세 DoD: [docs/phases/p10-plan.md](../phases/p10-plan.md) P10-C.
 
@@ -90,7 +90,7 @@
 
 `scientific` 모드에서는 대부분의 body 가 sub-pixel 로 표시되어 **빈 화면 이탈 리스크**가 있다 (Gemini 교차검증 지적, 2026-04-20). 이를 방어하기 위해:
 
-- 최초 `?mode=scientific` 진입 시 **안내 배너** 자동 표시 — "실제 비율에서는 대부분 천체가 매우 작게 보입니다. 줌 인/검색으로 특정 천체에 초점 맞추세요."
+- 최초 `?view=scientific` 진입 시 **안내 배너** 자동 표시 — "실제 비율에서는 대부분 천체가 매우 작게 보입니다. 줌 인/검색으로 특정 천체에 초점 맞추세요."
 - 사용자 dismiss 가능 (`localStorage.astro:scientific-notice-dismissed`).
 - 뷰포트에 `data-testid="scientific-mode-notice"` 노드 존재 (E2E 검증).
 

--- a/scripts/browser-verify-view-mode.mjs
+++ b/scripts/browser-verify-view-mode.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * P10-C-1 #278 — ViewMode 토글 브라우저 3단계 검증 (CRITICAL #3 준수).
+ *
+ * 사용: node scripts/browser-verify-view-mode.mjs [baseUrl]
+ * 기본 URL: http://localhost:3000
+ *
+ * Level 1 정적:     view-mode-switcher 존재, educational 초기 active, data-view-mode='educational'
+ * Level 2 인터랙션: 버튼 클릭 / 키보드 m / input 포커스 중 m 무시
+ * Level 3 흐름:     URL ?view=scientific 진입 시 초기 반영 / store→URL 동기화 / ?view 제거 시 educational
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3000';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotDir = join(__dirname, '..', '.verify-screenshots');
+mkdirSync(screenshotDir, { recursive: true });
+
+const results = { pass: [], fail: [] };
+const check = (name, condition, detail = '') => {
+  if (condition) results.pass.push(`${name}${detail ? ' — ' + detail : ''}`);
+  else results.fail.push(`${name}${detail ? ' — ' + detail : ''}`);
+};
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text());
+});
+page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+// ===== Level 1: 정적 =====
+console.log('\n[Level 1] 정적 검증');
+await page.goto(`${baseUrl}/ko`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1000);
+
+check('view-mode-switcher 존재', (await page.$('[data-testid="view-mode-switcher"]')) !== null);
+check(
+  'view-mode-educational 버튼 존재',
+  (await page.$('[data-testid="view-mode-educational"]')) !== null,
+);
+check(
+  'view-mode-scientific 버튼 존재',
+  (await page.$('[data-testid="view-mode-scientific"]')) !== null,
+);
+check(
+  'educational 초기 active',
+  (await page.getAttribute('[data-testid="view-mode-educational"]', 'data-active')) === 'true',
+);
+check(
+  'scientific 초기 inactive',
+  (await page.getAttribute('[data-testid="view-mode-scientific"]', 'data-active')) === 'false',
+);
+check(
+  'html[data-view-mode=educational] 초기 상태',
+  (await page.evaluate(() => document.documentElement.getAttribute('data-view-mode'))) ===
+    'educational',
+);
+check(
+  'ARIA radiogroup role',
+  (await page.getAttribute('[data-testid="view-mode-switcher"]', 'role')) === 'radiogroup',
+);
+
+await page.screenshot({
+  path: join(screenshotDir, 'view-mode-01-static.png'),
+  fullPage: false,
+});
+
+// ===== Level 2: 인터랙션 =====
+console.log('\n[Level 2] 인터랙션 검증');
+
+// 버튼 클릭 전환
+await page.click('[data-testid="view-mode-scientific"]');
+await page.waitForTimeout(200);
+check(
+  'scientific 클릭 시 active 전환',
+  (await page.getAttribute('[data-testid="view-mode-scientific"]', 'data-active')) === 'true',
+);
+check(
+  'data-view-mode=scientific 동기화',
+  (await page.evaluate(() => document.documentElement.getAttribute('data-view-mode'))) ===
+    'scientific',
+);
+
+// educational 로 다시 전환
+await page.click('[data-testid="view-mode-educational"]');
+await page.waitForTimeout(200);
+check(
+  'educational 재클릭 시 active',
+  (await page.getAttribute('[data-testid="view-mode-educational"]', 'data-active')) === 'true',
+);
+
+// 키보드 m 단축키
+await page.keyboard.press('m');
+await page.waitForTimeout(200);
+check(
+  '키보드 m 단축키 — scientific 전환',
+  (await page.getAttribute('[data-testid="view-mode-scientific"]', 'data-active')) === 'true',
+);
+await page.keyboard.press('m');
+await page.waitForTimeout(200);
+check(
+  '키보드 m 단축키 — educational 복귀',
+  (await page.getAttribute('[data-testid="view-mode-educational"]', 'data-active')) === 'true',
+);
+
+// 입력 요소 포커스 중 m 무시 — date-time-picker 같은 input 검색
+const inputs = await page.$$('input:not([type="checkbox"]):not([type="radio"])');
+if (inputs.length > 0) {
+  await inputs[0].focus();
+  await page.keyboard.press('m');
+  await page.waitForTimeout(200);
+  check(
+    'input 포커스 중 m 키 무시',
+    (await page.getAttribute('[data-testid="view-mode-educational"]', 'data-active')) === 'true',
+  );
+  // 포커스 해제
+  await page.evaluate(() => {
+    const el = document.activeElement;
+    if (el && typeof el.blur === 'function') el.blur();
+  });
+} else {
+  console.log('  ⚠  input 요소 없음 — 포커스 가드 테스트 스킵');
+}
+
+// ===== Level 3: 흐름 =====
+console.log('\n[Level 3] 흐름 검증');
+
+// URL ?view=scientific 초기 진입
+await page.goto(`${baseUrl}/ko?view=scientific`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1000);
+check(
+  'URL ?view=scientific 초기 반영 — data-view-mode',
+  (await page.evaluate(() => document.documentElement.getAttribute('data-view-mode'))) ===
+    'scientific',
+);
+check(
+  'URL ?view=scientific 초기 반영 — 버튼 active',
+  (await page.getAttribute('[data-testid="view-mode-scientific"]', 'data-active')) === 'true',
+);
+
+// store → URL 동기화 (educational 로 전환 시 ?view 제거)
+await page.click('[data-testid="view-mode-educational"]');
+await page.waitForTimeout(300);
+const urlAfterEducational = page.url();
+check(
+  'educational 전환 시 ?view URL 제거',
+  !urlAfterEducational.includes('view=educational'),
+  urlAfterEducational,
+);
+
+// scientific 재전환 시 ?view=scientific URL 반영
+await page.click('[data-testid="view-mode-scientific"]');
+await page.waitForTimeout(300);
+const urlAfterScientific = page.url();
+check(
+  'scientific 전환 시 ?view=scientific URL 반영',
+  urlAfterScientific.includes('view=scientific'),
+  urlAfterScientific,
+);
+
+// 잘못된 값 ?view=foo 는 무시되고 educational 유지
+await page.goto(`${baseUrl}/ko?view=foo`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1000);
+check(
+  '잘못된 ?view 값 무시 — educational 유지',
+  (await page.evaluate(() => document.documentElement.getAttribute('data-view-mode'))) ===
+    'educational',
+);
+
+// ===== 런타임 에러 =====
+check(
+  '런타임 에러 없음',
+  consoleErrors.length === 0,
+  consoleErrors.length ? consoleErrors.join(' | ').slice(0, 200) : '',
+);
+
+await page.screenshot({
+  path: join(screenshotDir, 'view-mode-99-final.png'),
+  fullPage: false,
+});
+
+await browser.close();
+
+// ===== 결과 =====
+console.log('\n========================================');
+console.log(`PASS: ${results.pass.length}건`);
+for (const p of results.pass) console.log(`  ✓ ${p}`);
+if (results.fail.length > 0) {
+  console.log(`\nFAIL: ${results.fail.length}건`);
+  for (const f of results.fail) console.log(`  ✗ ${f}`);
+}
+console.log(`\n스크린샷: ${screenshotDir}`);
+
+if (results.fail.length > 0) {
+  console.error('\n검증 실패 ✗');
+  process.exit(1);
+}
+console.log('\n모든 검증 통과 ✓');


### PR DESCRIPTION
## Summary

P10-C 사실 모드 UI 정비의 **코어 인프라** — 기존 `mode` (observe/research) 와 **직교 축**으로 `viewMode` (educational/scientific) 신설.

이슈 #278 C-1 DoD 완료 (2/3 Sub-phase 남음).

## 계약 재조정 (CRITICAL #6)

원래 계약 `?mode=scientific` 은 기존 `?mode=observe|research` URL key 와 충돌 — **Gemini 2차 교차검증도 놓친 건**.

**`?view=` 로 재조정**. 북마크 breaking 없이 뷰 모드 축 분리. 박제 3위치:
- 코드: `apps/web/src/store/sim-store.ts` (ViewMode 타입 주석)
- 원칙: `docs/principles/fact-first.md` §URL 동기화
- 플랜: `docs/phases/p10-plan.md` §P10-C (재조정 근거 주석)

CRITICAL #6 §6 의 ROI 5문 체크: "신규 URL key 비용 < 기존 ?mode= 재정의 비용" 판정 — `?view=` 신규 키가 최소 침범.

## Behavior Changes

- 헤더에 `ViewModeSwitcher` 추가 — **교육**(디폴트) / **사실** 2-버튼 토글 (ModeSwitcher 옆)
- 키보드 `m` 단축키로 educational ↔ scientific 전환 (input/textarea 포커스 + modifier 키 가드)
- URL sync — `?view=scientific` 북마크/공유. 디폴트 educational 은 URL 생략
- DOM: `html[data-view-mode="educational|scientific"]` 동기화 (E2E 셀렉터)
- Fact-First 원칙 문서 박제 정합화 (`?mode=` → `?view=`)

## duplicate-function-guard 경고 — 의도적 신규

`ViewModeSwitcher` 가 `ModeSwitcher` 와 공유 토큰 `{mode, switcher}` 때문에 유사 경고. **의도적 신규**:

- `ModeSwitcher`: 앱 사용 모드 (observe/research/education/sandbox) — **무엇을 하는지**
- `ViewModeSwitcher`: 뷰 과장 on/off (educational/scientific) — **어떻게 볼지**

두 축 직교. 공용화하면 prop drilling + 책임 혼재. 계약상 별도 컴포넌트 분리 정당화.

## 검증

- `pnpm -r test`: **269 tests passed** (shared 4 + physics-wasm 1 + core 165 + web 99 — +11 추가 / store viewMode 3 + component 8)
- `pnpm -r typecheck`: 통과
- `pnpm --filter @astro-simulator/web build`: 성공
- `scripts/browser-verify-view-mode.mjs`: **19/19 PASS** (정적 7 / 인터랙션 5 / 흐름 7)
- `scripts/browser-verify.mjs` (기존): **25/25 PASS** (회귀 없음)

## 비목표 (C-2/C-3 분리)

- 과장 배지 UI (hover/focus 스케일 표시) → C-2
- 온보딩 툴팁 (첫 진입 "실제 비율로 보기") → C-2
- scientific 모드 빈 화면 안내 배너 → C-2
- About 모달 + IAU/NASA 크레딧 → C-3
- P10-B 필드 (uncertainty/colorSource/dataSource) UI 노출 → C-3
- 과장 상수 파일 박제 + scientific 모드 실제 과장 적용 → C-2

## Test plan

- [x] store viewMode slice 3 단위 테스트 (초기값 / toggle / mode 와 직교)
- [x] ViewModeSwitcher 8 component 테스트 (렌더/클릭/DOM 동기화/키보드/포커스 가드/aria)
- [x] URL round-trip: `?view=scientific` 초기 진입 + store→URL + 제거
- [x] 잘못된 `?view=foo` 값 무시 → educational fallback
- [x] 기존 browser-verify.mjs 회귀 없음 (25/25)
- [x] typecheck + build + grep -c '�' 인코딩 검증

## 체크리스트 JSON

\`\`\`json
{
  "commit_sha": "c837805",
  "pr_url": "PENDING",
  "pr_comment_url": null,
  "labels_applied_or_transitioned": [],
  "auto_close_issue_states": {"#278": "OPEN (C-3 에서 close 예정)"},
  "blocking_issues": [],
  "non_blocking_suggestions": [
    "C-2 에서 data-view-mode 를 실제 과장 상수 토글에 연결 (현재는 DOM 어트리뷰트만, scientific 모드에서도 시각적 차이 없음 — C-2 의 주요 Behavior Change)"
  ],
  "spawned_bg_pids": [],
  "bg_process_handoff": "sub-agent-confirmed-done"
}
\`\`\`

Refs: #278 (C-3 PR 에서 close)
Builds on: #274 (P10-B closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)