### PR TITLE
[P10-C-3] #278 AboutModal IAU/NASA 크레딧 + info panel 감사 필드 — Closes #278

### DIFF
--- a/apps/web/src/components/layout/about-modal.test.tsx
+++ b/apps/web/src/components/layout/about-modal.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSimStore } from '@/store/sim-store';
+import { AboutModal } from './about-modal';
+
+beforeEach(() => {
+  useSimStore.setState({ viewMode: 'educational' });
+});
+
+describe('AboutModal (P10-C-3 #278)', () => {
+  it('초기 상태 — 버튼만 표시, 모달 숨김', () => {
+    render(<AboutModal />);
+    expect(screen.getByTestId('about-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('about-modal')).toBeNull();
+  });
+
+  it('버튼 클릭 → 모달 오픈', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    expect(screen.getByTestId('about-modal')).toBeInTheDocument();
+  });
+
+  it('출처 목록 — IAU / NASA / JPL 포함', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    const sources = screen.getByTestId('about-sources');
+    expect(sources).toHaveTextContent('IAU 2015');
+    expect(sources).toHaveTextContent('NASA Planetary Fact Sheet');
+    expect(sources).toHaveTextContent('NASA JPL Horizons');
+  });
+
+  it('educational 모드 — 과장 요약 표시', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    const modal = screen.getByTestId('about-modal');
+    expect(modal).toHaveTextContent('교육');
+    expect(modal).toHaveTextContent('×20');
+    expect(modal).toHaveTextContent('×500');
+    expect(modal).toHaveTextContent('×20,000');
+  });
+
+  it('scientific 모드 — 1.0 비율 안내 표시', () => {
+    useSimStore.setState({ viewMode: 'scientific' });
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    const modal = screen.getByTestId('about-modal');
+    expect(modal).toHaveTextContent('사실');
+    expect(modal).toHaveTextContent('1.0');
+  });
+
+  it('닫기 버튼 → 모달 제거', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    fireEvent.click(screen.getByTestId('about-close'));
+    expect(screen.queryByTestId('about-modal')).toBeNull();
+  });
+
+  it('Escape 키 → 모달 제거', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('about-modal')).toBeNull();
+  });
+
+  it('공차 ±0.01% 안내 포함', () => {
+    render(<AboutModal />);
+    fireEvent.click(screen.getByTestId('about-button'));
+    expect(screen.getByTestId('about-modal')).toHaveTextContent('±0.01%');
+  });
+});

--- a/apps/web/src/components/layout/about-modal.tsx
+++ b/apps/web/src/components/layout/about-modal.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSimStore } from '@/store/sim-store';
+
+const SOURCES = [
+  {
+    name: 'IAU 2015 Resolution B3',
+    purpose: '태양·지구·목성 nominal 값 (질량·반경)',
+    url: 'https://www.iau.org/static/resolutions/IAU2015_English.pdf',
+    license: '© IAU — 학술/교육 목적 인용 허용',
+  },
+  {
+    name: 'NASA Planetary Fact Sheet',
+    purpose: '수성·금성·화성·토성·천왕성·해왕성 (질량·반경·궤도)',
+    url: 'https://nssdc.gsfc.nasa.gov/planetary/factsheet/',
+    license: 'Public Domain (NASA)',
+  },
+  {
+    name: 'NASA JPL Horizons / SSD',
+    purpose: '위성 (Moon / Galilean / Phobos / Deimos) + 왜소행성 + 혜성',
+    url: 'https://ssd.jpl.nasa.gov/horizons/',
+    license: 'Public Domain (NASA JPL)',
+  },
+  {
+    name: 'Standish & Williams (1992) / DE440',
+    purpose: '행성 J2000.0 궤도 요소',
+    url: 'https://ssd.jpl.nasa.gov/planets/approx_pos.html',
+    license: 'Public Domain (NASA JPL)',
+  },
+];
+
+const SCALE_SUMMARY = [
+  { kind: '항성 (태양)', max: '×20' },
+  { kind: '행성 / 위성', max: '×500' },
+  { kind: '왜소행성', max: '×2,000' },
+  { kind: '혜성', max: '×20,000' },
+];
+
+/**
+ * P10-C-3 #278 — About 모달 (Fact-First 원칙 §"크레딧 뷰").
+ *
+ * - 데이터 출처 attribution (IAU / NASA / JPL)
+ * - 현재 과장 요약 (educational 모드의 kind 별 상한)
+ * - 모드별 비율 정책 안내
+ *
+ * 헤더 우측 버튼 ("?") 으로 열기, Esc 또는 닫기 버튼으로 닫기.
+ */
+export function AboutModal() {
+  const viewMode = useSimStore((s) => s.viewMode);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-testid="about-button"
+        title="데이터 출처 / 크레딧 / 과장 요약"
+        aria-label="데이터 출처 정보"
+        className="num text-caption bg-bg-surface/80 backdrop-blur border border-border-subtle rounded-sm px-2 py-1 text-fg-secondary hover:bg-bg-elevated transition-colors"
+        style={{ transitionDuration: 'var(--duration-fast)' }}
+      >
+        ?
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-bg-base/70 backdrop-blur-sm flex items-center justify-center p-4"
+          onClick={() => setOpen(false)}
+          role="presentation"
+        >
+          <div
+            className="max-w-2xl w-full max-h-[80vh] overflow-y-auto bg-bg-surface border border-border-subtle rounded-sm p-6 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="about-title"
+            data-testid="about-modal"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 id="about-title" className="font-display text-h3 text-fg-primary">
+                데이터 출처 · 크레딧
+              </h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                data-testid="about-close"
+                aria-label="닫기"
+                className="text-fg-secondary hover:text-fg-primary text-body transition-colors"
+                style={{ transitionDuration: 'var(--duration-fast)' }}
+              >
+                ✕
+              </button>
+            </div>
+
+            <section className="mb-5">
+              <h3 className="text-body-sm text-fg-secondary mb-2">출처</h3>
+              <ul className="flex flex-col gap-3" data-testid="about-sources">
+                {SOURCES.map((s) => (
+                  <li key={s.name} className="text-body-sm">
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-fg-primary hover:text-primary underline"
+                    >
+                      {s.name}
+                    </a>
+                    <p className="text-caption text-fg-tertiary mt-0.5">{s.purpose}</p>
+                    <p className="text-caption text-fg-tertiary italic">{s.license}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section className="mb-5 pt-4 border-t border-border-subtle">
+              <h3 className="text-body-sm text-fg-secondary mb-2">
+                현재 뷰 모드: {viewMode === 'educational' ? '교육 (과장)' : '사실 (1.0 비율)'}
+              </h3>
+              {viewMode === 'educational' ? (
+                <>
+                  <p className="text-caption text-fg-tertiary mb-2">
+                    시각 이해를 위해 천체 크기가 카메라 거리에 비례해 과장됩니다. 상한 요약:
+                  </p>
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-body-sm">
+                    {SCALE_SUMMARY.map((s) => (
+                      <div key={s.kind} className="flex items-baseline justify-between">
+                        <dt className="text-caption text-fg-tertiary">{s.kind}</dt>
+                        <dd className="num text-fg-primary">{s.max}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </>
+              ) : (
+                <p className="text-caption text-fg-tertiary">
+                  IAU 2015 실측 비율 1.0 — 대부분 천체가 sub-pixel 로 표시됩니다. 줌 인으로 특정
+                  천체에 초점을 맞추세요.
+                </p>
+              )}
+            </section>
+
+            <section className="pt-4 border-t border-border-subtle">
+              <p className="text-caption text-fg-tertiary">
+                정밀도: IAU 2015 ±0.01% 공차. 불확실성(관측 부정확, 비구형 body)은 각 천체 정보
+                패널의 오차 필드(±%)로 표시됩니다.
+              </p>
+            </section>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -9,6 +9,7 @@ import { ViewModeSwitcher } from './view-mode-switcher';
 import { ScaleBadge } from './scale-badge';
 import { OnboardingTooltip } from './onboarding-tooltip';
 import { ScientificModeNotice } from './scientific-mode-notice';
+import { AboutModal } from './about-modal';
 import { SidePanels } from './side-panels';
 import { ScaleControl } from './scale-control';
 import { TimeControls } from './time-controls';
@@ -43,6 +44,7 @@ export function AppShell() {
               <UnitToggle />
               <PhysicsEngineToggle />
               <BookmarkButton />
+              <AboutModal />
             </div>
           }
         />

--- a/apps/web/src/components/panels/celestial-info-panel.tsx
+++ b/apps/web/src/components/panels/celestial-info-panel.tsx
@@ -12,7 +12,20 @@ const KIND_LABEL: Record<string, string> = {
   planet: '행성',
   'dwarf-planet': '왜소행성',
   moon: '위성',
+  comet: '혜성',
 };
+
+// P10-B-2 #274 — colorSource 3종 한국어 라벨.
+const COLOR_SOURCE_LABEL: Record<string, string> = {
+  observed: '관측',
+  artistic: '아티스트',
+  inferred: '추론',
+};
+
+function formatUncertainty(value: number): string {
+  // 상대 오차 (0.05 = ±5%) — percent 표시
+  return `±${(value * 100).toFixed(value < 0.01 ? 2 : 1)}%`;
+}
 
 function formatExp(n: number, digits = 3): string {
   return n.toExponential(digits);
@@ -71,8 +84,16 @@ export function CelestialInfoPanel() {
       </div>
 
       <dl className="flex flex-col gap-2 text-body-sm">
-        <Row label="질량" value={`${formatExp(data.mass)} kg`} />
-        <Row label="반경" value={`${formatExp(data.radius)} m`} />
+        <Row
+          label="질량"
+          value={`${formatExp(data.mass)} kg`}
+          uncertainty={data.uncertainty?.mass}
+        />
+        <Row
+          label="반경"
+          value={`${formatExp(data.radius)} m`}
+          uncertainty={data.uncertainty?.radius}
+        />
         {data.orbit && (
           <>
             <Row label="궤도 장반경" value={`${(data.orbit.semiMajorAxis / AU).toFixed(4)} AU`} />
@@ -86,6 +107,39 @@ export function CelestialInfoPanel() {
         )}
       </dl>
 
+      {/* P10-C-3 #278 — P10-B 감사 메타데이터 (dataSource / lastVerified / colorSource) */}
+      {(data.dataSource || data.lastVerified || data.colorHint?.colorSource) && (
+        <div
+          className="mt-3 pt-3 border-t border-border-subtle"
+          data-testid="info-panel-audit-fields"
+        >
+          <h3 className="text-caption text-fg-tertiary mb-2">데이터 출처</h3>
+          <dl className="flex flex-col gap-1 text-body-sm">
+            {data.dataSource && (
+              <AuditRow
+                label="출처"
+                value={
+                  typeof data.dataSource === 'string'
+                    ? data.dataSource
+                    : data.dataSource.join(' / ')
+                }
+                testId="audit-data-source"
+              />
+            )}
+            {data.lastVerified && (
+              <AuditRow label="최종 검증" value={data.lastVerified} testId="audit-last-verified" />
+            )}
+            {data.colorHint?.colorSource && (
+              <AuditRow
+                label="색상 출처"
+                value={COLOR_SOURCE_LABEL[data.colorHint.colorSource] ?? data.colorHint.colorSource}
+                testId="audit-color-source"
+              />
+            )}
+          </dl>
+        </div>
+      )}
+
       <div className="mt-4 pt-3 border-t border-border-subtle">
         <MassSlider />
       </div>
@@ -93,13 +147,45 @@ export function CelestialInfoPanel() {
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({
+  label,
+  value,
+  uncertainty,
+}: {
+  label: string;
+  value: string;
+  uncertainty?: number;
+}) {
   return (
     <div className="flex items-baseline justify-between gap-2 border-b border-border-subtle/50 pb-1">
       <dt className="text-caption text-fg-tertiary">{label}</dt>
       <dd className="flex items-center gap-2">
         <span className="num text-fg-primary">{value}</span>
+        {uncertainty !== undefined && (
+          <span
+            className="num text-caption text-fg-tertiary"
+            data-testid="audit-uncertainty"
+            title="IAU 공식값 부재 — 상대 오차"
+          >
+            {formatUncertainty(uncertainty)}
+          </span>
+        )}
         <TierBadge tier={1} />
+      </dd>
+    </div>
+  );
+}
+
+function AuditRow({ label, value, testId }: { label: string; value: string; testId: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="text-caption text-fg-tertiary shrink-0">{label}</dt>
+      <dd
+        className="num text-caption text-fg-secondary text-right truncate"
+        data-testid={testId}
+        title={value}
+      >
+        {value}
       </dd>
     </div>
   );

--- a/scripts/browser-verify-view-mode.mjs
+++ b/scripts/browser-verify-view-mode.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * P10-C-1/C-2 #278 — ViewMode + UI 요소 브라우저 3단계 검증 (CRITICAL #3 준수).
+ * P10-C-1/C-2/C-3 #278 — ViewMode + UI 요소 + About 모달 + 감사 필드 브라우저 3단계 검증.
  *
  * 사용: node scripts/browser-verify-view-mode.mjs [baseUrl]
  * 기본 URL: http://localhost:3000
  *
- * Level 1 정적:     view-mode-switcher / scale-badge / onboarding-tooltip 존재
- * Level 2 인터랙션: 버튼 클릭 / 키보드 m / scientific 모드 scale=1 실측 / onboarding dismiss
- * Level 3 흐름:     URL ?view=scientific 진입 + scientific-mode-notice 배너 + dismiss 영속
+ * Level 1 정적:     view-mode-switcher / scale-badge / onboarding-tooltip / about-button 존재
+ * Level 2 인터랙션: 버튼 클릭 / 키보드 m / scientific scale=1 실측 / onboarding dismiss / About 모달
+ * Level 3 흐름:     URL ?view=scientific + notice 배너 영속 dismiss + About Esc 닫기
  */
 import { chromium } from 'playwright';
 import { mkdirSync } from 'node:fs';
@@ -86,6 +86,8 @@ check(
   'scientific-mode-notice 초기 educational 에서는 숨김',
   (await page.$('[data-testid="scientific-mode-notice"]')) === null,
 );
+// P10-C-3 추가 — About 버튼 존재
+check('about-button 존재', (await page.$('[data-testid="about-button"]')) !== null);
 
 await page.screenshot({
   path: join(screenshotDir, 'view-mode-01-static.png'),
@@ -200,6 +202,48 @@ check(
   jupiterScaleEdu !== null && jupiterScaleEdu > 1,
   `scaling=${jupiterScaleEdu}`,
 );
+
+// P10-C-3 — About 모달 열기/출처/닫기
+await page.click('[data-testid="about-button"]');
+await page.waitForTimeout(200);
+check('About 모달 오픈', (await page.$('[data-testid="about-modal"]')) !== null);
+const aboutSourcesText = (await page.textContent('[data-testid="about-sources"]')) ?? '';
+check('About 출처 — IAU 2015 포함', aboutSourcesText.includes('IAU 2015'));
+check('About 출처 — NASA Planetary Fact Sheet 포함', aboutSourcesText.includes('NASA'));
+check('About 출처 — JPL Horizons 포함', aboutSourcesText.includes('JPL Horizons'));
+// 닫기 버튼
+await page.click('[data-testid="about-close"]');
+await page.waitForTimeout(200);
+check('About 닫기 버튼 → 모달 제거', (await page.$('[data-testid="about-modal"]')) === null);
+// Escape 키로 닫기
+await page.click('[data-testid="about-button"]');
+await page.waitForTimeout(200);
+await page.keyboard.press('Escape');
+await page.waitForTimeout(200);
+check('About Escape 키 → 모달 제거', (await page.$('[data-testid="about-modal"]')) === null);
+
+// P10-C-3 — 지구 focus → info panel 에 P10-B 감사 필드 표시
+const focusEarthBtn = await page.$('[data-testid="focus-earth"]');
+if (focusEarthBtn) {
+  await focusEarthBtn.click();
+  await page.waitForTimeout(300);
+  // research 모드로 전환해야 info panel 표시됨 (관찰 모드는 좌우 패널 없음)
+  await page.click('[data-testid="mode-research"]');
+  await page.waitForTimeout(300);
+  check(
+    'info-panel-audit-fields 노출',
+    (await page.$('[data-testid="info-panel-audit-fields"]')) !== null,
+  );
+  const dataSourceText = (await page.textContent('[data-testid="audit-data-source"]')) ?? '';
+  check('audit-data-source — IAU 2015 포함 (지구)', dataSourceText.includes('IAU 2015'));
+  const lastVerifiedText = (await page.textContent('[data-testid="audit-last-verified"]')) ?? '';
+  check('audit-last-verified — 2026-04-21', lastVerifiedText.includes('2026-04-21'));
+  const colorSourceText = (await page.textContent('[data-testid="audit-color-source"]')) ?? '';
+  check('audit-color-source — 관측 (observed)', colorSourceText.includes('관측'));
+  // observe 모드 복귀
+  await page.click('[data-testid="mode-observe"]');
+  await page.waitForTimeout(200);
+}
 
 // ===== Level 3: 흐름 =====
 console.log('\n[Level 3] 흐름 검증');


### PR DESCRIPTION
## Summary

P10-C Phase **최종 마무리** — Fact-First 원칙의 attribution + transparency 박제. P10-C DoD 전체 완료.

## Behavior Changes

### AboutModal (신규)
- 헤더 우측 `?` 버튼으로 오픈 (data-testid=\`about-button\`)
- **4개 출처** attribution 링크 + 라이선스:
  - IAU 2015 Resolution B3 (태양·지구·목성 nominal)
  - NASA Planetary Fact Sheet (수성·금성·화성·토성·천왕성·해왕성)
  - NASA JPL Horizons / SSD (위성·왜소행성·혜성)
  - Standish & Williams (1992) / DE440 (J2000.0 궤도 요소)
- **현재 viewMode 별 정책**:
  - educational: 과장 요약 (항성 ×20 / 행성·위성 ×500 / 왜소행성 ×2,000 / 혜성 ×20,000)
  - scientific: 1.0 비율 안내 ("대부분 천체가 sub-pixel — 줌 인으로 초점")
- **공차 ±0.01%** 명시 (Fact-First 원칙 §2)
- Esc / 닫기 버튼 / 외부 클릭 닫기

### CelestialInfoPanel 감사 필드 노출 (P10-B → UI 연결)
- **"데이터 출처" 섹션 신설**:
  - `dataSource`: "IAU 2015 Resolution B3 §2" 등 (배열은 `/` 로 결합)
  - `lastVerified`: "2026-04-21"
  - `colorSource`: 관측 / 아티스트 / 추론 (한국어 매핑)
- **mass/radius 옆 uncertainty 표시** — irregular body (Phobos/Deimos/Haumea/혜성 등) 에 ±% 로 노출

## 신규/수정

- `apps/web/src/components/layout/about-modal.tsx` (신규, 150줄)
- `apps/web/src/components/layout/about-modal.test.tsx` (8 테스트)
- `apps/web/src/components/layout/app-shell.tsx` — AboutModal 배치
- `apps/web/src/components/panels/celestial-info-panel.tsx` — 감사 섹션 + uncertainty 컬럼
- `scripts/browser-verify-view-mode.mjs` — C-3 검증 11건 추가

## 검증

- **pnpm -r test**: 294 tests passed (+8 AboutModal)
- **pnpm -r typecheck**: 통과 (`data.dataSource: string | readonly string[]` narrowing 수정)
- **pnpm --filter @astro-simulator/web build**: 성공
- **browser-verify-view-mode.mjs**: **42/42 PASS** (+11 C-3)
  - About 출처 3건 (IAU/NASA/JPL) 렌더 확인
  - Esc 키 닫기 동작
  - 지구 focus → info panel 감사 필드: `audit-data-source="IAU 2015"` / `audit-last-verified="2026-04-21"` / `audit-color-source="관측"`
- **browser-verify.mjs**: 25/25 PASS (회귀 없음)

## P10-C 전체 완료 (3 PR)

| Phase | PR | 핵심 Behavior Change |
|---|---|---|
| C-1 | [#279](https://github.com/coseo12/astro-simulator/pull/279) | viewMode store + URL `?view=` + 토글 UI + 키보드 m |
| C-2 | [#280](https://github.com/coseo12/astro-simulator/pull/280) | scientific 실제 과장 해제 (scaling 500→1) + 배지 + 온보딩 + 안내 |
| C-3 | **본 PR** | About 크레딧 + info panel P10-B 필드 노출 |

## 다음 (P10-D)

정확도 이슈 소화 (B→C→D 직렬 — Gemini 교차검증 수용):
- [#261](https://github.com/coseo12/astro-simulator/issues/261) Galilean φ₀ = 218° → 180° (Laplace 평형점)
- [#263](https://github.com/coseo12/astro-simulator/issues/263) Osculating 속도 추정 timeScale 내성화
- [#255](https://github.com/coseo12/astro-simulator/issues/255) 목성 J2/J4 편평도 세차 반영

후속 → P10-D.5 벤치 회귀 측정.

## Test plan

- [x] AboutModal 8 단위 테스트 (렌더/클릭/Esc/출처/viewMode 분기)
- [x] browser-verify-view-mode.mjs 42/42 PASS
- [x] 기존 browser-verify.mjs 회귀 없음
- [x] typecheck + build + 인코딩 검증

## 체크리스트 JSON

\`\`\`json
{
  "commit_sha": "bbc9561",
  "pr_url": "PENDING",
  "pr_comment_url": null,
  "labels_applied_or_transitioned": [],
  "auto_close_issue_states": {"#278": "OPEN → CLOSED (머지 시)"},
  "blocking_issues": [],
  "non_blocking_suggestions": [
    "hover 기반 배지 (pointer event 통합) 는 후속 이슈 — 현재 focus 기반 MVP 로 계약 부합",
    "scale-badge 의 MAX_SCALE_BY_KIND SSoT ssr-safe 분리 — P11 이전 별도 이슈 검토 (shared/visual-constants)"
  ],
  "spawned_bg_pids": [],
  "bg_process_handoff": "sub-agent-confirmed-done"
}
\`\`\`

Closes #278
Builds on: #279 / #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)