### PR TITLE
chore(release): v0.12.0 — P12-B 8D 카메라 dolly + P12-C UI 단일 모드 전환 완결

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-04-23
+
+### P12-B 8D 카메라 dolly 애니메이션 (Display-Relative Scale Unification Phase B)
+
+메인 이슈: #298 · ADR: [`docs/decisions/20260423-display-relative-scale-unification.md`](docs/decisions/20260423-display-relative-scale-unification.md) §3 (배선 원리) / §Phase 분리 / §Concrete Prediction
+
+PR #304 (`208f5cb`) — Q8=8D 카메라 dolly 병행 interp + 입력 잠금. Phase A 의 Tier 엔진 기반 (v0.11.0) 위에 integration.
+
+#### Behavior Changes
+
+- **`runTierTransition` 신규 — scene scale 즉시 setAll + `camera.radius` 300ms ExponentialEase interp 병행** (`packages/core/src/scene/tier-transition.ts`) — apparent size 불변 수식 `radius_new = radius_old / ratio` (`ratio = renderScale_new / renderScale_old`) 로 focus body 화면 크기 유지. tier 전환 시 `scene.detachControl()` + `onAnimationEnd` / `setTimeout(lockMs=500)` 이중 해제. Pending tween 취소 (`scene.getAnimatableByTarget(camera).stop()`) + `document.visibilitychange` 핸들러 (idempotent attachControl)
+- **`setTier` 가 `runTierTransition` 호출로 전환** (`packages/core/src/scene/solar-system-scene.ts:436`) — 기존 `scaling.setAll` 즉시 반영은 유지하되 camera dolly 병행 추가. `isArcRotateCamera` 런타임 타입 가드
+- **`focusOn` JSDoc 에 Phase B tier 연계 맥락 박제** (`packages/core/src/scene/camera-controller.ts:44`) — user-trigger focus 경로 (`desiredRadius = meshRadius*5`) 는 유지. tier 전환 시 radius 재계산 경로는 `runTierTransition` 위임
+- **카메라 `minZ` 재조정** — tier 전환 전 `cam.minZ = radius_new * 0.01` 적용. `radius_new < minZ` clamp 충돌 방어 (V5 달성 센서)
+
+#### DoD 실측 (P12-B Phase B)
+
+| DoD                                      | 실측                                                                | 상태 |
+| ---------------------------------------- | ------------------------------------------------------------------- | ---- |
+| V5 T3 Body 지구 세로 40% ±5% (304~336px) | **322px**                                                           | PASS |
+| A1 focus 중심 편차 ≤10px                 | **0.0px**                                                           | PASS |
+| C1 apparent size 변동 ≤5%                | 수식 단위 테스트 (`tier-transition.test.ts` 11건, `1e-12` 상대오차) | PASS |
+| C2 fps<30 프레임 ≤2                      | canvas 비검정 + console.error 0 (Level 1)                           | PASS |
+| C3 전환 ≤500ms                           | QA 독립 재측정 lock 373.5ms / click→reattach 506ms                  | PASS |
+| C4 입력 잠금 + 100ms 내 재활성           | detachControl during=false / attachControl after=true (Level 2)     | PASS |
+
+위험 3건 해소: pending tween 연쇄 (getAnimatableByTarget.stop 구현) / 탭 비활성 영구 잠금 (visibilitychange + fallback timer 이중 방어) / minZ clamp (`radius_new * 0.01` 재조정).
+
 ### P12-C Display-Relative Scale Unification 완결 (Phase C)
 
 메인 이슈: #298 (auto-close) / #288 (auto-close) · ADR Amendment: [`docs/decisions/20260423-display-relative-scale-unification.md`](docs/decisions/20260423-display-relative-scale-unification.md) §Amendment / [`docs/decisions/20260422-floating-origin.md`](docs/decisions/20260422-floating-origin.md) §Amendment · 회고: [`docs/retrospectives/p12-retrospective.md`](docs/retrospectives/p12-retrospective.md)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/physics-wasm",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/shared",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Shared types, constants, and event definitions for astro-simulator",
   "type": "module",


### PR DESCRIPTION
## Summary

v0.11.0 (2026-04-23) 이후 develop 누적 2 PR 통합 릴리스:

- **#304 P12-B** — Q8=8D 카메라 dolly 애니메이션 (apparent size 불변 + 500ms 입력 잠금, V5 hard fail 실측 충족)
- **#309 P12-C** — UI 4건 제거 + sim-store.viewMode 제거 + R1 회귀 가드 CI + D1~D4 Amendment + 회고

## 버전 bump

- `package.json` / `apps/web` / `packages/core` / `packages/shared` / `packages/physics-wasm`: **0.11.0 → 0.12.0**
- `packages/physics-wasm/Cargo.toml`: 0.4.0 유지 (Rust 별도 계열, 본 범위 Rust 변경 없음)

## CHANGELOG 작업

- `[Unreleased]` → `[0.12.0] — 2026-04-23` 승격
- Phase B entry 신규 추가 (PR #304 머지 시 CHANGELOG 업데이트 누락 — 본 chore 에서 보완)
- Phase C entry (이미 PR #309 에서 작성) 유지

## SemVer 판정

**MINOR (0.11.0 → 0.12.0)**:
- 신규 행동 — `runTierTransition` 추가, 카메라 dolly interp 도입
- UI breaking UX 변화 — ViewMode/ScaleBadge 등 4건 제거, `?view=*` 무시
- 외부 consumer 없음 (app 내부 state/UI) → MAJOR 미해당
- 판정 애매 시 낮은 쪽 선택 원칙 적용 (CLAUDE.md 릴리스 규약)

## Test plan

- [x] `pnpm -r test` — 328 PASS (Phase C 머지 시점 실측)
- [x] `pnpm -r typecheck` — 0 errors
- [x] `pnpm build` — 성공
- [x] `scripts/verify-no-scientific-grep.mjs` — 157 파일 hit 0
- [x] 실 Chrome 3단계 검증 (Phase C 메인 레벨 재검증 완료)
- [x] 한글 U+FFFD 0건 (CHANGELOG)

## 태그 계획 (release PR 머지 후)

```bash
git checkout main
git pull origin main
git tag -a v0.12.0 -m "P12-B 8D 카메라 dolly + P12-C UI 단일 모드 전환 완결"
git push origin v0.12.0
gh release create v0.12.0 --title "v0.12.0 — P12 Display-Relative Scale Unification 완결" --notes-from-tag
```

## 다음 단계

본 PR 머지 후 **별도 release PR (develop → main, --merge 방식)** 생성. 그 시점에 `#298` / `#288` auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)