### PR TITLE
[#310] HUD Data Tier 범례 rename — "Tier 1 관측" → "정확도 · T1 관측"

### DIFF
--- a/apps/web/src/components/layout/hud-corners.tsx
+++ b/apps/web/src/components/layout/hud-corners.tsx
@@ -110,7 +110,7 @@ export function HudCorners() {
           className="inline-block w-2 h-2 rounded-full"
           style={{ background: 'var(--tier-1-observed)' }}
         />
-        Tier 1 관측
+        정확도 · T1 관측
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- ADR [\`20260424-tier-naming-policy.md\`](https://github.com/coseo12/astro-simulator/blob/develop/docs/decisions/20260424-tier-naming-policy.md) §결정 §2 적용
- \`apps/web/src/components/layout/hud-corners.tsx:113\` 1줄 치환
- Scale Tier (Solar/Inner/Body) 와 Data Tier 오인 방지 — "정확도" prefix + "T1" 축약 라벨로 시각 완전 분리

## 근거

PR #317 에서 박제된 네이밍 정책 ADR 의 실제 UI 반영. ADR §결정 §2 는 본 이슈 #310 의 완료 기준 #2 "HUD 범례 용어 치환" 에 대응.

## 변경 (1줄)

\`\`\`diff
-        Tier 1 관측
+        정확도 · T1 관측
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` pass
- [x] \`vitest run\` pass — 16 test files / 97 tests
- [x] CRITICAL #3 브라우저 3단계 검증 PASS
  - [x] **정적**: 초기 로드 시 우하단 HUD = "정확도 · T1 관측", 콘솔 에러 0
  - [x] **인터랙션**: 지구/태양 focus 클릭 / 1y 배속 재생 — UI 반응 정상, HUD 텍스트 불변
  - [x] **흐름**: Scale Tier 전환 (Body ↔ Solar) + play 중에도 HUD 유지 — Data Tier ↔ Scale Tier 독립성 실증
- [x] CRITICAL #4 U+FFFD 검증 통과 (\`grep -rn '�'\` 0건)

## Refs

- Refs: #310 (ADR DoD #2, 후속 PR 구현 의무 이행)
- Depends on: #317 (ADR 박제, develop merged)

## 영향 범위

단일 UI 텍스트 1줄. 기능 회귀 위험 없음 (\`pointer-events-none\`, 이벤트 핸들러 없음, 렌더 분기 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)