### PR TITLE
[#313] P11 재편 M2 — Floating Origin tier-conditional skip (T1/T2 overhead 제거)

### DIFF
--- a/docs/decisions/20260423-display-relative-scale-unification.md
+++ b/docs/decisions/20260423-display-relative-scale-unification.md
@@ -389,6 +389,31 @@ function currentTier(camera: ArcRotateCamera, focusBodyId: string | null): Tier 
 - 대체: (a) `floating-origin.test.ts` 의 기존 `reset()` / `setOriginToBody no-op` 테스트가 인접 property 테스트로 간접 보증 (b) 주석 계약 — `setTier` / primary follow / safety net 3지점에 "#313 M2 — P12 ADR §Q10 Amendment" 인라인 박제 (c) M3 bench 재측정 게이트 (non-focus 회귀율 < 5%) 가 회귀 시 자동 감지
 - **재조정 박제 3위치**: 본 Amendment (ADR) / PR 본문 / CHANGELOG Notes — CLAUDE.md 재조정 박제 규칙 준수
 
+### 2026-04-23 — QA 회귀 수정: setTier 대칭 처리 (#313 M2 QA)
+
+위 **Q10 구현 정합성 재평가** 1차 구현 (PR #315 commits c3695dc / 766a2ba) 에 대한 QA 동적 검증에서 **시각 회귀 2건** 발견:
+
+- **V5 지구 세로 40% ±5%** — 허용 304~336px, 실측 **296px** (develop baseline 322px → −26px 퇴행). 3회 결정적 재현
+- **A1 지구 focus 중심 편차 ≤ 10px** — 실측 **119.9px** (허용의 12배 초과). develop baseline 0.0px → PR 119.9px
+
+**원인**: `setTier` 내부 **비대칭 처리**.
+
+- T1/T2 진입 시 `floatingOrigin.reset()` 즉시 호출
+- T3 진입 시 **아무 처리 없음** — primary follow (line 583) 는 다음 `updateAt` 프레임에야 origin 갱신
+
+`runTierTransition` (tier-transition.ts:216-219) 이 `focusMesh.absolutePosition` 을 읽어 카메라 target 을 재계산하므로, T3 진입 시점에 origin + mesh.position 이 새 tier 좌표계로 이미 갱신되어 있지 않으면 **카메라 target 과 mesh 가 어긋남** (next frame primary follow 이 origin 을 focus 로 이동시켜 mesh.position 이 [0,0,0] 근처로 재배치되는데 camera.target 은 이전 origin 기준 좌표에 남음).
+
+**수정 (PR #315 추가 커밋)**:
+
+1. `packages/core/src/scene/tier.ts` 에 순수 함수 `computeFloatingOriginForTier(tier, focusId, lookup)` 추가 — tier 별 origin target 을 결정 (T1/T2 → `[0,0,0]`, T3+focus → focus world, T3+free-fly → `null`)
+2. `setTier` 가 위 함수 결과로 `floatingOrigin.reset()` 또는 `setOriginToBody(focusWorld)` 를 **대칭 호출**
+3. origin 갱신 직후 **mesh.position 재계산 루프** 추가 (`(world - origin) * newScale`, `computeWorldMatrix(true)` 포함) — `runTierTransition` 이 올바른 `focusMesh.absolutePosition` 을 읽도록
+4. `packages/core/src/scene/tier.test.ts` 에 `computeFloatingOriginForTier` 단위 테스트 8건 추가 — T1/T2/T3 × focus 유/무/stale 6조합 + reference 동일성 + [0,0,0] 계약 정합
+
+**DoD 재조정 번복**: 위 "DoD 재조정" 섹션의 "T3 기능 회귀 가드 단위 테스트" 생략 판정은 QA 실측 회귀로 **사후 번복**. `computeFloatingOriginForTier` 순수 함수 추출로 Scene 인스턴스 mock 없이 단위 테스트 가능해져 ROI 역전. 이후 유사 tier 분기 로직은 **순수 함수 추출 + 단위 테스트를 우선 검토**.
+
+**시사점 (CLAUDE.md 실전 교훈 후보)**: ROI 5문 체크에서 "주석 계약 + 인접 테스트" 로 대체 판정한 시각 회귀가 실제로 발생한 사례. "회귀 시 조용히 퇴행 vs 빌드 실패" 의 "조용히 퇴행" 이 **QA 브라우저 검증 없이는 감지 불가** 임을 실증. 순수 함수 추출 가능성이 1%라도 있으면 주석 계약 대체보다 추출 + 테스트를 기본 선택. 추후 volt 캡처 후보.
+
 ---
 
 ## 참고

--- a/docs/decisions/20260423-display-relative-scale-unification.md
+++ b/docs/decisions/20260423-display-relative-scale-unification.md
@@ -348,6 +348,8 @@ function currentTier(camera: ArcRotateCamera, focusBodyId: string | null): Tier 
 - **Phase C 처리**: **코드 변경 0, Amendment 만**. `floating-origin.ts` 및 관련 테스트 전부 유지
 - **#288 close 판정**: 본 PR 에서 close. scientific 모드 jitter 해소의 원 목표는 단일 모드 전환으로 근본 원인 소멸. `20260422-floating-origin.md` §Amendment 1줄 박제 — "P12 에서 역할 축소 (T3 primary, T1/T2 no-op)"
 
+> **Forward link (2026-04-23, #313 M2)**: 본 (c) 의 "코드 변경 0" 전제는 시각 효과만 다루고 컴퓨트 비용은 해소하지 않아 non-focus fps −38 ~ −44% 회귀 지속 확인 (#313 M1 재측정 Run #24837822902). 아래 §Amendments "2026-04-23 — Q10 구현 정합성 재평가 (#313 M2)" 에서 **부분 수정** (3지점 `activeTier === 'body'` 분기 추가 / `FloatingOrigin` 클래스·테스트·계약 전부 유지) 으로 재평가.
+
 #### (d) QA / Reviewer 이관 항목 반영 (Phase C)
 
 - **Reviewer M1** (Major, PR #304): `setTier` 가 `runTierTransition` cleanup 을 클로저에 저장해 연쇄 전환 시 이전 fallback timer / listener 를 먼저 해제. `tier-transition.test.ts` 에 "연쇄 전환 cleanup 호출" 단위 테스트 3건 추가

--- a/docs/decisions/20260423-display-relative-scale-unification.md
+++ b/docs/decisions/20260423-display-relative-scale-unification.md
@@ -358,6 +358,35 @@ function currentTier(camera: ArcRotateCamera, focusBodyId: string | null): Tier 
 - **Reviewer m2** (lowerRadiusLimit 원복): 후속 이슈 #305 로 분리 (P11-B billboard marker 통합 시점 재검토)
 - **developer suggestion #1** (FOCUS_RADIUS_MULTIPLIER viewport/fov 동적화): 후속 이슈 #306 으로 분리 (재검토 조건 #3 에 이미 박제)
 
+### 2026-04-23 — Q10 구현 정합성 재평가 (#313 M2)
+
+§Amendments (c) 는 "코드 변경 0, Amendment 만" 으로 박제했으나, #313 M1 재측정 (Run #24837822902, v0.12.0 main, `phase=p11-reshape-m1`) 에서 **non-focus scenario fps 회귀 −38 ~ −44% 가 P12 완결 이후에도 지속** 확인되어 재평가.
+
+**실측 회귀 (ubuntu median N=10, v0.10.0 baseline 대비)**:
+
+| scenario | v0.10.0 | v0.12.0 (M1) | Δ        |
+| -------- | ------- | ------------ | -------- |
+| idle     | 30.09   | 16.89        | **−44%** |
+| play-1d  | 21.64   | 13.41        | **−38%** |
+| play-1y  | 24.14   | 14.77        | **−39%** |
+
+**해석**: §Amendments (c) 의 "T1/T2 에서 `toLocal()` 오버헤드는 0 에 수렴" 전제가 **컴퓨트 비용 전체가 아닌 시각 효과만 다룸**. 실제로는 `updateAt` 매 프레임 내 primary follow (`setOriginToBody`) + free-fly safety net (`update()`) + `Vec3Double` 메모리 할당 + Set iteration (listener 0 건이어도 loop 진입) 등 **tier 무관 overhead** 가 누적되어 non-focus 회귀의 주범.
+
+**재평가 결정 (#313 M2)**:
+
+- §Amendments (c) "코드 변경 0" 을 **부분 수정**: `solar-system-scene.ts` 3지점에 `activeTier === 'body'` 분기 추가
+  - `setTier` — T3 이탈 시 `floatingOrigin.reset()` 1회 호출 (후속 프레임 origin `[0,0,0]` 유지)
+  - primary follow (line 581) — T3 에서만 `setOriginToBody(focusWorld)` 실행
+  - safety net (line 633) — T3 에서만 `floatingOrigin.update(cameraWorldMeters)` 실행
+- **FloatingOrigin 클래스 / `onOriginShift` 계약 / `floating-origin*.test.ts` 전부 유지** — §Amendments (c) 의 "제거 하지 않는 이유" 4항 모두 보존 (P11-A 회귀 가드, 미래 Trail 모듈 계약, toLocal 인터페이스)
+- M3 bench 재측정 게이트: skip 적용 후 회귀율 < 5% 충족 시 P11-A 원 DoD β 만족
+
+**DoD 재조정 (CLAUDE.md 스프린트 계약 6항 ROI 5문 체크)**:
+
+- 원 계약 "T3 기능 회귀 가드 단위 테스트 (지구/달 focus 시 FO primary follow 동작 유지)" 는 Scene 인스턴스 + tier 전환 mock 구축 비용이 수정 라인 수 (3줄) 대비 과다
+- 대체: (a) `floating-origin.test.ts` 의 기존 `reset()` / `setOriginToBody no-op` 테스트가 인접 property 테스트로 간접 보증 (b) 주석 계약 — `setTier` / primary follow / safety net 3지점에 "#313 M2 — P12 ADR §Q10 Amendment" 인라인 박제 (c) M3 bench 재측정 게이트 (non-focus 회귀율 < 5%) 가 회귀 시 자동 감지
+- **재조정 박제 3위치**: 본 Amendment (ADR) / PR 본문 / CHANGELOG Notes — CLAUDE.md 재조정 박제 규칙 준수
+
 ---
 
 ## 참고

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -31,6 +31,7 @@ import {
   initialTier as defaultInitialTier,
   tierFromFocus,
   tierFromCameraDistance,
+  computeFloatingOriginForTier,
   type Tier,
 } from './tier.js';
 import { runTierTransition } from './tier-transition.js';
@@ -449,13 +450,37 @@ export function createSolarSystemScene(
     }
     rebuildOrbitLines();
 
-    // #313 M2 — P12 ADR §Q10 Amendment 구현 정합성. T3 (body) 이탈 시 originOffset 을 [0,0,0] 으로
-    // 리셋하여 T1/T2 에서 mesh.position 이 shift 없는 절대 월드 좌표 × renderScale 로 계산되도록 한다.
-    // T1/T2 는 renderScale 이 작아 origin shift 의 visible 효과가 sub-pixel 이지만, 매 프레임
-    // setOriginToBody / update() overhead 는 실재 (#294 non-focus −38~−44% 회귀). reset 1 회로 이후
-    // 프레임의 primary follow / safety net 이 조건부 skip 가능.
-    if (tier !== 'body') {
-      floatingOrigin.reset();
+    // #313 M2 — P12 ADR §Q10 Amendment 구현 정합성. tier 전환 시 origin 을 대칭 처리.
+    //  - T1/T2 진입 → [0,0,0] reset (T1/T2 에서 매 프레임 FO overhead 제거)
+    //  - T3 진입 + focus 있음 → setOriginToBody(focusWorld) 즉시 동기 (QA 회귀 수정: 비대칭 처리 시
+    //    runTierTransition 이 focusMesh.absolutePosition 을 이전 origin 기준으로 읽어 카메라 target
+    //    mismatch 발생 — PR #315 QA A1 119.9px / V5 296px 퇴행 재현)
+    //  - T3 진입 + focus 없음 (free-fly) → null (기존 origin 유지, 다음 updateAt 의 safety net 이 처리)
+    const originTarget = computeFloatingOriginForTier(tier, focusBodyIdForAssert, (id) =>
+      worldPositions.get(id),
+    );
+    if (originTarget !== null) {
+      if (originTarget[0] === 0 && originTarget[1] === 0 && originTarget[2] === 0) {
+        floatingOrigin.reset();
+      } else {
+        floatingOrigin.setOriginToBody(originTarget);
+      }
+    }
+
+    // origin 과 newScale 기준으로 mesh.position 즉시 재계산 — `runTierTransition` 이 읽는
+    // `focusMesh.absolutePosition` (tier-transition.ts:216-219) 이 새 tier 좌표계여야 카메라 target 정합.
+    // updateAt 의 mesh.position 루프 (line 595-610) 와 동일 수식 (의도된 duplication — tier 전환 시점에
+    // 1회 추가 실행으로 transition 이 올바른 좌표를 읽게 함).
+    const tierTransitionOrigin = floatingOrigin.originOffset;
+    for (const [id, world] of worldPositions) {
+      const mesh = meshes.get(id);
+      if (!mesh) continue;
+      mesh.position.set(
+        (world[0] - tierTransitionOrigin[0]) * newScale,
+        (world[1] - tierTransitionOrigin[1]) * newScale,
+        (world[2] - tierTransitionOrigin[2]) * newScale,
+      );
+      mesh.computeWorldMatrix(true);
     }
 
     // Phase B — camera dolly interp. scene.activeCamera 가 ArcRotateCamera 가 아니면 skip.

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -449,6 +449,15 @@ export function createSolarSystemScene(
     }
     rebuildOrbitLines();
 
+    // #313 M2 — P12 ADR §Q10 Amendment 구현 정합성. T3 (body) 이탈 시 originOffset 을 [0,0,0] 으로
+    // 리셋하여 T1/T2 에서 mesh.position 이 shift 없는 절대 월드 좌표 × renderScale 로 계산되도록 한다.
+    // T1/T2 는 renderScale 이 작아 origin shift 의 visible 효과가 sub-pixel 이지만, 매 프레임
+    // setOriginToBody / update() overhead 는 실재 (#294 non-focus −38~−44% 회귀). reset 1 회로 이후
+    // 프레임의 primary follow / safety net 이 조건부 skip 가능.
+    if (tier !== 'body') {
+      floatingOrigin.reset();
+    }
+
     // Phase B — camera dolly interp. scene.activeCamera 가 ArcRotateCamera 가 아니면 skip.
     // (e.g. 테스트 셋업 / 비정상 초기화 경로). 통상 경로는 setupArcRotateCamera 에서 항상 ArcRotateCamera.
     //
@@ -578,7 +587,10 @@ export function createSolarSystemScene(
     // 다음 프레임에 focus body 가 local 에서 멀어져 jitter 재발 → 매 프레임 origin 을
     // 현재 focus body 의 world 로 따라가게 한다. `setOriginToBody` 가 변화 없으면 no-op
     // 반환하므로 listener 는 델타가 0 인 프레임에는 호출되지 않는다 (Trail 불필요 호출 방지).
-    if (focusBodyIdForAssert) {
+    //
+    // #313 M2 — P12 ADR §Q10 Amendment: T3 (body) 에서만 활성. T1/T2 는 setTier 가 origin 을
+    // 리셋해 [0,0,0] 유지 → 아래 primary follow skip 으로 매 프레임 setOriginToBody 호출 제거.
+    if (activeTier === 'body' && focusBodyIdForAssert) {
       const focusWorld = worldPositions.get(focusBodyIdForAssert);
       if (focusWorld) {
         floatingOrigin.setOriginToBody([focusWorld[0], focusWorld[1], focusWorld[2]]);
@@ -630,7 +642,11 @@ export function createSolarSystemScene(
     // #292 회귀 가드: focus 활성 상태에서 safety net 이 primary origin (line 445-450 의
     // `setOriginToBody`) 을 덮어쓰면 originOffset 이 카메라 월드 좌표를 추적 → ADR §3
     // Heliocentric 계약 위배. focus 가 없는 free-fly 탐색에만 safety net 적용한다.
-    if (cam && !focusBodyIdForAssert) {
+    //
+    // #313 M2 — P12 ADR §Q10 Amendment: T3 (body) 에서만 활성. T1/T2 는 renderScale 이 작아
+    // 카메라 이동이 AU 단위여도 sub-pixel → safety net skip + origin [0,0,0] 유지. 매 프레임
+    // metersPerSceneUnit 환산 + floatingOrigin.update() + AU 곱셈 3회 overhead 제거 (#294 회귀 주범 후보).
+    if (cam && !focusBodyIdForAssert && activeTier === 'body') {
       // cam.globalPosition 은 scene unit. P12-A 이후 1 unit 크기는 tier 별 상이 — 환산 factor 는
       // 현재 tier 의 renderScale 역수 (1/sceneUnitPerMeter). fo 는 m 단위 계약.
       const metersPerSceneUnit = sceneUnitPerMeter > 0 ? 1 / sceneUnitPerMeter : AU;

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -674,7 +674,12 @@ export function createSolarSystemScene(
     // local 에 1e5 m 제한을 두면 T3 body tier (P12 단일 모드) 가 물리적으로 동작 불가. float32 jitter 는
     // mesh local (작은 값) 에서만 발생하므로 카메라 local 은 Three.js/Babylon 내부 부동소수점 관리에
     // 위임한다. ADR 20260422-floating-origin.md §6-β / §Amendments 2026-04-22 참조.
-    if (floatingOriginAssertEnabled() && cam) {
+    //
+    // #313 M2 reviewer 권고 — T3 (body) 에서만 assert 활성. T1/T2 는 `floatingOrigin.reset()` 으로
+    // origin=[0,0,0] 유지 → focus body local = 절대 월드 좌표 (지구 = 1 AU ≈ 1.5e11 m) 로 항상 ≥1e5
+    // 임계 초과 → dev 빌드 console.error spam 발생. assert 자체가 T3 primary follow 불변식 검증 목적
+    // 이므로 T1/T2 에서는 무의미. primary follow / safety net 가드와 동일 조건으로 통일.
+    if (floatingOriginAssertEnabled() && cam && activeTier === 'body') {
       const focusId = focusBodyIdForAssert;
       const focusWorld = focusId ? worldPositions.get(focusId) : null;
       if (focusWorld) {

--- a/packages/core/src/scene/tier.test.ts
+++ b/packages/core/src/scene/tier.test.ts
@@ -14,6 +14,7 @@ import {
   tierFromFocus,
   tierFromCameraDistance,
   TIER_HYSTERESIS,
+  computeFloatingOriginForTier,
 } from './tier.js';
 
 describe('renderScaleForTier — ADR §1 수식 재현', () => {
@@ -152,5 +153,59 @@ describe('R6 DoD — Rust engine 경계 유지 (tier scale 은 렌더 전용)', 
       expect(distScene / s).toBeGreaterThanOrEqual(dist * 0.9999);
       expect(distScene / s).toBeLessThanOrEqual(dist * 1.0001);
     }
+  });
+});
+
+describe('computeFloatingOriginForTier — #313 M2 QA 회귀 가드', () => {
+  // 배경: PR #315 초기 구현에서 `setTier` 가 T1/T2 진입 시 reset 만 호출하고 T3 진입 시
+  // 아무 처리도 하지 않아 runTierTransition 이 이전 origin 기준의 focus mesh 좌표를 읽고
+  // 카메라 target 과 mismatch 를 일으켰다 (A1 119.9px / V5 296px 퇴행). 대칭 처리 함수.
+  const earthWorld = [1.496e11, 0, 0] as const; // 1 AU
+  const moonWorld = [1.496e11 + 3.84e8, 0, 0] as const;
+  const worldMap = new Map<string, readonly [number, number, number]>([
+    ['earth', earthWorld],
+    ['moon', moonWorld],
+  ]);
+  const lookup = (id: string) => worldMap.get(id);
+
+  it('T1 (solar) 진입 → [0,0,0] reset (focus 유무 무관)', () => {
+    expect(computeFloatingOriginForTier('solar', 'earth', lookup)).toEqual([0, 0, 0]);
+    expect(computeFloatingOriginForTier('solar', null, lookup)).toEqual([0, 0, 0]);
+  });
+
+  it('T2 (inner) 진입 → [0,0,0] reset (focus 유무 무관)', () => {
+    expect(computeFloatingOriginForTier('inner', 'earth', lookup)).toEqual([0, 0, 0]);
+    expect(computeFloatingOriginForTier('inner', null, lookup)).toEqual([0, 0, 0]);
+  });
+
+  it('T3 (body) + focus 지구 → 지구 world 좌표 반환 (setOriginToBody 용)', () => {
+    expect(computeFloatingOriginForTier('body', 'earth', lookup)).toEqual([1.496e11, 0, 0]);
+  });
+
+  it('T3 (body) + focus 달 → 달 world 좌표 반환 (지구-달 거리 반영)', () => {
+    const origin = computeFloatingOriginForTier('body', 'moon', lookup);
+    expect(origin).toEqual([1.496e11 + 3.84e8, 0, 0]);
+  });
+
+  it('T3 (body) + focus null (free-fly) → null (기존 origin 유지)', () => {
+    expect(computeFloatingOriginForTier('body', null, lookup)).toBeNull();
+  });
+
+  it('T3 (body) + focus id 가 worldMap 에 없음 → null (stale focus 방어)', () => {
+    expect(computeFloatingOriginForTier('body', 'nonexistent', lookup)).toBeNull();
+  });
+
+  it('반환된 좌표는 lookup 원본과 **값 동일** (reference 공유 여부 불가지, 수치 정합만 확인)', () => {
+    const origin = computeFloatingOriginForTier('body', 'earth', lookup);
+    expect(origin![0]).toBe(earthWorld[0]);
+    expect(origin![1]).toBe(earthWorld[1]);
+    expect(origin![2]).toBe(earthWorld[2]);
+  });
+
+  it('T1/T2 의 [0,0,0] 반환은 호출부에서 reset() 분기 — setOriginToBody([0,0,0]) 은 no-op 계약', () => {
+    // 본 테스트는 floating-origin.ts 계약 (setOriginToBody 가 원점과 동일하면 no-op) 과의
+    // 인접 정합성 박제. 호출부는 [0,0,0] 감지 시 `reset()` 을 선호 (listener emit 0 건 보장).
+    const solarOrigin = computeFloatingOriginForTier('solar', 'earth', lookup);
+    expect(solarOrigin).toEqual([0, 0, 0]);
   });
 });

--- a/packages/core/src/scene/tier.ts
+++ b/packages/core/src/scene/tier.ts
@@ -36,6 +36,8 @@
 
 import { AU } from '@astro-simulator/shared';
 
+import type { Vec3Double } from '../coords/vec3.js';
+
 /** P12-A Tier 3단 (Q6=6A). */
 export type Tier = 'solar' | 'inner' | 'body';
 
@@ -193,4 +195,46 @@ export function resolveCurrentTier(
  */
 export function initialTier(): Tier {
   return 'solar';
+}
+
+/**
+ * #313 M2 QA 회귀 수정 — `setTier` 대칭 처리 헬퍼 (순수 함수).
+ *
+ * `runTierTransition` 은 `focusMesh.absolutePosition` 을 읽어 카메라 target 을 재계산한다
+ * (tier-transition.ts line 216-219). 즉 tier 전환 **시점에** mesh.position 이 새 tier 좌표계
+ * (올바른 origin + newScale) 로 이미 재계산되어 있어야 한다.
+ *
+ * 비대칭 처리 (T1/T2 만 reset, T3 진입 시 origin 미갱신) 시:
+ *  1. setTier('body') 호출 시점 origin 은 여전히 [0,0,0] (T1/T2 에서 왔으므로)
+ *  2. `runTierTransition` 이 focusMesh.absolutePosition 을 [world * newScale] 로 읽음 (origin 0 기준)
+ *  3. 카메라 target 이 이 좌표로 설정
+ *  4. 다음 updateAt 의 primary follow 가 origin = focusWorld 로 이동 → mesh.position = [0,0,0] 근처
+ *  5. 카메라 target 과 mesh 가 어긋남 — PR #315 QA 실측 A1 119.9px / V5 296px 퇴행
+ *
+ * 본 함수는 tier 전환 시 적용할 origin target 을 반환한다:
+ *  - T1/T2 진입 → `[0,0,0]` (reset)
+ *  - T3 진입 + focus body 있음 → focus body world 좌표
+ *  - T3 진입 + focus 없음 (free-fly) → `null` (기존 origin 유지 — safety net 이 다음 프레임 재계산)
+ *
+ * 호출부는 반환값이:
+ *  - `[0,0,0]` 이면 `floatingOrigin.reset()`
+ *  - 그 외 배열이면 `floatingOrigin.setOriginToBody(value)`
+ *  - `null` 이면 origin 변경 없음
+ * 을 실행하고, 이어서 origin + newScale 기준으로 mesh.position 재계산 루프를 돌려야 한다.
+ *
+ * @param tier 전환 target tier
+ * @param focusBodyId 현재 focus body id (null 이면 free-fly)
+ * @param lookupFocusWorld focus body 의 절대 월드 좌표 lookup
+ * @returns 적용할 origin 값 또는 null (변경 없음)
+ */
+export function computeFloatingOriginForTier(
+  tier: Tier,
+  focusBodyId: string | null,
+  lookupFocusWorld: (id: string) => Vec3Double | undefined,
+): Vec3Double | null {
+  if (tier !== 'body') return [0, 0, 0];
+  if (focusBodyId === null) return null;
+  const focusWorld = lookupFocusWorld(focusBodyId);
+  if (!focusWorld) return null;
+  return [focusWorld[0], focusWorld[1], focusWorld[2]];
 }


### PR DESCRIPTION
## Summary

- **#313 M2 구현** — Floating Origin primary follow + free-fly safety net 을 `activeTier === 'body'` (T3) 조건부로 전환. T1 (Solar) / T2 (Inner) 에서 매 프레임 `setOriginToBody` + `update()` + `Vec3Double` 할당 overhead 제거
- **P12 ADR §Amendments (c) 구현 정합성 복구** — "T1/T2 no-op" Amendment 가 시각 효과만 다루고 컴퓨트 비용은 해소하지 않아 non-focus fps −38~−44% 회귀 지속 (#313 M1 재측정 실증)
- **FloatingOrigin 클래스 / `onOriginShift` 계약 / `floating-origin*.test.ts` 전부 유지** — §Amendments (c) "제거 하지 않는 이유" 4항 (P11-A 회귀 가드, Trail 모듈 계약, toLocal 인터페이스, #294~#297 기준선) 모두 보존

## 배경

ADR `20260423-display-relative-scale-unification.md` §Amendments (c) 은 P12 완결 시점에 "코드 변경 0, Amendment 만" 으로 박제했으나 (`originOffset=[0,0,0]` 유지 시 toLocal 오버헤드는 `subtract([0,0,0])` 수준으로 0 에 수렴), **M1 재측정에서 실측 overhead 가 실재** 확인됨.

### M1 재측정 수치 (Run #24837822902, v0.12.0 main, `phase=p11-reshape-m1`)

| scenario | v0.10.0 | v0.12.0 (M1) | vs v0.10.0 |
|---|---|---|---|
| idle | 30.09 | 16.89 | **−44%** |
| play-1d | 21.64 | 13.41 | **−38%** |
| play-1y | 24.14 | 14.77 | **−39%** |
| focus-earth | 60.16 | 66.24 | +10% |
| focus-neptune | 60.28 | 144.28 | +139% |

Overhead 원인: `updateAt` 매 프레임 내 primary follow + free-fly safety net + `Vec3Double` 메모리 할당 + Set iteration (listener 0 건이어도 loop 진입) 누적. tier 무관 실행이라 T1/T2 sub-pixel 시각 영향에 비해 비용 불균형.

## 변경 내용

### `packages/core/src/scene/solar-system-scene.ts` (+18 / −2)

1. **`setTier`** — `tier !== 'body'` 로 전환 시 `floatingOrigin.reset()` 1회 호출 (T1/T2 에서 origin `[0,0,0]` 불변식 유지)
2. **Primary follow (line 583)** — `activeTier === 'body' && focusBodyIdForAssert` 로 조건 강화. T1/T2 매 프레임 `setOriginToBody` 호출 제거
3. **Safety net (line 637)** — `cam && !focusBodyIdForAssert && activeTier === 'body'` 로 조건 강화. T1/T2 매 프레임 `metersPerSceneUnit` 환산 + `update()` + AU 곱셈 3회 제거

각 지점에 "#313 M2 — P12 ADR §Q10 Amendment" 주석 계약 인라인 박제.

### `docs/decisions/20260423-display-relative-scale-unification.md` (+29)

§Amendments 에 "2026-04-23 — Q10 구현 정합성 재평가 (#313 M2)" 섹션 추가. M1 실측 수치, 재평가 결정, DoD 재조정 (ROI 5문 체크) 박제.

## DoD 재조정 (CLAUDE.md 스프린트 계약 6항)

원 계약 "T3 기능 회귀 가드 단위 테스트 (지구/달 focus 시 FO primary follow 동작 유지)" 는 Scene 인스턴스 + tier 전환 mock 구축 비용이 수정 라인 수 (3줄) 대비 과다.

**ROI 5문 체크**:
- ✅ 테스트 환경 구축 비용 > 5배: Scene integration 테스트 인프라 신설 필요 (vitest 환경에서 Babylon Scene 인스턴스 + CameraController + FO 조합)
- ✅ 몇 줄 보호: 3줄 (reset 1줄 + 분기 2개)
- ✅ 회귀 시 조용히 퇴행 vs 빌드 실패: **조용히 퇴행** — 하지만 M3 bench 재측정 게이트로 자동 감지 가능 (non-focus 회귀율 < 5%)
- ✅ 인접 테스트로 간접 보증: `packages/core/src/coords/floating-origin.test.ts` 의 `reset()` / `setOriginToBody no-op` 테스트가 기본 계약 보증
- ✅ 미래 fixture 후 저렴: Scene integration 테스트 인프라는 별도 이슈 후보 (P17 기술부채)

**대체 보장**:
1. 주석 계약 — `setTier` / primary follow / safety net 3지점에 "#313 M2 — P12 ADR §Q10 Amendment" 인라인 박제 (drift 방어)
2. `floating-origin.test.ts` 의 기존 16개 테스트 유지 (인접 property 테스트)
3. **M3 bench 재측정 게이트** — PR 머지 후 `bench-baseline-remeasure` workflow 실행, non-focus 회귀율 < 5% 충족 시 #294 close. 미충족 시 회귀 즉시 감지

**재조정 박제 3위치** (CLAUDE.md 준수): ADR §Amendments / 본 PR 본문 / CHANGELOG Notes (릴리스 시)

## Test plan

- [x] `pnpm --filter @astro-simulator/core exec tsc --noEmit` — 통과
- [x] `pnpm --filter @astro-simulator/core exec vitest run` — 226/226 통과 (기존 floating-origin 테스트 포함)
- [x] 한글 인코딩 검증 `grep -rn '�' <수정 파일>` — 깨짐 0건
- [ ] CI 전체 통과 (이 PR 의 checks)
- [ ] **Reviewer 리뷰** (ADR §Amendments 재평가 타당성 + 3지점 분기 논리)
- [ ] **QA 브라우저 3단계 검증**:
  - 정적: T1 (Solar) / T2 (Inner) / T3 (Body) 각 tier 에서 렌더 시각 회귀 없음
  - 인터랙션: 지구 focus → T3 진입 → FO primary follow 동작 유지 (달 jitter 없음)
  - 흐름: T3 focus 해제 → free-fly (T2) 복귀 시 `originOffset` [0,0,0] 리셋 후 정상 렌더
- [ ] **M3 bench 재측정** (PR 머지 후) — `bench-baseline-remeasure` workflow 실행, non-focus 회귀율 < 5% 확인 → #294 close

## Behavior Changes

- **T1 (Solar) / T2 (Inner) tier**: `floatingOrigin` 의 `originOffset` 이 항상 `[0,0,0]` 고정. 매 프레임 `setOriginToBody` / `update()` 호출 제거
- **T3 (Body) tier**: 기존 동작 100% 유지 — focus body primary follow + free-fly safety net 그대로
- **tier 전환 시**: T3 이탈 → `floatingOrigin.reset()` 1회 호출 (listener 호출 없음 — `reset()` 계약)
- **관찰 효과** (M3 재측정 후 확인): non-focus scenario (idle/play-1d/play-1y) fps 개선. focus scenario 영향 없음

## Related

- Relates to #294 (M3 재측정 후 회귀율 < 5% 확인 시 수동 close 예정 — 자동 close 방지)
- Blocks: #313 M3 (PR 머지 → bench 재측정 → #294 close)
- Related: #288 (P11-A Floating Origin, §Amendments (c) 재평가 대상)
- ADR: `docs/decisions/20260423-display-relative-scale-unification.md` §Amendments
- M1 재측정 PR: #314 (보류, M3 재측정 PR 로 대체 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
