### PR TITLE
[#288] P11-A Floating Origin — scientific 모드 jitter 해소

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -282,13 +282,28 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         instance.setCameraHandlers(
           (bodyId: string) => {
             const mesh = solar.meshes.get(bodyId);
-            if (mesh) controller.focusOn({ mesh });
+            if (mesh) {
+              // P11-A #288 — Floating Origin primary shift (ADR §1-B).
+              // focus 전환과 **동일 프레임** 에 origin 을 해당 body 월드 좌표로 이동.
+              // 이후 `updateAt` 이 body 를 scene 원점 근처에서 렌더 → float32 jitter 제거.
+              solar.setFocusOrigin(bodyId);
+              controller.focusOn({ mesh });
+            }
           },
           () => controller.reset(35),
           (radius: number) => {
             camera.radius = radius;
           },
         );
+
+        // P11-A #288 — dev 빌드 한정 `__floatingOrigin` 전역 노출 (검증 스크립트용).
+        // prod 에서도 `__solarScene.floatingOrigin` 경유 접근 가능하지만 편의상 top-level 도 제공.
+        if (process.env.NODE_ENV !== 'production') {
+          Object.defineProperty(window, '__floatingOrigin', {
+            configurable: true,
+            get: () => solar.floatingOrigin,
+          });
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;

--- a/apps/web/src/store/sim-store.test.ts
+++ b/apps/web/src/store/sim-store.test.ts
@@ -158,4 +158,24 @@ describe('useSimStore', () => {
       });
     });
   });
+
+  // P11-A #288 — DoD γ: Zustand store Heliocentric 불변식 계약.
+  describe('Floating Origin 배선 후에도 store 는 Heliocentric 불변식 유지 (P11-A #288 DoD γ)', () => {
+    it('store 에 body 월드 좌표 field 가 없음 — scene 좌표 누출 경로 차단', () => {
+      // 현재 store state 에는 body 월드 좌표가 저장되어 있지 않다 (__solarScene.meshes 직접 접근 경로).
+      // 본 테스트는 미래 drift 방어 — 누군가 body 월드 좌표를 store 에 추가했다면 절대 Heliocentric (m) 이어야 함.
+      const state = useSimStore.getState();
+      const keys = Object.keys(state);
+      // scene / shifted / local 어휘를 포함한 key 는 scene 좌표 누출 신호
+      const suspectKeys = keys.filter((k) => /scene|shifted|local|floating|origin/i.test(k));
+      expect(suspectKeys).toEqual([]);
+    });
+
+    it('계약 주석 위반 감지 — 미래 body world 좌표 추가 시 키 네이밍 가이드', () => {
+      // 이 테스트는 의도적으로 주석-테스트 계약으로 남긴다 (ADR §3 주석 계약 + CLAUDE.md 주석 계약 교훈).
+      // body 월드 좌표를 store 에 추가하는 순간 필드명은 `bodyWorldPositionsHelio` 등 Heliocentric 명시,
+      // 그리고 위 suspect-key 테스트가 예외 경로로 허용하도록 명시적으로 allowlist 갱신 필수.
+      expect(true).toBe(true);
+    });
+  });
 });

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -52,6 +52,16 @@ export const RUNNABLE_ENGINES: ReadonlySet<PhysicsEngineKind> = new Set([
  *
  * Core에서 방출되는 이벤트를 어댑터가 이 store에 반영한다.
  * 컴포넌트는 이 store를 선택적으로 구독한다 (리렌더 최소화).
+ *
+ * ## 좌표계 불변식 (P11-A #288, ADR `docs/decisions/20260422-floating-origin.md` §3)
+ *
+ * 만약 body 월드 좌표를 이 store 에 추가하게 되면 **반드시 Heliocentric 절대 좌표 (m)** 를 유지한다.
+ * - Rust physics engine state: Heliocentric 절대 좌표 (m)
+ * - 본 store state: Heliocentric 절대 좌표 (m) — 정보 패널 거리 표시, JPL 호환
+ * - Babylon/Three.js scene 좌표: Scene 삽입 **직전** 에만 Floating Origin 행렬 변환 적용 (shift-local)
+ *
+ * Scene 좌표 (shift-local 또는 scene unit) 가 store 로 누출되면 origin shift 에 따라
+ * UI 숫자가 흔들려 사용자 혼란 + JPL 외부 비교 불가 → 즉시 버그로 간주.
  */
 export interface SimStoreState {
   // 엔진 상태

--- a/docs/decisions/20260422-floating-origin.md
+++ b/docs/decisions/20260422-floating-origin.md
@@ -1,0 +1,247 @@
+# ADR: Floating Origin — scientific 모드 float32 jitter 해소
+
+- **상태**: Accepted
+- **날짜**: 2026-04-22
+- **결정자**: architect (P11-A #288)
+- **관련**: P11-A #288 (본 마일스톤), #271 (close 대상 — P10 known issue), #247 (P11-B 관찰), #256 (P16), P10-A #268 (로드맵 v2 박제), ADR `20260420-mobile-support-suspension.md` (M1 백업 경로 비현실성 근거), ADR `20260419-satellite-orbit-hybrid.md` (parentId 계층 계약 — 데이터 확장 전제)
+
+## 배경
+
+로드맵 v2 §P11 (`docs/phases/roadmap-v2-solar-precision.md` line 75~96) 의 3-way 분할 중 첫 번째. IAU 2015 실측 거리 (해왕성 궤도 4.5e12 m ≈ 30 AU) 를 `?view=scientific` 모드로 렌더 시 **float32 좌표 정밀도 한계**로 카메라 이동 시 jitter 발생 — P10 known issue #271 + Gemini 교차검증 Medium 고유 발견 근거.
+
+**물리적 원인**:
+
+- GPU 렌더 파이프라인은 float32. 30 AU = 4.5e12 m 스케일에서 float32 유효숫자 ~7자리 → 카메라 pan 마다 하위 비트가 손실되어 body 중심 픽셀이 ±1~3px 점프
+- Babylon 씬 단위: `1 scene unit = 1 AU` (`SCENE_UNIT_PER_METER = 1/AU`). scene 좌표로 환산해도 해왕성까지 30 단위, log-depth 와 조합하여 depth 는 해결되지만 position 은 여전히 float32 cast 직전 손실 발생
+- P10 educational 모드는 `maxScaleForKind` 로 body 크기를 과장 (`MAX_VISUAL_SCALE_PLANET = 500`) 해 시각적으로 jitter 가 body radius 보다 작아 가려짐. scientific 모드는 scale=1 강제 (P10-C-2 #278) 라 jitter 가 pixel 단위로 노출
+
+**이미 존재하는 자산** (CLAUDE.md "신규 함수 ≠ 신규 구현" 교훈):
+
+- `packages/core/src/coords/floating-origin.ts` — `FloatingOrigin` 클래스 완성 (update/toWorld/toLocal/reset). 단위 테스트 7건 존재
+- `packages/core/src/coords/rte.ts` — `toRelativeToEye` / `manyToRelativeToEye` — CPU float64 → GPU float32 RTE 변환
+- `packages/core/src/coords/vec3.ts` — `Vec3Double` 타입, `subtract`, `length`, `add`
+- `CameraController` (`packages/core/src/scene/camera-controller.ts`) 주석: "C7/P2에서 coords/FloatingOrigin 통합 예정" — **미통합 상태, 본 Phase 에서 배선**
+
+즉 P11-A 는 "구현 신설"이 아니라 **"기존 `FloatingOrigin` 유틸을 scene/카메라/update 루프에 배선"** 이 본질. ADR 의 초점은 알고리즘 선택이 아니라 **배선 지점 / 좌표계 계약 / 트리거 정책 / smoothing 전략 / 회귀 가드** 에 있다.
+
+**Zustand 좌표계 불변식 전제** (cross-validate 반영 §5):
+
+- Rust physics engine state: Heliocentric 절대 좌표 (변경 없음)
+- Frontend Zustand store state: Heliocentric 절대 좌표 (정보 패널 거리 표시, JPL 호환)
+- Three.js / Babylon scene 좌표: Scene 삽입 직전에만 Floating Origin 행렬 변환 적용
+
+## 후보 비교
+
+### 1. Floating Origin 트리거 알고리즘
+
+| 후보                                                                   | 정확도                            | 구현 복잡도                                       | Discontinuity 위험                                        | 비고                                                          |
+| ---------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------- |
+| **A. 카메라 위치 기반 threshold shift** (현 `FloatingOrigin.update()`) | ⭐ 어떤 focus 든 카메라 근처 보장 | ⭐ 기존 API 즉시 배선                             | △ 사용자 pan 중 shift → hysteresis 필요                   | 기본 — 임계 초과 시 origin 을 카메라 위치로 1회 이동          |
+| **B. focus body 기반 origin = focus target 좌표**                      | ⭐ focus body 가 항상 정확히 원점 | △ focus 전환 시마다 명시적 origin update          | ⭐ focus 전환 = origin shift 1회, 중간 discontinuity 없음 | focus 전환 hook (`controller.focusOn` + `reset`) 에서만 shift |
+| **C. 가장 가까운 major body 기반**                                     | △ 카메라가 두 body 사이면 불안정  | ✗ 근접 body 탐색 매 프레임 O(N) + hysteresis 복잡 | ✗ body 경계에서 빈번한 shift                              | 기각 — 상호 이동하는 solar system 에서 flicker 리스크         |
+
+**결정**: **B (focus body origin) + A (카메라 이동 거리 safety net)** 하이브리드.
+
+근거:
+
+- B 단독으로는 free-fly 카메라 (focus 없는 사용자 drag zoom) 에서 jitter 재발 — focus 를 벗어난 pan 에 대응 불가
+- A 단독으로는 focus 전환 순간 카메라가 이미 멀리 떨어진 상태에서 shift 가 한 템포 늦게 발동 → focus 전환과 shift 사이 flicker 1 프레임 발생 가능
+- **B 가 primary**: `controller.focusOn(mesh)` 호출 시 즉시 `fo.reset()` 후 origin 을 해당 mesh 의 world 좌표로 set. scene 의 모든 body mesh 위치를 새 origin 기준으로 재계산
+- **A 가 secondary (safety net)**: focus 없는 자유 탐색 중 카메라 local 좌표 `|cameraLocal| > threshold` 초과 시 기존 `fo.update(cameraWorld)` 로 추가 shift. hysteresis 는 threshold 단일값 (1 AU) 으로 충분 — 카메라가 1 AU 이상 이동해야 shift 발동하므로 빈번한 toggle 위험 낮음
+- `FloatingOrigin.update()` API 는 이미 카메라 위치 기반이므로 **신규 코드는 B 전용 `setOriginToBody(bodyWorldPos)` 헬퍼 추가** 1개만 필요. 기존 클래스 파괴적 변경 없음
+
+### 2. Trail / Particle GPU 버퍼 shift 전략 (cross-validate 반영 §3)
+
+| 후보                                                  | 성능                        | 정확도                   | 구현 복잡도                               | 적용 시점       |
+| ----------------------------------------------------- | --------------------------- | ------------------------ | ----------------------------------------- | --------------- |
+| **A. Origin shift 시 기존 GPU 버퍼 일괄 translation** | ⭐ 1 frame 내 일괄 업데이트 | ⭐ 기존 궤적 연속성 보존 | △ 버퍼 모듈별 `translate(delta)` API 신규 | Trail 도입 시점 |
+| **B. Origin 변경 시 Trail/Particle clear 후 재생성**  | △ clear = flicker 1 프레임  | ✗ 궤적 끊김 regression   | ⭐ 기존 buffer 폐기만                     | Trail 도입 시점 |
+| **C. 계약만 수립 — Trail 미도입이므로 구현은 후속**   | ⭐ 현재 비용 0              | ⭐ 추상화 명세만         | ⭐ 규약 주석 + 회귀 테스트 skip           | P11-A 본 Phase  |
+
+**결정**: **C (계약 수립) + 향후 Trail 도입 시 A 채택**.
+
+근거:
+
+- **현재 코드베이스에 Trail 모듈 없음** — `Grep "Trail|onBeforeRender|useFrame"` 결과 0건 (`packages/core/src` 전범위). `AsteroidBelt.writeWorldPositions` 는 매 프레임 flat positions 에서 ThinInstance 를 완전 덮어쓰므로 shift 영향 없음 (매 프레임 상태가 engine 에서 다시 옴)
+- 따라서 본 Phase 는 "shift 시 GPU 버퍼 translate" 를 **미래 Trail 모듈의 계약 (규약)** 으로 박제. 실제 구현은 Trail 이 도입되는 Phase (현 로드맵엔 없음, 예: P14+ 혜성 궤적)
+- **계약 구현**: `FloatingOrigin` 인터페이스에 `onOriginShift(listener: (delta: Vec3Double) => void): () => void` subscription API 추가. 미래 Trail/Particle 모듈이 mount 시 subscribe → delta 만큼 버퍼 translate
+- Strategy B 는 원칙적으로 거부 — volt #33 "headless false positive" 계열로 궤적 끊김은 QA 실 브라우저 3단계 검증 대상인데, 본 Phase QA 가 놓치면 회귀 감지 지연
+
+### 3. 좌표계 계약 — 변환 함수 위치와 호출 지점
+
+| 후보                                                | Zustand 불변식 유지 | Rust engine 경계   | 구현 위치                               | 비고                                         |
+| --------------------------------------------------- | ------------------- | ------------------ | --------------------------------------- | -------------------------------------------- |
+| **A. scene update 루프 마지막 단계에서 shift 적용** | ⭐                  | ⭐ engine 무변경   | `solar-system-scene.ts` `updateAt` 후반 | mesh.position 을 local 좌표로 기록           |
+| **B. mesh.position setter 를 wrapper 로 감싸기**    | ⭐                  | ⭐                 | Babylon mesh 전체 hook                  | Babylon 내부 구현 의존, 파손 위험            |
+| **C. Rust engine 좌표계 자체를 Floating Origin 화** | ✗                   | ✗ engine 계약 깨짐 | `nbody.rs`                              | 기각 — Rust 는 절대 좌표 (heliocentric) 유지 |
+
+**결정**: **A**.
+
+**구현 위치 명세**:
+
+1. **생성**: `sim-canvas.tsx` 의 `useEffect` 내 `SimulationCore` start 후 `new FloatingOrigin(threshold)` 1개 생성 → window 전역 노출 (`__floatingOrigin`, dev/검증용)
+2. **focus 전환 시 reset + setOrigin**: `controller.focusOn(mesh)` 호출 지점 (`instance.setCameraHandlers` 콜백) 에서 `fo.reset()` + `fo.setOriginToBody(meshWorldPos)` 호출
+3. **매 프레임 safety net**: `solar-system-scene.ts` `updateAt(jd)` 함수 마지막, 기존 `mesh.position.set(world * SCENE_UNIT_PER_METER)` 루프를 다음으로 교체:
+   ```ts
+   // 기존: mesh.position.set(world[0] * SCENE_UNIT_PER_METER, ...)
+   // 변경: local = fo.toLocal(world_in_meters); mesh.position.set(local[0] * SCENE_UNIT_PER_METER, ...)
+   ```
+4. **safety net shift 트리거**: `updateAt` 말미에 `fo.update(cameraWorldInMeters)` 1회 호출. shift 발생 시 해당 프레임 mesh 위치는 이미 shift 반영된 local 로 기록됨 (3번 루프가 fo 상태를 읽으므로 자동 일관성)
+5. **주석 계약 박제** — mesh.position 할당 지점 직상단에 주석:
+   ```ts
+   // Floating Origin 계약 (ADR 20260422-floating-origin.md §3):
+   //   - world: Heliocentric 절대 좌표 (m) — Rust engine / Zustand store 와 동일
+   //   - local: fo.toLocal(world) — scene 삽입 직전 origin shift 적용
+   //   - mesh.position: scene unit (local * 1/AU)
+   //   이 3단 변환을 우회하면 float32 jitter regression 재발 (#271 재현).
+   ```
+
+**CLAUDE.md 주석 계약 vs 구현 drift 교훈 반영** — 본 주석 계약은 테스트로도 커버: `solar-system-scene.test.ts` 에 "mesh.position 이 fo.toLocal(world) 과 일치한다" assert 추가.
+
+### 4. Origin shift threshold 값
+
+| 후보                               | 배경                                              | 장점              | 단점                          |
+| ---------------------------------- | ------------------------------------------------- | ----------------- | ----------------------------- |
+| **A. 1 AU (1.496e11 m)**           | scene unit 1 = 1 AU, safety net 만 보조           | 분기 빈도 최소    | 1 AU 이동 중 jitter 재발 가능 |
+| **B. 0.1 AU (1.496e10 m)**         | DoD β (≤1e5 m) 와 거리 멀지만 jitter 실측 한계 내 | jitter 선제 차단  | focus 전환 주기보다 자주 발동 |
+| **C. focus body 주기 의존 (동적)** | 달 (3.84e8 m) 포커스면 threshold ~ 1e9 m          | focus 스케일 적응 | 복잡, 디버깅 어려움           |
+
+**결정**: **A (1 AU = 1.496e11 m)**.
+
+근거:
+
+- B 는 focus 기반 origin shift (결정 1 전략 B) 가 primary 이므로 불필요. safety net 은 focus 없는 free-fly 에서만 발동하며 사용자가 1 AU 이상 이동하는 경우는 "태양계 간 광역 pan" 정도로 빈도 낮음
+- C 는 P11-A 비-범위 (Tier Preset 과 유사한 분기 로직). P11-C 에서 재검토
+- A 는 `FloatingOrigin` 기본 threshold (10_000 m) 와 다르므로 **생성자에 `threshold = AU` 명시**
+
+### 5. Origin shift 프레임 smoothing (flicker 방어)
+
+| 후보                                  | 효과                 | 구현 복잡도 | 비고                                                                  |
+| ------------------------------------- | -------------------- | ----------- | --------------------------------------------------------------------- |
+| **A. 즉시 shift (1 프레임 내 적용)**  | ⭐ 단순, 결정론적    | ⭐          | focus 전환은 이미 `Animation.CreateAndStartAnimation` 으로 300ms 보간 |
+| **B. 1 프레임 선형 interp**           | △ 수치적 불연속 숨김 | △           | 카메라 interp 와 merge 시 복잡도 증가                                 |
+| **C. shift 직후 render skip 1 frame** | ✗ flicker 는 더 보임 | ⭐          | 기각                                                                  |
+
+**결정**: **A (즉시 shift)**.
+
+근거:
+
+- focus 전환은 이미 `CameraController.focusOn` 내 Babylon `Animation` 이 300ms easing 보간 → **animation 시작 시점에 origin shift 1회** 로 처리하면 animation 중간에는 mesh 위치가 local 좌표에서 자연스럽게 animation. 별도 smoothing 불필요
+- Safety net shift (A 전략) 는 사용자가 1 AU 이동해야 발동 — 이 순간 사용자는 wide zoom 상태이므로 1 픽셀 shift 는 육안 감지 불가 (scientific 모드 even scale=1 에서 1 AU 이동 중 행성은 sub-pixel)
+- 본 Phase 에서 복잡한 smoothing 은 **과공학**. QA 에서 flicker 실측 시 B 로 upgrade 재검토 (재검토 조건 §4)
+
+### 6. DoD 검증 방법
+
+#### 6-α: 픽셀 안정성 DoD (카메라 matrix projection 기반, cross-validate §2 반영)
+
+- **검증 대상**: 1 AU 줌 상태 카메라 pan 시 인접 2프레임 간 body 중심 projected pixel shift
+- **측정 방법** (렌더 결과 비의존, 결정론적):
+  1. body world 좌표 (m) 를 `fo.toLocal(world) * SCENE_UNIT_PER_METER` 로 scene 좌표 변환
+  2. Babylon camera `getViewMatrix()` × `getProjectionMatrix()` 곱을 계산해 clip-space 변환
+  3. clip-space → NDC → screen-space (viewport width/height 곱) 로 pixel 좌표 계산
+  4. 프레임 N 과 N+1 의 pixel 좌표 차분이 ≤ 0.5px 인지 assert
+- **구현 위치**: `apps/web/scripts/browser-verify-floating-origin.mjs` (신규, 기존 browser-verify 스크립트 패턴)
+- **보조**: 실 Chrome GUI 육안 확인 (volt #33 "headless false positive" 방어 — headless 만으로 accept 금지)
+
+#### 6-β: 좌표 오차 DoD (dev 빌드 assert)
+
+- **검증 대상 (cross-validate §1 반영)**: 현재 focus body + 카메라 의 `fo.toLocal(world)` 절대값 ≤ 1e5 m (100 km)
+- **비검증 대상**: 원거리 background body (예: 목성 focus 중 태양 좌표 7.7e8 m) — 이들은 LOD low billboard 로 픽셀 오차 은폐 (P11-B 범위). 본 Phase 에선 일반 body 로 렌더되지만 scale=1 scientific 모드에서 sub-pixel 이므로 jitter 가 육안 검출 안 됨
+- **구현 위치**: dev 빌드 한정 (`process.env.NODE_ENV !== 'production'` 가드). `solar-system-scene.ts` `updateAt` 말미:
+  ```ts
+  if (process.env.NODE_ENV !== 'production') {
+    const focusLocal = fo.toLocal(focusBodyWorld);
+    const cameraLocal = fo.toLocal(cameraWorldInMeters);
+    console.assert(
+      Math.max(Math.abs(focusLocal[0]), Math.abs(focusLocal[1]), Math.abs(focusLocal[2])) < 1e5,
+      `[floating-origin] focus body local 좌표 초과: ${focusLocal}`,
+    );
+    console.assert(
+      Math.max(Math.abs(cameraLocal[0]), Math.abs(cameraLocal[1]), Math.abs(cameraLocal[2])) < 1e5,
+      `[floating-origin] camera local 좌표 초과: ${cameraLocal}`,
+    );
+  }
+  ```
+- prod 빌드에선 dead-code elimination 으로 제거 (`process.env.NODE_ENV` pattern)
+
+#### 6-γ: Zustand Heliocentric 불변식 테스트 (cross-validate §5 반영)
+
+- **검증 대상**: origin shift 전후 Zustand store state 의 `worldPositions` (있다면) 또는 정보 패널이 읽는 body world 좌표가 절대값 유지 (shift 영향 없음)
+- **구현 위치**: `apps/web/src/store/sim-store.test.ts` 에 테스트 1건 추가 ("scientific 모드 origin shift 후에도 store 의 body 좌표는 Heliocentric 절대값 유지"). 단위 테스트 — Babylon scene 없이 `FloatingOrigin` 인스턴스 직접 조작
+- **실제로 store 는 현재 body world 좌표를 저장하지 않음** (panels 는 `__solarScene.meshes` 로 접근 또는 어댑터 경유 이벤트). **계약 주석**: `sim-store.ts` 상단에 "만약 body 월드 좌표를 store 에 추가할 때는 반드시 Heliocentric 절대 좌표 (m) 유지. scene 좌표 누출 금지 (#288 ADR §3)" 박제
+
+## 결정
+
+**배선 전략 요약**:
+
+1. **API 확장**: `FloatingOrigin` 에 `setOriginToBody(world: Vec3Double): Vec3Double` 헬퍼 + `onOriginShift(listener): () => void` subscription 2개 추가 (기존 API 파괴적 변경 없음)
+2. **Primary (focus body 기반, 결정 §1-B)**: `instance.setCameraHandlers` focus 콜백에서 `fo.setOriginToBody(mesh 의 world 좌표)`
+3. **Secondary (safety net, 결정 §1-A)**: `updateAt(jd)` 말미에서 `fo.update(cameraWorldInMeters)` 호출. threshold = 1 AU (§4)
+4. **좌표 변환 지점** (결정 §3): `solar-system-scene.ts` `updateAt` 의 mesh.position 할당 루프에서 `fo.toLocal(world)` 사용
+5. **Trail/Particle 계약** (결정 §2): subscription API 로 계약만 수립, 실제 구현은 미래 Trail 모듈 도입 시 A 전략 따름
+6. **Smoothing**: 없음 — focus animation 기반 자연 smoothing (결정 §5-A)
+7. **DoD α 검증**: camera matrix projection 기반 결정론적 pixel shift 계산 + 실 Chrome 육안 (§6-α)
+8. **DoD β 검증**: dev 빌드 assert (focus body + 카메라 local ≤ 1e5 m, §6-β)
+9. **DoD γ 검증**: Zustand Heliocentric 불변식 단위 테스트 + 주석 계약 (§6-γ)
+10. **#271 회귀 방어**: 기존 "scientific 모드 jitter" 재현 시나리오 (목성→지구 zoom) 를 browser-verify 스크립트에 영구 등록
+
+**비-범위 재확인** (이슈 #288 본문 + cross-validate §4 반영):
+
+- ❌ LOD 3단계 (P11-B 로 이관)
+- ❌ Tier Preset (P11-C 로 이관)
+- ❌ Distance Scale 모드 (P11-B)
+- ❌ 모바일 Graceful Degradation (P11-C)
+- ❌ PBR / Cloud Layer (P12)
+- ❌ 토성계 위성 (P13)
+- ❌ 위성 Osculating 동기화 구현 (#247, P13 후보)
+- ❌ **M1 백업 경로 (double-precision shim)**: WebGPU f64 미지원으로 **폐기** (cross-validate §4). Floating Origin 을 SPOF 로 간주. 실패 판정 시 대체안은 "LOD low billboard 강제 fallback + scientific 모드 경고 배너" (P11-B 에서 결합)
+- ❌ Trail/Particle 모듈 실제 구현 (계약만, 미래 Phase)
+
+## 결과·재검토 조건
+
+### 예상 결과
+
+- 목성→지구 zoom in 시 scientific 모드 육안 jitter 제거
+- DoD α (projected pixel shift ≤ 0.5px) 충족
+- DoD β (focus+카메라 local 좌표 ≤ 1e5 m) 충족
+- #271 회귀 검증 후 close
+- bench 회귀율 < 5% (`fo.toLocal()` 은 subtract 3회 / per-body / per-frame — O(N) 추가, N=태양계 ~100 규모에서 무시 가능)
+
+### Concrete Prediction (CLAUDE.md "신규 데이터 ≠ 신규 코드" 교훈 반영)
+
+추상화 건강성 예측 박제:
+
+1. **P13 토성계 위성 추가 시** (`packages/core/src/ephemeris/solar-system.json` 에 티탄·엔셀라두스·미마스 등 JSON 엔티티 추가) — Floating Origin 관련 코드 변경 **0 줄**. `updateAt` 루프는 body 수에 무관하게 `fo.toLocal(world)` 호출이 동일하게 적용되어야 한다
+2. **P11-B LOD 시스템 도입 시** — `FloatingOrigin` 자체 코드 변경 **0 줄**. LOD 모듈은 mesh.position 할당 전에 이미 fo.toLocal 이 적용된 좌표를 읽으므로 투명
+3. **P12 PBR 머티리얼 도입 시** — `FloatingOrigin` 자체 코드 변경 **0 줄**. 머티리얼은 좌표와 무관
+4. **미래 Trail 모듈 도입 시** — `FloatingOrigin` 코드 변경 **0 줄**. Trail 은 `onOriginShift` subscription 으로 delta 를 받아 자체 버퍼 translate
+
+이 4가지 예측이 실패하면 (= 계층 수정 필요) Floating Origin 추상화가 부족하다는 신호 → ADR Amendment 박제 후 재설계.
+
+### 재검토 조건
+
+다음 중 하나 발생 시 ADR 재검토:
+
+1. **목성→지구 zoom 에서 DoD α 미달 (픽셀 shift > 0.5px)** — §1 알고리즘 재선택 (B→B+A), §4 threshold 강화 (1 AU→0.1 AU) 순으로 조치
+2. **focus 전환 시 flicker 관찰** — §5 smoothing A→B upgrade (1 프레임 선형 interp)
+3. **Trail 모듈 도입 시 궤적 끊김 regression** — §2 계약 (A: GPU 버퍼 translation) 구현
+4. **bench 회귀율 ≥ 5%** — `fo.toLocal` 을 `manyToLocal` batch API 로 전환 (SIMD 최적화 여지)
+5. **Zustand store 에 body world 좌표 도입 필요 시** — §3 주석 계약 검증 (Heliocentric 절대값 유지), 위반 시 ADR Amendment
+6. **scientific 모드 scale=1 전환에서 jitter 재발견 (다른 경로)** — 원인 추적 후 §3 주석 계약 범위 확장
+
+### 암묵 전제 박제
+
+- Babylon `scene.activeCamera.globalPosition` 단위는 scene unit (1 AU) — `updateAt` 에서 `fo.update` 호출 전 `globalPosition * AU` 로 m 단위 환산 필요
+- `controller.focusOn(mesh)` 의 `mesh.absolutePosition` 도 scene unit — 마찬가지로 m 환산 후 `setOriginToBody` 호출
+- `FloatingOrigin` 내부는 m 단위 일관 — scene unit 과 혼용 금지 (주석 계약)
+- `process.env.NODE_ENV !== 'production'` 가드 — Next.js webpack DCE 로 prod bundle 에서 제거 (기존 `__simStore` 패턴과 동일)
+
+## 참고
+
+- `docs/phases/roadmap-v2-solar-precision.md` §P11 (line 75~96)
+- `docs/principles/fact-first.md` §"scientific 모드 UX 보호" (line 89~96)
+- `docs/decisions/20260420-mobile-support-suspension.md` — 모바일 보류 (M1 백업 경로 비현실성 근거)
+- `docs/retrospectives/p10-retrospective.md` — P10 회고 (#271 known issue 원 기술)
+- CLAUDE.md "신규 함수 ≠ 신규 구현" / "신규 데이터 ≠ 신규 코드" / "주석 계약 vs 구현 drift" 교훈
+- volt #29 (Phase 분리 릴리스 리듬), volt #33 (headless false positive 방어), volt #47 (ADR Concrete Prediction)
+- 기존 자산: `packages/core/src/coords/floating-origin.ts` + `rte.ts` + `vec3.ts`

--- a/docs/decisions/20260422-floating-origin.md
+++ b/docs/decisions/20260422-floating-origin.md
@@ -143,23 +143,21 @@
 - **구현 위치**: `apps/web/scripts/browser-verify-floating-origin.mjs` (신규, 기존 browser-verify 스크립트 패턴)
 - **보조**: 실 Chrome GUI 육안 확인 (volt #33 "headless false positive" 방어 — headless 만으로 accept 금지)
 
-#### 6-β: 좌표 오차 DoD (dev 빌드 assert)
+#### 6-β: 좌표 오차 DoD (dev 빌드 assert) — v2 (2026-04-22 재정정)
 
-- **검증 대상 (cross-validate §1 반영)**: 현재 focus body + 카메라 의 `fo.toLocal(world)` 절대값 ≤ 1e5 m (100 km)
+- **검증 대상**: 현재 **focus body** 의 `fo.toLocal(world)` 절대값 ≤ 1e5 m (100 km)
+- **카메라 local 불포함 (v2 정정)**: Floating Origin 의 목적은 렌더 대상(mesh) 의 scene 좌표 jitter 해소이지 카메라를 원점 근처로 두는 것이 아님. 카메라는 focus body 를 관찰하기 위해 수 AU 떨어진 정상 위치에 배치되며, 카메라 local 에 1e5 m 제한을 두면 scientific 모드 자체가 동작 불가능. float32 jitter 는 mesh local (작은 값) 에서만 발생하므로 카메라 local 은 Three.js/Babylon 내부 부동소수점 관리에 위임
 - **비검증 대상**: 원거리 background body (예: 목성 focus 중 태양 좌표 7.7e8 m) — 이들은 LOD low billboard 로 픽셀 오차 은폐 (P11-B 범위). 본 Phase 에선 일반 body 로 렌더되지만 scale=1 scientific 모드에서 sub-pixel 이므로 jitter 가 육안 검출 안 됨
+- **cross-validate §2 정정 (2026-04-22)**: 초기 cross-validate 교정안 ([#288 comment](https://github.com/coseo12/astro-simulator/issues/288#issuecomment-4293503652)) 이 "focus 대상 + 카메라" 병행을 제안했으나 실 dev 서버 검증에서 매 프레임 `[floating-origin] camera local 좌표 초과 (≥1e5m)` 로 실패하며 잘못된 설계임을 확인. 카메라 local 조건 제거로 재정정
 - **구현 위치**: dev 빌드 한정 (`process.env.NODE_ENV !== 'production'` 가드). `solar-system-scene.ts` `updateAt` 말미:
   ```ts
   if (process.env.NODE_ENV !== 'production') {
     const focusLocal = fo.toLocal(focusBodyWorld);
-    const cameraLocal = fo.toLocal(cameraWorldInMeters);
     console.assert(
       Math.max(Math.abs(focusLocal[0]), Math.abs(focusLocal[1]), Math.abs(focusLocal[2])) < 1e5,
       `[floating-origin] focus body local 좌표 초과: ${focusLocal}`,
     );
-    console.assert(
-      Math.max(Math.abs(cameraLocal[0]), Math.abs(cameraLocal[1]), Math.abs(cameraLocal[2])) < 1e5,
-      `[floating-origin] camera local 좌표 초과: ${cameraLocal}`,
-    );
+    // 카메라 local 체크 없음 — scientific 모드에서 카메라는 수 AU 떨어진 정상 배치.
   }
   ```
 - prod 빌드에선 dead-code elimination 으로 제거 (`process.env.NODE_ENV` pattern)
@@ -181,7 +179,7 @@
 5. **Trail/Particle 계약** (결정 §2): subscription API 로 계약만 수립, 실제 구현은 미래 Trail 모듈 도입 시 A 전략 따름
 6. **Smoothing**: 없음 — focus animation 기반 자연 smoothing (결정 §5-A)
 7. **DoD α 검증**: camera matrix projection 기반 결정론적 pixel shift 계산 + 실 Chrome 육안 (§6-α)
-8. **DoD β 검증**: dev 빌드 assert (focus body + 카메라 local ≤ 1e5 m, §6-β)
+8. **DoD β 검증**: dev 빌드 assert (focus body local ≤ 1e5 m, §6-β v2 — 카메라 local 불포함)
 9. **DoD γ 검증**: Zustand Heliocentric 불변식 단위 테스트 + 주석 계약 (§6-γ)
 10. **#271 회귀 방어**: 기존 "scientific 모드 jitter" 재현 시나리오 (목성→지구 zoom) 를 browser-verify 스크립트에 영구 등록
 
@@ -203,7 +201,7 @@
 
 - 목성→지구 zoom in 시 scientific 모드 육안 jitter 제거
 - DoD α (projected pixel shift ≤ 0.5px) 충족
-- DoD β (focus+카메라 local 좌표 ≤ 1e5 m) 충족
+- DoD β (focus body local 좌표 ≤ 1e5 m, 카메라 local 불포함 — v2 정정) 충족
 - #271 회귀 검증 후 close
 - bench 회귀율 < 5% (`fo.toLocal()` 은 subtract 3회 / per-body / per-frame — O(N) 추가, N=태양계 ~100 규모에서 무시 가능)
 
@@ -235,6 +233,12 @@
 - `controller.focusOn(mesh)` 의 `mesh.absolutePosition` 도 scene unit — 마찬가지로 m 환산 후 `setOriginToBody` 호출
 - `FloatingOrigin` 내부는 m 단위 일관 — scene unit 과 혼용 금지 (주석 계약)
 - `process.env.NODE_ENV !== 'production'` 가드 — Next.js webpack DCE 로 prod bundle 에서 제거 (기존 `__simStore` 패턴과 동일)
+
+## Amendments
+
+| 날짜       | 변경                                                                                                                                                                                                                                       | 이력                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| 2026-04-22 | DoD β 정의에서 카메라 local 제한 제거 — scientific 모드에서 카메라는 focus body 를 관찰하기 위해 수 AU 떨어진 위치가 정상. cross-validate §2 초기 교정 ("focus 대상 + 카메라" 병행) 이 오류였음을 실 dev 서버 매 프레임 assert 실패로 확인 | PR #291 / #292 연쇄 수정 |
 
 ## 참고
 

--- a/packages/core/src/coords/floating-origin-pixel-stability.test.ts
+++ b/packages/core/src/coords/floating-origin-pixel-stability.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { FloatingOrigin } from './floating-origin.js';
+import { type Vec3Double } from './vec3.js';
+
+/**
+ * P11-A #288 DoD α — 픽셀 안정성 (렌더 비의존 결정론적 검증).
+ *
+ * Babylon 의존 없이 **scene 좌표 float32 quantization error** 를 측정한다.
+ *
+ * GPU 파이프라인은 float32. scientific 모드에서 mesh.position 은 scene unit (1 unit = 1 AU).
+ * 해왕성 30 AU 위치 body 가 baseline (shift 없음) 에선 float32 `fround(30 * SCENE_UNIT_PER_METER)`
+ * 근방에 양자화되어 카메라 이동 중 카메라 local 좌표와 body 좌표의 차이가 float32 ε 이하로 떨어지면
+ * projection 후 ±1~3 pixel jitter 발생 (#271 관찰 증상).
+ *
+ * FloatingOrigin 배선 후에는 local ≈ 0 이라 float32 precision 이 원점 근처에서 최대 (ε ~ 1.2e-7).
+ *
+ * 본 테스트는 **quantization error 의 비율** 을 비교해 shift 의 효과를 증명한다.
+ * projection 전체 파이프라인 (view × projection × NDC → pixel) 은 Babylon 의존적이므로 browser-verify
+ * 스크립트가 담당 (QA 단계).
+ */
+
+const AU = 1.495_978_707e11;
+const SCENE_UNIT_PER_METER = 1 / AU;
+
+/** world (m) 를 scene unit 으로 변환 후 float32 cast (GPU 파이프라인 모방). */
+function worldToSceneFloat32(
+  world: Vec3Double,
+  origin: Vec3Double,
+): { x: number; y: number; z: number } {
+  const lx = world[0] - origin[0];
+  const ly = world[1] - origin[1];
+  const lz = world[2] - origin[2];
+  return {
+    x: Math.fround(lx * SCENE_UNIT_PER_METER),
+    y: Math.fround(ly * SCENE_UNIT_PER_METER),
+    z: Math.fround(lz * SCENE_UNIT_PER_METER),
+  };
+}
+
+/**
+ * scene 좌표의 float32 quantization step — 해당 값 근방의 ULP (unit in last place).
+ *
+ * 값이 크면 ULP 도 커진다 (float32 는 mantissa 23 비트).
+ * 30 AU 위치 (scene = 30) 에선 ULP ≈ 30 × 2^-23 ≈ 3.57e-6 (scene unit).
+ * 이를 m 단위로 환산하면 3.57e-6 × AU ≈ 535 km.
+ *
+ * 카메라가 body 에서 0.01 scene unit (1.5e9 m ≈ 10 million km) 떨어진 위치에서 pan 할 때
+ * pixel-level jitter 가 발생할 수 있는 floor 값이다.
+ */
+function float32ULP(value: number): number {
+  // Math.fround(value) 의 인접 float32 값과의 차이.
+  const v = Math.fround(value);
+  if (v === 0) return Math.fround(1e-45); // 최소 subnormal
+  // 지수부 기반: ULP ≈ 2^(floor(log2(|v|)) - 23)
+  const exp = Math.floor(Math.log2(Math.abs(v)));
+  return Math.pow(2, exp - 23);
+}
+
+describe('P11-A #288 DoD α — scene 좌표 float32 quantization', () => {
+  const jupiter: Vec3Double = [5.2 * AU, 0, 0]; // ~5.2 AU
+  const neptune: Vec3Double = [30 * AU, 0, 0]; // ~30 AU
+
+  it('baseline (shift 없음) — 해왕성 30 AU 위치 ULP 는 m 단위 1e5 이상 (jitter 여지)', () => {
+    const scene = worldToSceneFloat32(neptune, [0, 0, 0]);
+    const ulpScene = float32ULP(scene.x);
+    const ulpMeters = ulpScene * AU;
+    // 30 AU scene 좌표 근방 float32 quantization step
+    expect(ulpMeters).toBeGreaterThan(1e5); // 100 km 이상
+    // 이 ULP 만큼 mesh.position 이 frame 마다 변하면 projection 후 pixel 단위 jitter
+  });
+
+  it('baseline — 목성 5.2 AU 위치 ULP (비교)', () => {
+    const scene = worldToSceneFloat32(jupiter, [0, 0, 0]);
+    const ulpScene = float32ULP(scene.x);
+    const ulpMeters = ulpScene * AU;
+    // 5.2 scene unit float32 ULP
+    expect(ulpMeters).toBeGreaterThan(1e4); // 10 km 이상
+  });
+
+  it('FloatingOrigin 배선 후 — 목성 focus 시 body 의 scene 좌표 ULP 는 sub-km (DoD α 충족)', () => {
+    const fo = new FloatingOrigin(AU);
+    fo.setOriginToBody(jupiter);
+    const origin = fo.originOffset;
+    const scene = worldToSceneFloat32(jupiter, origin);
+    // local ≈ 0 → float32 ULP 는 최소 subnormal 근방
+    expect(Math.abs(scene.x)).toBeLessThan(1e-30);
+    expect(Math.abs(scene.y)).toBeLessThan(1e-30);
+    expect(Math.abs(scene.z)).toBeLessThan(1e-30);
+  });
+
+  it('FloatingOrigin 배선 후 — 해왕성 focus 시에도 scene 좌표 ≈ 0 (shift quantization 의 이점)', () => {
+    const fo = new FloatingOrigin(AU);
+    fo.setOriginToBody(neptune);
+    const origin = fo.originOffset;
+    const scene = worldToSceneFloat32(neptune, origin);
+    expect(Math.abs(scene.x)).toBeLessThan(1e-30);
+    expect(Math.abs(scene.y)).toBeLessThan(1e-30);
+    expect(Math.abs(scene.z)).toBeLessThan(1e-30);
+  });
+
+  it('FloatingOrigin 배선 후 — focus 대비 인근 body 도 float32 정밀도 유지 (달: 지구 focus 시)', () => {
+    // 지구 focus 상태에서 달 (지구로부터 ~3.84e8 m) 의 scene 좌표 정밀도 확인
+    const earth: Vec3Double = [AU, 0, 0]; // 1 AU
+    const moon: Vec3Double = [AU + 3.844e8, 0, 0]; // 지구 +384,400km
+    const fo = new FloatingOrigin(AU);
+    fo.setOriginToBody(earth);
+    const origin = fo.originOffset;
+    const moonScene = worldToSceneFloat32(moon, origin);
+    // 달의 scene 좌표 = 3.844e8 / AU ≈ 2.57e-3 scene unit
+    const expectedMoonX = 3.844e8 * SCENE_UNIT_PER_METER;
+    // float32 fround 로도 정밀도 유지 (작은 값이므로 ULP 매우 작음)
+    expect(Math.abs(moonScene.x - expectedMoonX)).toBeLessThan(expectedMoonX * 1e-6);
+    // 달의 ULP 는 2.57e-3 근방이므로 10m 수준 — 프레임 간 변화로 pixel jitter 발생 안 함
+    const ulpMoon = float32ULP(moonScene.x);
+    const ulpMoonMeters = ulpMoon * AU;
+    expect(ulpMoonMeters).toBeLessThan(100); // 100m 이하 (scientific 모드에서 sub-pixel)
+  });
+
+  it('shift 전후 비교 — 해왕성 focus 시 quantization 감소 배율', () => {
+    // shift 없음
+    const noShift = worldToSceneFloat32(neptune, [0, 0, 0]);
+    const ulpNoShift = float32ULP(noShift.x);
+    // FloatingOrigin 배선
+    const fo = new FloatingOrigin(AU);
+    fo.setOriginToBody(neptune);
+    const shifted = worldToSceneFloat32(neptune, fo.originOffset);
+    // shift 후에는 body 좌표가 0 → 인근 카메라 위치 (0.1 scene unit) 로 비교
+    const nearCam = { x: Math.fround(0.1), y: 0, z: 0 };
+    const ulpShiftedCam = float32ULP(nearCam.x);
+    // shift 가 quantization 을 최소 200x 축소 (실측 기대값)
+    expect(ulpNoShift / ulpShiftedCam).toBeGreaterThan(200);
+    expect(Math.abs(shifted.x)).toBeLessThan(Math.abs(noShift.x));
+  });
+});

--- a/packages/core/src/coords/floating-origin.test.ts
+++ b/packages/core/src/coords/floating-origin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { FloatingOrigin } from './floating-origin.js';
-import { vec3 } from './vec3.js';
+import { vec3, type Vec3Double } from './vec3.js';
 
 describe('FloatingOrigin', () => {
   it('임계 거리 미만에서는 shift 없음', () => {
@@ -192,6 +192,96 @@ describe('FloatingOrigin', () => {
       const delta = fo.update(vec3(AU * 1.5, 0, 0));
       expect(delta).not.toBeNull();
       expect(fo.originOffset[0]).toBeCloseTo(AU * 1.5, 0);
+    });
+  });
+
+  // --- #292 회귀 가드: focus 활성 상태에서 safety net 비활성화 계약 ---
+  // `solar-system-scene.ts` updateAt 은 매 프레임:
+  //   1) focus 있으면 `setOriginToBody(focusWorld)` 로 primary shift (ADR §1-B)
+  //   2) focus 없으면 `update(cameraWorld)` 로 safety net (ADR §1-A)
+  // 2개를 **동시에 호출하면** primary 를 safety net 이 덮어써 originOffset 이 카메라 월드 좌표를
+  // 추적 → ADR §3 "Heliocentric 절대 좌표" 계약 위배. 아래 테스트는 scene 호출 패턴을 pure
+  // 함수로 재현해 회귀 방지.
+  describe('scene updateAt 호출 규약 (#292 회귀 가드)', () => {
+    const AU = 1.495_978_707e11;
+
+    // scene 의 "매 프레임" 로직을 순수 함수로 축약. focusWorld 가 주어지면 primary, 없으면
+    // safety net 만 호출. 이 구조를 유지해야 originOffset 이 focus body 를 추적한다.
+    function scenePerFrame(
+      fo: FloatingOrigin,
+      focusWorld: Vec3Double | null,
+      cameraWorld: Vec3Double,
+    ): void {
+      if (focusWorld) {
+        fo.setOriginToBody(focusWorld);
+      }
+      if (!focusWorld) {
+        fo.update(cameraWorld);
+      }
+    }
+
+    it('focus 상태에서 카메라가 1 AU 이상 이동해도 originOffset 은 focus body 만 추적', () => {
+      const fo = new FloatingOrigin(AU);
+      const earth: Vec3Double = [AU, 0, 0]; // ~1 AU
+      // 카메라가 focus body 와 10 AU 이상 떨어진 상태 — safety net 이 발동하면 originOffset
+      // 이 카메라 월드 좌표 (earth + (10AU, 0, 0) = 11AU) 로 이동해버림
+      const cameraWorld: Vec3Double = [AU + AU * 10, 0, 0];
+
+      scenePerFrame(fo, earth, cameraWorld);
+
+      // 기대: focus primary 가 유지되어 originOffset === earth world (≈ 1 AU)
+      expect(fo.originOffset[0]).toBeCloseTo(AU, 0);
+      // 회귀 가드: 카메라 월드 좌표 (11 AU) 를 추적하면 안 됨
+      expect(fo.originOffset[0]).toBeLessThan(AU * 2);
+    });
+
+    it('focus 해제 상태에서는 safety net 이 정상 작동 (카메라 1 AU 이동 시 shift)', () => {
+      const fo = new FloatingOrigin(AU);
+      const cameraWorld: Vec3Double = [AU * 1.5, 0, 0];
+
+      scenePerFrame(fo, null, cameraWorld);
+
+      // safety net 활성 — 카메라 월드 좌표로 shift
+      expect(fo.originOffset[0]).toBeCloseTo(AU * 1.5, 0);
+    });
+
+    it('focus → 해제 → 다시 focus 전환 시나리오', () => {
+      const fo = new FloatingOrigin(AU);
+      const earth: Vec3Double = [AU, 0, 0];
+      const jupiter: Vec3Double = [AU * 5.2, 0, 0];
+
+      // 1) 지구 focus — origin = earth
+      scenePerFrame(fo, earth, [AU * 5, 0, 0]);
+      expect(fo.originOffset[0]).toBeCloseTo(AU, 0);
+
+      // 2) focus 해제 + 카메라 추가 이동 — safety net 이 origin 을 카메라 월드로 이동
+      // (이 시점 origin 은 지구 AU 이므로 카메라 local 5 AU → world 6 AU)
+      const camLocal: Vec3Double = [AU * 5, 0, 0];
+      const camWorld: Vec3Double = [AU * 5 + AU, 0, 0];
+      scenePerFrame(fo, null, camWorld);
+      expect(fo.originOffset[0]).toBeCloseTo(AU * 6, 0);
+      void camLocal;
+
+      // 3) 다시 목성 focus — origin = jupiter (safety net 결과 무관하게 primary 재적용)
+      scenePerFrame(fo, jupiter, [AU * 10, 0, 0]);
+      expect(fo.originOffset[0]).toBeCloseTo(AU * 5.2, 0);
+    });
+
+    it('DoD β: focus body 의 local 좌표는 focus 활성 프레임에서 ≤ 1e5 m', () => {
+      // 버그 당시 시나리오 재현: originOffset 이 카메라 월드 (예: 1173 AU) 를 추적하면
+      // focus body local 이 수백 AU 단위가 되어 DoD β (≤ 1e5 m) 를 위반.
+      const fo = new FloatingOrigin(AU);
+      const jupiter: Vec3Double = [AU * 5.2, 0, 0];
+      const farCamera: Vec3Double = [AU * 1173, 0, 0];
+
+      scenePerFrame(fo, jupiter, farCamera);
+      const jupiterLocal = fo.toLocal(jupiter);
+      const localMax = Math.max(
+        Math.abs(jupiterLocal[0]),
+        Math.abs(jupiterLocal[1]),
+        Math.abs(jupiterLocal[2]),
+      );
+      expect(localMax).toBeLessThan(1e5);
     });
   });
 });

--- a/packages/core/src/coords/floating-origin.test.ts
+++ b/packages/core/src/coords/floating-origin.test.ts
@@ -284,4 +284,105 @@ describe('FloatingOrigin', () => {
       expect(localMax).toBeLessThan(1e5);
     });
   });
+
+  // --- DoD β v2 (2026-04-22): 카메라 local 조건 제거 회귀 가드 ---
+  // ADR §6-β v2 / §Amendments 2026-04-22. cross-validate §2 초기 교정이 "focus + 카메라"
+  // 병행을 제안했으나 scientific 모드에서 카메라는 focus body 관찰을 위해 수 AU 떨어진
+  // 정상 배치. 카메라 local 에 1e5 m 제한을 두면 scene 매 프레임 assert 실패.
+  //
+  // 아래 테스트는 `solar-system-scene.ts` updateAt 말미의 DoD β assert 경로를 pure 함수로
+  // 축약. focus body local 만 검사하고 카메라 local 은 검사하지 않음을 회귀 가드로 박제.
+  describe('DoD β v2 — 카메라 local 조건 제거 회귀 가드 (ADR §6-β v2)', () => {
+    const AU = 1.495_978_707e11;
+
+    // scene 의 DoD β assert 경로를 순수 함수로 축약. focus body local 이 1e5 m 를 넘으면
+    // violation 목록에 추가. 카메라 local 은 의도적으로 검사하지 않음.
+    // 반환: violation 메시지 배열 (빈 배열이면 assert pass)
+    function dodBetaAssert(params: {
+      focusBodyWorld: Vec3Double | null;
+      cameraWorld: Vec3Double;
+      originOffset: Vec3Double;
+    }): string[] {
+      const { focusBodyWorld, originOffset } = params;
+      const violations: string[] = [];
+      if (focusBodyWorld) {
+        const fx = focusBodyWorld[0] - originOffset[0];
+        const fy = focusBodyWorld[1] - originOffset[1];
+        const fz = focusBodyWorld[2] - originOffset[2];
+        const focusLocalMax = Math.max(Math.abs(fx), Math.abs(fy), Math.abs(fz));
+        if (focusLocalMax >= 1e5) {
+          violations.push(`focus body local 초과: ${fx},${fy},${fz}`);
+        }
+      }
+      // 의도적으로 카메라 local 검사 없음 — scientific 모드에서 수 AU 정상 배치.
+      return violations;
+    }
+
+    it('카메라가 focus body 로부터 수 AU 떨어진 정상 상태 — assert 발동 없음', () => {
+      // 실 시나리오: 목성 focus, 카메라는 목성을 관찰하기 위해 5 AU 떨어진 배치.
+      // 버그 버전에서는 이 상태에서 `camera local 좌표 초과` 가 매 프레임 발생했음.
+      const fo = new FloatingOrigin(AU);
+      const jupiter: Vec3Double = [AU * 5.2, 0, 0];
+      fo.setOriginToBody(jupiter);
+      const cameraWorld: Vec3Double = [AU * 5.2 + AU * 5, 0, 0]; // 목성에서 5 AU 떨어진 카메라
+
+      const violations = dodBetaAssert({
+        focusBodyWorld: jupiter,
+        cameraWorld,
+        originOffset: fo.originOffset,
+      });
+
+      expect(violations).toEqual([]);
+    });
+
+    it('버그 재현 시나리오 — 카메라 world = 수백 AU 여도 focus body local 만 검사', () => {
+      // 버그 버전 메시지 예시: `camera local 좌표 초과 (≥1e5m): 551609191979.78, ...`
+      // = 약 3.7 AU. 이 값은 scientific 모드 관찰 배치에서 정상이며 assert 대상 아님.
+      const fo = new FloatingOrigin(AU);
+      const earth: Vec3Double = [AU, 0, 0];
+      fo.setOriginToBody(earth);
+      const farCamera: Vec3Double = [551609191979.78, 267067450948.42, 35002965518.79];
+
+      const violations = dodBetaAssert({
+        focusBodyWorld: earth,
+        cameraWorld: farCamera,
+        originOffset: fo.originOffset,
+      });
+
+      // focus body (earth) local ≈ 0 → pass. 카메라 조건 제거로 전체 pass.
+      expect(violations).toEqual([]);
+    });
+
+    it('focus body local 초과 시에는 여전히 violation 발동 (primary 계약 유지)', () => {
+      // DoD β 의 본질 — focus body local ≤ 1e5 m. 이 조건은 v2 에서도 유지.
+      // origin 이 focus body 와 크게 어긋난 상태를 인위적으로 구성해 violation 유도.
+      const fo = new FloatingOrigin(AU);
+      const earth: Vec3Double = [AU, 0, 0];
+      // origin 을 목성으로 잘못 잡은 상태 (회귀: #292 류 drift)
+      fo.setOriginToBody([AU * 5.2, 0, 0]);
+      const cameraWorld: Vec3Double = [AU * 5, 0, 0];
+
+      const violations = dodBetaAssert({
+        focusBodyWorld: earth,
+        cameraWorld,
+        originOffset: fo.originOffset,
+      });
+
+      expect(violations.length).toBe(1);
+      expect(violations[0]).toMatch(/focus body local 초과/);
+    });
+
+    it('focus 가 null 이면 assert 는 아무것도 검사하지 않음 (free-fly 탐색 중)', () => {
+      const fo = new FloatingOrigin(AU);
+      const farCamera: Vec3Double = [AU * 1000, 0, 0];
+
+      const violations = dodBetaAssert({
+        focusBodyWorld: null,
+        cameraWorld: farCamera,
+        originOffset: fo.originOffset,
+      });
+
+      expect(violations).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/coords/floating-origin.test.ts
+++ b/packages/core/src/coords/floating-origin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FloatingOrigin } from './floating-origin.js';
 import { vec3 } from './vec3.js';
 
@@ -66,5 +66,132 @@ describe('FloatingOrigin', () => {
     expect(() => new FloatingOrigin(-100)).toThrow();
     expect(() => new FloatingOrigin(Number.NaN)).toThrow();
     expect(() => new FloatingOrigin(Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  // --- P11-A #288 ---
+  // Focus body 기반 primary origin shift + subscription API.
+
+  describe('setOriginToBody (P11-A #288)', () => {
+    it('origin 을 body 월드 좌표로 즉시 이동시킨다', () => {
+      const fo = new FloatingOrigin(1_000);
+      const delta = fo.setOriginToBody(vec3(7.7e8, 0, 0));
+      expect(fo.originOffset).toEqual([7.7e8, 0, 0]);
+      expect(delta).toEqual([7.7e8, 0, 0]);
+    });
+
+    it('body 를 focus 한 직후 body.local ≈ 0', () => {
+      const fo = new FloatingOrigin(1_000);
+      const bodyWorld = vec3(1.5e11, 0, 0); // 1 AU
+      fo.setOriginToBody(bodyWorld);
+      const local = fo.toLocal(bodyWorld);
+      expect(Math.max(Math.abs(local[0]), Math.abs(local[1]), Math.abs(local[2]))).toBeLessThan(1);
+    });
+
+    it('threshold 미만 카메라 거리여도 즉시 shift (safety net update 와 독립)', () => {
+      const fo = new FloatingOrigin(1.5e11); // 1 AU threshold
+      // 카메라가 원점 근처라도 focus body 로 강제 이동해야 함
+      const delta = fo.setOriginToBody(vec3(5_000, 0, 0));
+      expect(delta).toEqual([5_000, 0, 0]);
+      expect(fo.originOffset).toEqual([5_000, 0, 0]);
+    });
+
+    it('델타가 0 이면 no-op 이며 null 반환 (예: 동일 body 재focus)', () => {
+      const fo = new FloatingOrigin(1_000);
+      fo.setOriginToBody(vec3(1e10, 0, 0));
+      const delta = fo.setOriginToBody(vec3(1e10, 0, 0));
+      expect(delta).toBeNull();
+    });
+
+    it('누적 shift — 연속 focus 전환 시 origin 은 마지막 body 좌표와 일치', () => {
+      const fo = new FloatingOrigin(1_000);
+      fo.setOriginToBody(vec3(1e10, 0, 0)); // Jupiter 근방
+      fo.setOriginToBody(vec3(7.7e8, 0, 0)); // Earth 근방
+      expect(fo.originOffset).toEqual([7.7e8, 0, 0]);
+    });
+  });
+
+  describe('onOriginShift (P11-A #288, Trail 계약)', () => {
+    it('update 로 shift 발생 시 listener 에 delta 전달', () => {
+      const fo = new FloatingOrigin(10_000);
+      const deltas: number[][] = [];
+      fo.onOriginShift((d) => deltas.push([d[0], d[1], d[2]]));
+      fo.update(vec3(15_000, 0, 0));
+      expect(deltas).toEqual([[15_000, 0, 0]]);
+    });
+
+    it('setOriginToBody 로 shift 발생 시 listener 호출', () => {
+      const fo = new FloatingOrigin(10_000);
+      const deltas: number[][] = [];
+      fo.onOriginShift((d) => deltas.push([d[0], d[1], d[2]]));
+      fo.setOriginToBody(vec3(1e10, 0, 0));
+      expect(deltas).toEqual([[1e10, 0, 0]]);
+    });
+
+    it('threshold 미만 update 는 listener 호출 안 함', () => {
+      const fo = new FloatingOrigin(10_000);
+      const listener = vi.fn();
+      fo.onOriginShift(listener);
+      fo.update(vec3(5_000, 0, 0));
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribe 후 호출되지 않음', () => {
+      const fo = new FloatingOrigin(10_000);
+      const listener = vi.fn();
+      const unsubscribe = fo.onOriginShift(listener);
+      fo.update(vec3(15_000, 0, 0));
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsubscribe();
+      fo.update(vec3(30_000, 0, 0));
+      expect(listener).toHaveBeenCalledTimes(1); // 추가 호출 없음
+    });
+
+    it('listener 예외는 격리되어 다른 listener 와 후속 shift 에 영향 없음', () => {
+      const fo = new FloatingOrigin(10_000);
+      const good = vi.fn();
+      // Trail 모듈 버그 시나리오: 예외가 scene 전체를 break 하면 안 됨
+      fo.onOriginShift(() => {
+        throw new Error('Trail 모듈 버그 시뮬레이션');
+      });
+      fo.onOriginShift(good);
+      // console.error 경로로 빠짐 — 예외 밖으로 propagate 하지 않아야 함
+      expect(() => fo.update(vec3(15_000, 0, 0))).not.toThrow();
+      expect(good).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('scientific 모드 사용 — 1 AU threshold + body-focus (ADR §4 통합 시나리오)', () => {
+    it('목성 focus 후 지구로 전환 시 두 body 모두 local 좌표 ≤ 1e5 m (DoD β)', () => {
+      const AU = 1.495_978_707e11;
+      const fo = new FloatingOrigin(AU);
+      // Heliocentric 절대 좌표 (예시값)
+      const jupiter = vec3(7.8e11, 0, 0); // ~5.2 AU
+      const earth = vec3(1.496e11, 0, 0); // ~1 AU
+
+      // 1) 목성 focus
+      fo.setOriginToBody(jupiter);
+      const jupiterLocal = fo.toLocal(jupiter);
+      expect(
+        Math.max(Math.abs(jupiterLocal[0]), Math.abs(jupiterLocal[1]), Math.abs(jupiterLocal[2])),
+      ).toBeLessThan(1e5);
+
+      // 2) 지구 focus — primary shift 로 origin 재배치
+      fo.setOriginToBody(earth);
+      const earthLocal = fo.toLocal(earth);
+      expect(
+        Math.max(Math.abs(earthLocal[0]), Math.abs(earthLocal[1]), Math.abs(earthLocal[2])),
+      ).toBeLessThan(1e5);
+    });
+
+    it('safety net update — 자유 탐색 중 카메라가 1 AU 이동 시 shift', () => {
+      const AU = 1.495_978_707e11;
+      const fo = new FloatingOrigin(AU);
+      // threshold 미만 (0.5 AU) 은 shift 없음
+      expect(fo.update(vec3(AU * 0.5, 0, 0))).toBeNull();
+      // threshold 초과 (1.5 AU) 는 shift 발동
+      const delta = fo.update(vec3(AU * 1.5, 0, 0));
+      expect(delta).not.toBeNull();
+      expect(fo.originOffset[0]).toBeCloseTo(AU * 1.5, 0);
+    });
   });
 });

--- a/packages/core/src/coords/floating-origin.ts
+++ b/packages/core/src/coords/floating-origin.ts
@@ -1,20 +1,33 @@
 import { length, subtract, type Vec3Double } from './vec3.js';
 
+/** Origin shift 이벤트 listener. 이전 origin → 새 origin 으로의 절대 월드 델타 (m) 를 받는다. */
+export type OriginShiftListener = (delta: Vec3Double) => void;
+
 /**
  * Floating Origin 관리자.
  *
  * 카메라(또는 기준점)가 월드 원점에서 일정 거리 이상 멀어지면 월드 전체 좌표계를 평행이동하여
  * 카메라를 다시 원점 근처로 되돌린다. 씬 그래프는 이 shift만큼 반대로 이동한 것으로 해석된다.
  *
- * ADR: docs/phases/architecture.md §4 "RTE + Floating Origin"
+ * ADR: `docs/decisions/20260422-floating-origin.md` (P11-A #288)
  *
- * 이 클래스는 좌표 계산만 담당한다. 실제 씬 노드 이동은 호출 측(카메라 시스템 C6)에서 수행.
+ * 이 클래스는 좌표 계산만 담당한다. 실제 씬 노드 이동은 호출 측(scene/카메라 시스템)에서 수행.
+ *
+ * ## 트리거 전략
+ *  - `setOriginToBody(world)` — focus 전환 시 primary. 주어진 절대 월드 좌표로 origin 즉시 이동.
+ *  - `update(cameraWorld)` — safety net. free-fly 시 카메라 local 좌표가 threshold 초과하면 shift.
+ *
+ * ## subscription
+ *  - `onOriginShift(listener)` — origin 이 이동할 때마다 delta 를 전달. Trail/Particle 모듈이
+ *    자체 GPU 버퍼를 delta 만큼 translate 할 때 사용 (ADR §2, 미래 Phase 용 계약).
  */
 export class FloatingOrigin {
   /** 누적 원점 오프셋 (월드 절대좌표 누산) */
   #originOffset: Vec3Double = [0, 0, 0];
   /** shift 트리거 임계 거리 */
   readonly threshold: number;
+  /** origin shift listener 집합 (Trail/Particle 모듈용, ADR §2) */
+  readonly #listeners = new Set<OriginShiftListener>();
 
   constructor(threshold = 10_000) {
     if (!(threshold > 0) || !Number.isFinite(threshold)) {
@@ -40,7 +53,7 @@ export class FloatingOrigin {
   }
 
   /**
-   * 카메라(월드 절대좌표)를 받아 필요 시 shift를 수행한다.
+   * 카메라(월드 절대좌표)를 받아 필요 시 shift를 수행한다 (safety net).
    *
    * @returns 이번 호출에서 발생한 shift 델타 (원점 이동량). shift가 없으면 null.
    */
@@ -53,11 +66,55 @@ export class FloatingOrigin {
     // 카메라 로컬 좌표만큼 원점을 이동시켜 카메라를 다시 (0,0,0) 근처로 되돌림
     const o = this.#originOffset;
     this.#originOffset = [o[0] + local[0], o[1] + local[1], o[2] + local[2]];
+    this.#emitShift(local);
     return local;
   }
 
-  /** 원점 리셋 (테스트/전환용) */
+  /**
+   * focus body 기반 primary origin shift (ADR §1-B).
+   *
+   * focus 전환 hook (예: `controller.focusOn`) 에서 호출해 origin 을 focus body 의 절대 월드 좌표로
+   * 즉시 이동시킨다. threshold 를 무시하고 항상 shift 하며, 델타는 이전 origin → 새 origin 이다.
+   *
+   * @param bodyWorld focus body 의 절대 월드 좌표 (m)
+   * @returns 이번 호출의 shift 델타 (이전 origin 대비). 델타가 0 이면 shift 없음으로 간주하고 null 반환.
+   */
+  setOriginToBody(bodyWorld: Vec3Double): Vec3Double | null {
+    const delta = this.toLocal(bodyWorld);
+    // 원점과 완전히 같으면 (예: sun focus 직후 재호출) no-op.
+    if (delta[0] === 0 && delta[1] === 0 && delta[2] === 0) return null;
+    this.#originOffset = [bodyWorld[0], bodyWorld[1], bodyWorld[2]];
+    this.#emitShift(delta);
+    return delta;
+  }
+
+  /**
+   * Origin shift 이벤트 구독.
+   *
+   * 미래 Trail/Particle 모듈이 shift 발생 시 자체 GPU 버퍼를 delta 만큼 translate 할 때 사용한다
+   * (ADR §2 Concrete Prediction #4). 호출 순서는 등록 순서.
+   *
+   * @returns unsubscribe 함수.
+   */
+  onOriginShift(listener: OriginShiftListener): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  /** 원점 리셋 (테스트/전환용). listener 는 호출하지 않는다. */
   reset(): void {
     this.#originOffset = [0, 0, 0];
+  }
+
+  /** 내부: shift 이벤트를 등록 순서대로 발행. listener 예외는 격리 (다른 listener 에 영향 없음). */
+  #emitShift(delta: Vec3Double): void {
+    for (const listener of this.#listeners) {
+      try {
+        listener(delta);
+      } catch (err) {
+        // Trail 모듈 버그가 scene update 전체를 break 하지 않도록 격리.
+        console.error('[floating-origin] onOriginShift listener 예외', err);
+      }
+    }
   }
 }

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -528,10 +528,16 @@ export function createSolarSystemScene(
       floatingOrigin.update(cameraWorldMeters);
     }
 
-    // P11-A #288 DoD β — dev 빌드 assert: focus body + 카메라 의 local 좌표 절대값 ≤ 1e5 m (100 km).
+    // P11-A #288 DoD β v2 — dev 빌드 assert: **focus body** local 좌표 절대값 ≤ 1e5 m (100 km).
     // core 패키지는 `process` 타입이 없으므로 runtime guard 사용. Next.js webpack 이 `process.env.NODE_ENV`
     // 를 빌드 타임 치환 → prod bundle 에서는 `'development' !== 'production'` 이 false 가 되어 DCE.
     // SSR / 테스트 환경은 `globalThis.process` 유/무 가드로 안전 접근.
+    //
+    // 카메라 local 불포함 (2026-04-22 재정정): Floating Origin 의 목적은 렌더 대상(mesh) 의 scene
+    // 좌표 jitter 해소. 카메라는 focus body 를 관찰하기 위해 수 AU 떨어진 위치가 정상이며, 카메라
+    // local 에 1e5 m 제한을 두면 scientific 모드가 물리적으로 동작 불가. float32 jitter 는 mesh
+    // local (작은 값) 에서만 발생하므로 카메라 local 은 Three.js/Babylon 내부 부동소수점 관리에
+    // 위임한다. ADR 20260422-floating-origin.md §6-β / §Amendments 2026-04-22 참조.
     if (floatingOriginAssertEnabled() && cam) {
       const focusId = focusBodyIdForAssert;
       const focusWorld = focusId ? worldPositions.get(focusId) : null;
@@ -545,14 +551,6 @@ export function createSolarSystemScene(
             `[floating-origin] focus body '${focusId}' local 좌표 초과 (≥1e5m): ${fx},${fy},${fz}`,
           );
         }
-      }
-      // 카메라 local (scene unit × AU → m)
-      const cxm = cam.globalPosition.x * AU;
-      const cym = cam.globalPosition.y * AU;
-      const czm = cam.globalPosition.z * AU;
-      const cameraLocalMax = Math.max(Math.abs(cxm), Math.abs(cym), Math.abs(czm));
-      if (cameraLocalMax >= 1e5) {
-        console.error(`[floating-origin] camera local 좌표 초과 (≥1e5m): ${cxm},${cym},${czm}`);
       }
     }
 

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -13,6 +13,7 @@ import { AU, GRAVITATIONAL_CONSTANT, J2000_JD } from '@astro-simulator/shared';
 import { getSolarSystem, type LoadedCelestialBody } from '../ephemeris/solar-system-loader.js';
 import { positionAt } from '../physics/kepler.js';
 import { add } from '../coords/vec3.js';
+import { FloatingOrigin } from '../coords/floating-origin.js';
 import {
   NBodyEngine,
   buildInitialState,
@@ -32,6 +33,29 @@ import { computeVisualScale, maxScaleForKind } from './visual-scale.js';
  * float32/logarithmic depth 조합으로 지구 표면(수 μ AU) ~ 해왕성 궤도(30 AU) 범위 커버.
  */
 const SCENE_UNIT_PER_METER = 1 / AU;
+
+/**
+ * Floating Origin safety net threshold (P11-A #288, ADR §4).
+ *
+ * 1 AU (1.496e11 m) — focus body origin shift (primary) 가 이미 focus 전환마다 origin 재배치를 처리하므로
+ * safety net 은 free-fly 탐색 중 카메라가 1 AU 이상 이동한 경우만 발동한다.
+ * threshold 를 낮추면 빈번한 shift 로 log-depth 재계산 오버헤드 증가 가능.
+ */
+const FLOATING_ORIGIN_THRESHOLD_METERS = AU;
+
+/**
+ * P11-A #288 — dev-only assert gate.
+ *
+ * core 패키지는 `@types/node` 를 의존으로 두지 않으므로 `process` 가 types 에 없다.
+ * runtime 에 `globalThis.process?.env?.NODE_ENV` 를 안전하게 읽고, Next.js webpack 이
+ * 빌드 시점에 `NODE_ENV` 를 리터럴 치환 → prod bundle 에선 이 함수가 `false` 를 반환해
+ * 하위 assert 블록이 DCE 된다.
+ */
+function floatingOriginAssertEnabled(): boolean {
+  const g = globalThis as { process?: { env?: { NODE_ENV?: string } } };
+  const env = g.process?.env?.NODE_ENV;
+  return env !== 'production';
+}
 
 /**
  * 시각 스케일 — #100에서 카메라 거리 의존 동적 계산으로 전환.
@@ -74,6 +98,25 @@ export interface SolarSystemSceneHandles {
   resetMassMultipliers: () => void;
   /** P5-C #179 — force/integrator 셰이더별 GPU ms. WebGPU 엔진 + gpuTimer 활성 시만. */
   readShaderTimings: () => { forceMs: number | null; integratorMs: number | null } | null;
+  /**
+   * P11-A #288 — Floating Origin 인스턴스.
+   *
+   * scientific 모드 float32 jitter 해소를 위해 scene 내부가 매 프레임 `fo.toLocal(world)` 적용.
+   * 외부 노출은 (a) dev 빌드 `__floatingOrigin` 전역 + (b) 미래 Trail 모듈의 `onOriginShift`
+   * 구독을 위함. Zustand store 는 이 값을 저장하지 않는다 (Heliocentric 불변식 — ADR §3).
+   */
+  floatingOrigin: FloatingOrigin;
+  /**
+   * P11-A #288 — focus 전환 hook (primary origin shift).
+   *
+   * `CameraController.focusOn(mesh)` 와 동일 시점에 호출. 해당 body 의 월드 좌표로 origin 즉시 재배치
+   * → focus body 는 scene 원점 근처에서 렌더되어 float32 jitter 제거. `bodyId` 미존재 시 no-op.
+   *
+   * **호출 타이밍**: `setCameraHandlers` focus 콜백에서 `controller.focusOn` 과 같은 프레임에 호출.
+   * 내부적으로 `updateAt` 이 다음 프레임에 origin 반영된 local 좌표로 mesh.position 을 재기록하므로
+   * focus animation (300ms) 중에도 일관된 좌표계 유지.
+   */
+  setFocusOrigin: (bodyId: string) => void;
   dispose: () => void;
 }
 
@@ -312,6 +355,23 @@ export function createSolarSystemScene(
     viewMode = mode;
   };
 
+  // P11-A #288 — Floating Origin 인스턴스 (scene-scoped).
+  //
+  // - Primary trigger: `setFocusOrigin(bodyId)` 가 focus 전환 시 origin 을 body 월드 좌표로 이동.
+  // - Secondary trigger: `updateAt` 말미에서 `fo.update(cameraWorldMeters)` safety net (1 AU).
+  // - mesh.position 할당은 `fo.toLocal(world)` 경유 — ADR §3 주석 계약 아래 박제.
+  //
+  // Zustand store / Rust engine / worldPositions 는 Heliocentric 절대 좌표 유지 — ADR §3 불변식.
+  const floatingOrigin = new FloatingOrigin(FLOATING_ORIGIN_THRESHOLD_METERS);
+  // DoD β dev-only assert 용 — 현재 focus body id 추적. `null` 이면 자유 탐색 (assert 스킵).
+  let focusBodyIdForAssert: string | null = null;
+  const setFocusOrigin = (bodyId: string) => {
+    const world = worldPositions.get(bodyId);
+    if (!world) return;
+    floatingOrigin.setOriginToBody([world[0], world[1], world[2]]);
+    focusBodyIdForAssert = bodyId;
+  };
+
   // P10-D #263 — Newton 엔진 state 에서 body pos/vel 직접 추출 (timeScale 내성).
   // WebGPU 엔진은 velocities() 가 Promise 반환 → 동기 경로 지원 불가 → null 반환.
   // Kepler 경로·엔진 미활성 시 null 반환 → 호출자 fallback.
@@ -376,18 +436,44 @@ export function createSolarSystemScene(
       updateAtKepler(jd);
     }
 
-    // 메쉬 위치 갱신 (미터 → 씬 단위)
+    // Floating Origin primary follow (ADR §1-B 확장).
+    //
+    // focus body 는 태양을 공전하므로 매 프레임 world 좌표가 바뀐다. origin 을 고정하면
+    // 다음 프레임에 focus body 가 local 에서 멀어져 jitter 재발 → 매 프레임 origin 을
+    // 현재 focus body 의 world 로 따라가게 한다. `setOriginToBody` 가 변화 없으면 no-op
+    // 반환하므로 listener 는 델타가 0 인 프레임에는 호출되지 않는다 (Trail 불필요 호출 방지).
+    if (focusBodyIdForAssert) {
+      const focusWorld = worldPositions.get(focusBodyIdForAssert);
+      if (focusWorld) {
+        floatingOrigin.setOriginToBody([focusWorld[0], focusWorld[1], focusWorld[2]]);
+      }
+    }
+
+    // Floating Origin 계약 (ADR `docs/decisions/20260422-floating-origin.md` §3):
+    //   - `world` (worldPositions): Heliocentric 절대 좌표 (m) — Rust engine / Zustand store 와 동일
+    //   - `local = floatingOrigin.toLocal(world)` : scene 삽입 직전 origin shift 적용 (m)
+    //   - `mesh.position` : scene unit (local × SCENE_UNIT_PER_METER, 1 unit = 1 AU)
+    // 이 3단 변환을 우회하여 `world * SCENE_UNIT_PER_METER` 를 직접 할당하면 scientific 모드
+    // float32 jitter regression 재발 (#271 재현). 아래 루프를 수정할 때 이 주석 계약 유지 필수.
+    const origin = floatingOrigin.originOffset;
+    const ox = origin[0];
+    const oy = origin[1];
+    const oz = origin[2];
     for (const [id, world] of worldPositions) {
       const mesh = meshes.get(id);
       if (!mesh) continue;
+      // float64 뺄셈 (큰 수 - 큰 수 = 작은 수) 을 먼저 수행 후 float32 scene unit 변환.
+      // `toRelativeToEye` 와 동일 원리 — double precision 유지 후 결과만 float32 cast.
       mesh.position.set(
-        world[0] * SCENE_UNIT_PER_METER,
-        world[1] * SCENE_UNIT_PER_METER,
-        world[2] * SCENE_UNIT_PER_METER,
+        (world[0] - ox) * SCENE_UNIT_PER_METER,
+        (world[1] - oy) * SCENE_UNIT_PER_METER,
+        (world[2] - oz) * SCENE_UNIT_PER_METER,
       );
     }
 
     // 거리 기반 per-body 시각 스케일 (#100)
+    // 카메라 거리 계산도 shift 반영된 local 좌표계에서 수행 — mesh.position 이 이미 local 이므로
+    // cam.globalPosition 도 같은 local 좌표계에 있다고 가정할 수 있다 (Floating Origin 은 scene 전체에 균등 적용).
     const cam = scene.activeCamera;
     if (cam) {
       const cx = cam.globalPosition.x;
@@ -410,12 +496,61 @@ export function createSolarSystemScene(
       }
     }
 
+    // Sun light — worldPositions['sun'] 도 Heliocentric 절대 좌표 (m). Floating Origin shift 반영.
     const sunWorld = worldPositions.get('sun') ?? [0, 0, 0];
     sunLight.position.set(
-      sunWorld[0] * SCENE_UNIT_PER_METER,
-      sunWorld[1] * SCENE_UNIT_PER_METER,
-      sunWorld[2] * SCENE_UNIT_PER_METER,
+      (sunWorld[0] - ox) * SCENE_UNIT_PER_METER,
+      (sunWorld[1] - oy) * SCENE_UNIT_PER_METER,
+      (sunWorld[2] - oz) * SCENE_UNIT_PER_METER,
     );
+
+    // P11-A #288 — safety net (ADR §1-A). focus 가 없는 free-fly 탐색 중 카메라가 1 AU 이상
+    // 이동하면 origin 을 카메라 위치로 추가 shift. 다음 프레임의 `updateAt` 이 새 origin 으로
+    // 좌표 재기록 — 같은 프레임 내 mesh.position 은 shift 전 좌표라 1 프레임 visible delta 존재 가능.
+    // 1 AU 이동 시점에서 scene scale 이 매우 wide 하므로 sub-pixel (ADR §5).
+    if (cam) {
+      // cam.globalPosition 은 scene unit (1 AU = 1 unit). fo 는 m 단위 계약 — 환산 후 전달.
+      const cameraLocalMeters = [
+        cam.globalPosition.x * AU,
+        cam.globalPosition.y * AU,
+        cam.globalPosition.z * AU,
+      ] as const;
+      // local → world = local + current origin (shift 전 기준)
+      const cameraWorldMeters: [number, number, number] = [
+        cameraLocalMeters[0] + ox,
+        cameraLocalMeters[1] + oy,
+        cameraLocalMeters[2] + oz,
+      ];
+      floatingOrigin.update(cameraWorldMeters);
+    }
+
+    // P11-A #288 DoD β — dev 빌드 assert: focus body + 카메라 의 local 좌표 절대값 ≤ 1e5 m (100 km).
+    // core 패키지는 `process` 타입이 없으므로 runtime guard 사용. Next.js webpack 이 `process.env.NODE_ENV`
+    // 를 빌드 타임 치환 → prod bundle 에서는 `'development' !== 'production'` 이 false 가 되어 DCE.
+    // SSR / 테스트 환경은 `globalThis.process` 유/무 가드로 안전 접근.
+    if (floatingOriginAssertEnabled() && cam) {
+      const focusId = focusBodyIdForAssert;
+      const focusWorld = focusId ? worldPositions.get(focusId) : null;
+      if (focusWorld) {
+        const fx = focusWorld[0] - ox;
+        const fy = focusWorld[1] - oy;
+        const fz = focusWorld[2] - oz;
+        const focusLocalMax = Math.max(Math.abs(fx), Math.abs(fy), Math.abs(fz));
+        if (focusLocalMax >= 1e5) {
+          console.error(
+            `[floating-origin] focus body '${focusId}' local 좌표 초과 (≥1e5m): ${fx},${fy},${fz}`,
+          );
+        }
+      }
+      // 카메라 local (scene unit × AU → m)
+      const cxm = cam.globalPosition.x * AU;
+      const cym = cam.globalPosition.y * AU;
+      const czm = cam.globalPosition.z * AU;
+      const cameraLocalMax = Math.max(Math.abs(cxm), Math.abs(cym), Math.abs(czm));
+      if (cameraLocalMax >= 1e5) {
+        console.error(`[floating-origin] camera local 좌표 초과 (≥1e5m): ${cxm},${cym},${czm}`);
+      }
+    }
 
     // 소행성대 업데이트.
     // P4-A #165 — N-body 편입 경로: 엔진이 이미 advance 됐으니 flat positions에서 읽어 ThinInstance에 반영.
@@ -532,6 +667,8 @@ export function createSolarSystemScene(
       }
       return null;
     },
+    floatingOrigin,
+    setFocusOrigin,
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -508,7 +508,11 @@ export function createSolarSystemScene(
     // 이동하면 origin 을 카메라 위치로 추가 shift. 다음 프레임의 `updateAt` 이 새 origin 으로
     // 좌표 재기록 — 같은 프레임 내 mesh.position 은 shift 전 좌표라 1 프레임 visible delta 존재 가능.
     // 1 AU 이동 시점에서 scene scale 이 매우 wide 하므로 sub-pixel (ADR §5).
-    if (cam) {
+    //
+    // #292 회귀 가드: focus 활성 상태에서 safety net 이 primary origin (line 445-450 의
+    // `setOriginToBody`) 을 덮어쓰면 originOffset 이 카메라 월드 좌표를 추적 → ADR §3
+    // Heliocentric 계약 위배. focus 가 없는 free-fly 탐색에만 safety net 적용한다.
+    if (cam && !focusBodyIdForAssert) {
       // cam.globalPosition 은 scene unit (1 AU = 1 unit). fo 는 m 단위 계약 — 환산 후 전달.
       const cameraLocalMeters = [
         cam.globalPosition.x * AU,

--- a/scripts/browser-verify-floating-origin.mjs
+++ b/scripts/browser-verify-floating-origin.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * P11-A #288 — Floating Origin 브라우저 검증.
+ *
+ * 사용: node scripts/browser-verify-floating-origin.mjs [baseUrl]
+ * 기본 URL: http://localhost:3000
+ *
+ * Level 1 정적:     window.__floatingOrigin 존재, scientific 모드 초기 로드 콘솔 에러 없음
+ * Level 2 인터랙션: focus 전환 시 floatingOrigin.originOffset 갱신, 각 body focus 시 local ≈ 0
+ * Level 3 흐름:     DoD α — 목성→지구 zoom 시 projected pixel shift ≤ 0.5px (camera matrix 기반)
+ *                   DoD β — focus body local 좌표 절대값 ≤ 1e5 m (100 km)
+ *                   #271 회귀 — scientific 모드 jitter 재현 불가
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const baseUrl = process.argv[2] ?? 'http://localhost:3000';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const screenshotDir = join(__dirname, '..', '.verify-screenshots');
+mkdirSync(screenshotDir, { recursive: true });
+
+const AU = 1.495_978_707e11;
+
+const results = { pass: [], fail: [] };
+const check = (name, condition, detail = '') => {
+  if (condition) results.pass.push(`${name}${detail ? ' — ' + detail : ''}`);
+  else results.fail.push(`${name}${detail ? ' — ' + detail : ''}`);
+};
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await context.newPage();
+
+const consoleErrors = [];
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text());
+});
+page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+// ===== Level 1: 정적 =====
+console.log('\n[Level 1] 정적 검증');
+await page.goto(`${baseUrl}/ko?view=scientific`, { waitUntil: 'networkidle' });
+await page.waitForTimeout(2000); // scene frame 렌더 대기
+
+check(
+  '__floatingOrigin 전역 노출 (dev 빌드)',
+  await page.evaluate(
+    () => typeof window.__floatingOrigin === 'object' && window.__floatingOrigin !== null,
+  ),
+);
+check(
+  '__floatingOrigin.threshold === 1 AU',
+  await page.evaluate(() => Math.abs(window.__floatingOrigin.threshold - 1.495_978_707e11) < 1),
+);
+check(
+  '__floatingOrigin.originOffset 초기값 정의됨',
+  await page.evaluate(() => {
+    const o = window.__floatingOrigin?.originOffset;
+    return Array.isArray(o) && o.length === 3 && o.every((v) => Number.isFinite(v));
+  }),
+);
+check(
+  '__solarScene 존재 (dev 빌드)',
+  await page.evaluate(() => typeof window.__solarScene === 'object'),
+);
+check(
+  '__solarScene.floatingOrigin === __floatingOrigin (동일 인스턴스)',
+  await page.evaluate(() => window.__solarScene?.floatingOrigin === window.__floatingOrigin),
+);
+check(
+  'scientific 모드 초기 로드 시 console.error 없음',
+  consoleErrors.length === 0,
+  consoleErrors.length ? consoleErrors.join(' | ').slice(0, 200) : '',
+);
+
+await page.screenshot({
+  path: join(screenshotDir, 'floating-origin-01-static.png'),
+  fullPage: false,
+});
+
+// ===== Level 2: 인터랙션 =====
+console.log('\n[Level 2] 인터랙션 검증');
+
+// 지구 focus → originOffset 이 지구 월드 좌표 근처
+const focusEarthBtn = await page.$('[data-testid="focus-earth"]');
+if (focusEarthBtn) {
+  await focusEarthBtn.click();
+  await page.waitForTimeout(500);
+  const earthLocal = await page.evaluate(() => {
+    const scene = window.__solarScene;
+    const earth = scene?.meshes.get('earth');
+    if (!earth) return null;
+    // mesh.position 은 scene unit (1 AU). local 좌표계 원점 근처여야 함.
+    const p = earth.position;
+    const sceneDistFromOrigin = Math.hypot(p.x, p.y, p.z);
+    return sceneDistFromOrigin * 1.495_978_707e11; // 미터 환산
+  });
+  check(
+    '지구 focus 후 earth.local 절대값 ≤ 1e5 m (DoD β)',
+    earthLocal !== null && earthLocal < 1e5,
+    `local=${earthLocal}m`,
+  );
+  const originAfterEarth = await page.evaluate(() => window.__floatingOrigin.originOffset);
+  const distFromHelio = Math.hypot(...originAfterEarth);
+  check(
+    'originOffset 은 Heliocentric 절대값 (0 이 아님, 지구 ~1 AU 근처)',
+    distFromHelio > 1e11 && distFromHelio < 2e11,
+    `distHelio=${(distFromHelio / AU).toFixed(3)} AU`,
+  );
+}
+
+// 목성 focus → originOffset 재배치
+const focusJupiterBtn = await page.$('[data-testid="focus-jupiter"]');
+if (focusJupiterBtn) {
+  await focusJupiterBtn.click();
+  await page.waitForTimeout(500);
+  const jupiterLocal = await page.evaluate(() => {
+    const scene = window.__solarScene;
+    const jup = scene?.meshes.get('jupiter');
+    if (!jup) return null;
+    const p = jup.position;
+    return Math.hypot(p.x, p.y, p.z) * 1.495_978_707e11;
+  });
+  check(
+    '목성 focus 후 jupiter.local 절대값 ≤ 1e5 m (DoD β)',
+    jupiterLocal !== null && jupiterLocal < 1e5,
+    `local=${jupiterLocal}m`,
+  );
+  const originAfterJupiter = await page.evaluate(() => window.__floatingOrigin.originOffset);
+  const distFromHelio = Math.hypot(...originAfterJupiter);
+  check(
+    '목성 focus originOffset ~ 5.2 AU',
+    distFromHelio > 5 * AU && distFromHelio < 6 * AU,
+    `distHelio=${(distFromHelio / AU).toFixed(3)} AU`,
+  );
+}
+
+await page.screenshot({
+  path: join(screenshotDir, 'floating-origin-02-focus-jupiter.png'),
+  fullPage: false,
+});
+
+// ===== Level 3: 흐름 =====
+console.log('\n[Level 3] 흐름 검증');
+
+// DoD α — 목성 focus 상태에서 카메라 pan 시 projected pixel shift ≤ 0.5px
+// Babylon 카메라 matrix (view × projection) 를 읽어 body 중심을 pixel 로 projection 후 shift 측정
+if (focusJupiterBtn) {
+  // 이미 목성 focus 상태
+  await page.waitForTimeout(300);
+  const pixelShift = await page.evaluate(() => {
+    const scene = window.__solarScene?.meshes;
+    if (!scene) return null;
+    const jup = scene.get('jupiter');
+    if (!jup) return null;
+    // 활성 카메라 + 엔진
+    // (babylon 은 __solarScene 에 직접 scene 참조가 없음 — jup.getEngine/getScene 경유)
+    const babScene = jup.getScene();
+    const cam = babScene.activeCamera;
+    const engine = babScene.getEngine();
+    if (!cam || !engine) return null;
+
+    const vp = babScene.getTransformMatrix();
+    const width = engine.getRenderWidth();
+    const height = engine.getRenderHeight();
+
+    // 프레임 1 — 현재 카메라 위치 기준 projection
+    const project = () => {
+      const v = jup.position.clone();
+      // clip = vp × [v.x,v.y,v.z,1]
+      const m = vp.m;
+      const cx = m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12];
+      const cy = m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13];
+      const cw = m[3] * v.x + m[7] * v.y + m[11] * v.z + m[15];
+      return {
+        x: (cx / cw + 1) * 0.5 * width,
+        y: (1 - cy / cw) * 0.5 * height,
+      };
+    };
+    const p1 = project();
+    // 카메라를 아주 조금 회전 (alpha 1e-5 rad)
+    cam.alpha += 1e-5;
+    // 새 view matrix 업데이트
+    cam.getViewMatrix(true);
+    const vp2 = babScene.getTransformMatrix();
+    const project2 = () => {
+      const v = jup.position.clone();
+      const m = vp2.m;
+      const cx = m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12];
+      const cy = m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13];
+      const cw = m[3] * v.x + m[7] * v.y + m[11] * v.z + m[15];
+      return {
+        x: (cx / cw + 1) * 0.5 * width,
+        y: (1 - cy / cw) * 0.5 * height,
+      };
+    };
+    const p2 = project2();
+    cam.alpha -= 1e-5; // rollback
+
+    return {
+      p1,
+      p2,
+      dx: Math.abs(p2.x - p1.x),
+      dy: Math.abs(p2.y - p1.y),
+      finite: [p1, p2].every((p) => Number.isFinite(p.x) && Number.isFinite(p.y)),
+    };
+  });
+
+  check(
+    'DoD α — 목성 focus pixel shift 유한',
+    pixelShift !== null && pixelShift.finite,
+    pixelShift
+      ? `p1=(${pixelShift.p1.x.toFixed(2)},${pixelShift.p1.y.toFixed(2)}) p2=(${pixelShift.p2.x.toFixed(2)},${pixelShift.p2.y.toFixed(2)})`
+      : 'null',
+  );
+  check(
+    'DoD α — pixel shift ≤ 0.5px (scientific 모드)',
+    pixelShift !== null && pixelShift.dx <= 0.5 && pixelShift.dy <= 0.5,
+    pixelShift ? `dx=${pixelShift.dx.toFixed(3)}px dy=${pixelShift.dy.toFixed(3)}px` : 'null',
+  );
+}
+
+// #271 회귀 — scientific 모드 화면이 검정이 아니고 body 가 렌더됨
+const canvasPixelCheck = await page.evaluate(() => {
+  const canvas = document.querySelector('[data-testid="sim-canvas"]');
+  if (!canvas) return null;
+  const ctx = document.createElement('canvas').getContext('2d');
+  if (!ctx) return null;
+  ctx.canvas.width = canvas.width;
+  ctx.canvas.height = canvas.height;
+  ctx.drawImage(canvas, 0, 0);
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  // 중앙 근처 픽셀 100x100 샘플링
+  const cx = Math.floor(canvas.width / 2);
+  const cy = Math.floor(canvas.height / 2);
+  let nonBlack = 0;
+  let total = 0;
+  for (let dy = -50; dy < 50; dy += 5) {
+    for (let dx = -50; dx < 50; dx += 5) {
+      const idx = ((cy + dy) * canvas.width + (cx + dx)) * 4;
+      const r = img.data[idx] ?? 0;
+      const g = img.data[idx + 1] ?? 0;
+      const b = img.data[idx + 2] ?? 0;
+      total += 1;
+      if (r + g + b > 30) nonBlack += 1;
+    }
+  }
+  return { nonBlackRatio: nonBlack / total, total };
+});
+if (canvasPixelCheck) {
+  check(
+    '#271 회귀 — scientific 모드 canvas 렌더 (비-검정 pixel 존재)',
+    canvasPixelCheck.nonBlackRatio > 0.05,
+    `nonBlack=${(canvasPixelCheck.nonBlackRatio * 100).toFixed(1)}%`,
+  );
+}
+
+// 런타임 에러 재확인
+check(
+  '런타임 에러 없음 (#271 관련 floating-origin assert 포함)',
+  consoleErrors.length === 0,
+  consoleErrors.length ? consoleErrors.join(' | ').slice(0, 200) : '',
+);
+
+await page.screenshot({
+  path: join(screenshotDir, 'floating-origin-99-final.png'),
+  fullPage: false,
+});
+
+await browser.close();
+
+// ===== 결과 =====
+console.log('\n========================================');
+console.log(`PASS: ${results.pass.length}건`);
+for (const p of results.pass) console.log(`  ✓ ${p}`);
+if (results.fail.length > 0) {
+  console.log(`\nFAIL: ${results.fail.length}건`);
+  for (const f of results.fail) console.log(`  ✗ ${f}`);
+}
+console.log(`\n스크린샷: ${screenshotDir}`);
+
+if (results.fail.length > 0) {
+  console.error('\n검증 실패 ✗');
+  process.exit(1);
+}
+console.log('\n모든 검증 통과 ✓');


### PR DESCRIPTION
## Summary

**P11-A 로드맵 v2** (scientific 모드 float32 jitter 해소) 의 첫 단계. 기존 `packages/core/src/coords/` 유틸 재사용 + scene graph 배선이 본질 — 신규 알고리즘 없음 (CLAUDE.md "신규 함수 ≠ 신규 구현" 교훈 적용).

**배선 전략** (ADR `docs/decisions/20260422-floating-origin.md`, architect sub-agent + cross-validate 반영):

- **Primary**: focus body 기반 origin shift (`FloatingOrigin.setOriginToBody`) — focus 전환 시 즉시 재배치 + 매 프레임 focus body 공전 추적
- **Secondary**: 카메라 threshold 1 AU safety net (`FloatingOrigin.update`) — free-fly 탐색 중 카메라가 1 AU 이상 이동 시 발동
- **좌표 변환 지점**: `solar-system-scene.ts` `updateAt` 의 mesh.position 할당 루프 직전. `(world - origin) * SCENE_UNIT_PER_METER` 로 float64 뺄셈 선행 후 float32 scene unit cast
- **Zustand 불변식** (ADR §3): Rust engine / worldPositions / store state 는 Heliocentric 절대 좌표 유지. Scene 좌표 누출 방지 주석 계약 + 테스트 박제
- **Trail/Particle 계약**: `onOriginShift(listener)` subscription API — 미래 모듈이 GPU 버퍼 translate 시 사용 (Concrete Prediction #4)
- **Smoothing**: 없음 — focus animation (300ms) 기반 자연 smoothing

## Closes

- Closes #271 (P10 known issue — scientific 모드 jitter. 머지 + QA 3단계 브라우저 검증 통과 시 close)
- Closes #292 (drift 조사 이슈 — safety net 조건 분기 누락 수정으로 해소)
- Refs #288

## Behavior Changes

- **Scientific 모드 jitter 해소**: 목성/해왕성 focus 상태에서 카메라 pan 시 픽셀 양자화 제거. body 중심이 scene 원점 근처에서 렌더되어 float32 유효숫자 손실 없음
- **Floating Origin primary follow**: focus body 는 매 프레임 scene 원점 근처 (local 좌표 ≤1e5 m) 유지. 단, Zustand / Rust engine state 는 Heliocentric 절대값 유지 (정보 패널 거리 표시 변함 없음)
- **`__floatingOrigin` / `__solarScene.floatingOrigin` 전역 노출** (dev 빌드 한정) — browser-verify 스크립트용
- **SolarSystemSceneHandles API 확장** — `floatingOrigin` + `setFocusOrigin(bodyId)` 2개 field 추가 (기존 field 파괴적 변경 없음)
- **`FloatingOrigin` API 확장** — `setOriginToBody(world)` + `onOriginShift(listener)` 2개 메서드 추가 (기존 `update` / `toLocal` / `toWorld` 변경 없음)

## Test plan

### 단위 테스트 (본 PR 범위 — 모두 통과)

- [x] `packages/core/src/coords/floating-origin.test.ts` — 기존 7건 + 신규 12건 = 19건
  - `setOriginToBody` 5건 (즉시 shift / local ≈ 0 / threshold 무관 / no-op / 누적)
  - `onOriginShift` 5건 (update 경로 / setOriginToBody 경로 / threshold 미만 비호출 / unsubscribe / 예외 격리)
  - scientific 시나리오 통합 2건 (목성↔지구 DoD β, safety net 1 AU)
- [x] `packages/core/src/coords/floating-origin-pixel-stability.test.ts` — **DoD α 결정론적 검증 6건** (신규)
  - float32 `Math.fround` 기반 scene 좌표 quantization ULP 측정
  - 해왕성 30 AU baseline: ULP ≈ 535 km (jitter 원인)
  - FloatingOrigin 배선 후: local ≈ 0 → ULP 200배+ 감소 증명
- [x] `apps/web/src/store/sim-store.test.ts` — DoD γ Heliocentric 불변식 2건 추가
- [x] 전체: core 183/183, web 126/126, shared 4/4, physics-wasm 1/1 — 총 314건 통과
- [x] typecheck 전 패키지 통과
- [x] lint — 우리 변경 0 errors

### QA 단계 (PR 머지 전 확인 필요)

- [ ] `node scripts/browser-verify-floating-origin.mjs http://localhost:3000` — Playwright 기반 3단계 검증
  - Level 1: `__floatingOrigin` 전역 노출 / threshold === 1 AU / console.error 없음
  - Level 2: 지구 focus → `earth.local < 1e5 m` + `originOffset ~ 1 AU` / 목성 focus → `jupiter.local < 1e5 m` + `originOffset ~ 5.2 AU`
  - Level 3: **DoD α — Babylon view-projection matrix 직접 읽어 목성 focus 상태 카메라 회전 1e-5 rad 시 projected pixel shift ≤ 0.5px**
- [ ] 실 Chrome GUI 육안 확인 — volt #33 "headless false positive" 방어. 목성→지구 zoom 시 scientific 모드 jitter 없음 1회 육안 확인
- [ ] bench 회귀 게이트 — `bench:baseline-remeasure` 회귀율 < 5%. `fo.toLocal` 은 per-body subtract 3회만 — 태양계 ~100 body 규모에서 무시 가능한 오버헤드 예상

## Risks

- **Trail 모듈 계약 검증 지연**: `onOriginShift` API 는 계약만 박제 (ADR §2-C). 호출자가 없는 상태로 exposed — 미래 Trail Phase 도입 시 실 사용 검증 (Concrete Prediction #4)
- **매 프레임 primary follow** 가 추가되어 origin shift 가 매 프레임 발생 가능 — `setOriginToBody` no-op 가드로 listener 호출은 회피하지만, 이후 Trail 도입 시 매 프레임 delta 계산 비용 측정 필요
- **M1 백업 경로 폐기** (ADR §비-범위): WebGPU f64 미지원으로 double-precision shim 불가. Floating Origin 이 SPOF. 실패 판정 시 대체안은 "LOD low billboard 강제 fallback + scientific 모드 경고 배너" (P11-B 에서 결합)

## Concrete Prediction (추상화 건강성 예측 박제 — ADR §결과·재검토 조건)

P11-B / P12 / P13 / 미래 Trail 도입 시 `FloatingOrigin` 코드 변경 **0 줄** 예상. 실패 시 ADR Amendment 후 재설계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

