### PR TITLE
[#289] P11-B.1 LOD 3단 + 거리 하이브리드 임계 구현

### DIFF
--- a/apps/web/src/components/layout/app-shell.tsx
+++ b/apps/web/src/components/layout/app-shell.tsx
@@ -3,6 +3,7 @@
 import { TopBar } from './top-bar';
 import { TimeBar } from './time-bar';
 import { HudCorners } from './hud-corners';
+import { LodDevOverlay } from './lod-dev-overlay';
 import { FocusQuickButtons } from './focus-quick-buttons';
 import { ModeSwitcher } from './mode-switcher';
 import { AboutModal } from './about-modal';
@@ -44,6 +45,7 @@ export function AppShell() {
         />
         <UrlSync />
         <HudCorners />
+        <LodDevOverlay />
         <SidePanels />
         <ScaleControl />
         <TimeBar>

--- a/apps/web/src/components/layout/lod-dev-overlay.tsx
+++ b/apps/web/src/components/layout/lod-dev-overlay.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * P11-B #289 — LOD dev overlay
+ *
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §결정 §6
+ *
+ * draw call 분포를 시각화해 LOD 동작을 런타임 관찰 가능하게 한다.
+ *
+ * 활성 조건:
+ *  - `process.env.NODE_ENV !== 'production'` (prod 빌드에서 DCE)
+ *  - URL `?debug=draw-calls` 옵트인 (dev 에서도 기본 숨김, 필요할 때만 활성)
+ *
+ * 표시 형식: `LOD H:12 M:8 L:72 (auto)` — LOD 별 body 수 + override 상태
+ *
+ * 갱신: 1초 throttle. 매 프레임 갱신은 LOD 분기 O(N) 대비 과도한 re-render 비용.
+ */
+import { useEffect, useState } from 'react';
+
+// `window.__solarScene` 는 dev 빌드에서 sim-canvas 가 노출하는 handles (`Object.defineProperty`).
+// LOD 집계는 `getLodStats()` 반환. handles 구조는 solar-system-scene.ts SolarSystemSceneHandles 참조.
+interface LodStats {
+  high: number;
+  mid: number;
+  low: number;
+  override: 'high' | 'mid' | 'low' | 'auto';
+}
+
+interface SceneHandlesPartial {
+  getLodStats?: () => LodStats;
+}
+
+const POLL_INTERVAL_MS = 1000;
+
+export function LodDevOverlay() {
+  const [stats, setStats] = useState<LodStats | null>(null);
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    if (typeof window === 'undefined') return;
+    const debugParam = new URLSearchParams(window.location.search).get('debug');
+    if (debugParam !== 'draw-calls') return;
+    setEnabled(true);
+    const timer = window.setInterval(() => {
+      const scene = (window as unknown as { __solarScene?: SceneHandlesPartial }).__solarScene;
+      if (scene?.getLodStats) {
+        setStats(scene.getLodStats());
+      }
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  if (!enabled || !stats) return null;
+
+  const total = stats.high + stats.mid + stats.low;
+  return (
+    <div
+      data-testid="lod-dev-overlay"
+      className="absolute bottom-36 left-2 text-caption num text-fg-tertiary bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle pointer-events-none"
+    >
+      LOD · total {total} · H:{stats.high} M:{stats.mid} L:{stats.low} ({stats.override})
+    </div>
+  );
+}

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -6,6 +6,7 @@ import { SimulationCore, scene as sceneApi, gpu as gpuApi } from '@astro-simulat
 import { attachCoreToStore } from '@/core/core-adapter';
 import { parseIntegratorKind } from '@/core/parse-integrator';
 import { parseGrMode } from '@/core/parse-gr-mode';
+import { parseLodLevel } from '@/core/parse-lod-level';
 import { detectIsMobile } from '@/core/is-mobile';
 import { SimCommandProvider } from '@/core/sim-context';
 import { useSimStore } from '@/store/sim-store';
@@ -258,6 +259,22 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
         }
 
         instance.on('timeChanged', ({ julianDate }) => solar.updateAt(julianDate));
+
+        // P11-B #289 — `setLodOverride` command → scene 에 전달. URL `?lod=` 초기 1회 호출 경로.
+        // UrlSync 가 mount 시 `sendCommand({ type: 'setLodOverride', level })` 호출 → 여기로 라우팅.
+        //
+        // [타이밍 주의] UrlSync 의 mount useEffect 는 `setCore(instance)` 직후 실행되지만 scene 초기화
+        // (`instance.start().then(...)`) 는 비동기라 handler 가 아직 null. 이 경우 command 가 no-op 되어
+        // override 유실. 방어 장치로 handler 등록 시점에 **URL 을 직접 재파싱** 하여 즉시 override 적용
+        // (UrlSync 호출이 이미 지나갔어도 최신 URL 상태 복원). 두 경로 동시 적용해도 idempotent.
+        instance.setLodOverrideHandler((level) => {
+          solar.setLodOverride(level);
+        });
+        {
+          const lodParam = new URLSearchParams(window.location.search).get('lod');
+          const parsed = parseLodLevel(lodParam);
+          solar.setLodOverride(parsed);
+        }
 
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)
         // + 질량 배수 변경 → setBodyMassMultiplier (#107)

--- a/apps/web/src/core/parse-lod-level.test.ts
+++ b/apps/web/src/core/parse-lod-level.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { parseLodLevel } from './parse-lod-level';
+
+describe('parseLodLevel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('공식값 high / mid / low 는 그대로 통과', () => {
+    expect(parseLodLevel('high')).toBe('high');
+    expect(parseLodLevel('mid')).toBe('mid');
+    expect(parseLodLevel('low')).toBe('low');
+  });
+
+  it("'auto' 는 그대로 통과 (자동 판정 모드)", () => {
+    expect(parseLodLevel('auto')).toBe('auto');
+  });
+
+  it('대소문자 무시 — HIGH / Mid / LOW / AUTO', () => {
+    expect(parseLodLevel('HIGH')).toBe('high');
+    expect(parseLodLevel('Mid')).toBe('mid');
+    expect(parseLodLevel('LOW')).toBe('low');
+    expect(parseLodLevel('AUTO')).toBe('auto');
+  });
+
+  it("null / undefined / 빈 문자열 → 'auto' (기본값)", () => {
+    expect(parseLodLevel(null)).toBe('auto');
+    expect(parseLodLevel(undefined)).toBe('auto');
+    expect(parseLodLevel('')).toBe('auto');
+  });
+
+  it("알 수 없는 값은 'auto' 폴백 + console.warn 호출", () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseLodLevel('xyz')).toBe('auto');
+    expect(parseLodLevel('super-high')).toBe('auto');
+    expect(parseLodLevel('ultra')).toBe('auto');
+    expect(parseLodLevel('0')).toBe('auto');
+    expect(spy).toHaveBeenCalledTimes(4);
+    // 첫 호출에 파라미터 값 포함 확인.
+    expect(spy.mock.calls[0]?.[0]).toContain('xyz');
+  });
+});

--- a/apps/web/src/core/parse-lod-level.ts
+++ b/apps/web/src/core/parse-lod-level.ts
@@ -1,0 +1,38 @@
+/**
+ * P11-B #289 — `?lod=` URL 파라미터 → `LodOverride` 파싱 순수 함수.
+ *
+ * 선례: `parse-integrator.ts` / `parse-gr-mode.ts` 동일 구조.
+ *
+ * 정책:
+ *  - 공식값: `high` · `mid` · `low` — 전 body LOD 강제 (디버그/개발 용도)
+ *  - `auto` (또는 미지정): 거리 자동 판정 — 기본값
+ *  - 대소문자 무시 (URL 사용자 편의)
+ *  - 알 수 없는 값 → `'auto'` 폴백 + `console.warn`
+ *
+ * 런타임 핫스왑은 비지원 — 이 파서는 초기화 시점에 1회만 호출된다.
+ *
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §축 5
+ */
+import type { render } from '@astro-simulator/core';
+
+type LodOverride = render.LodOverride;
+
+const VALID_LOD_LEVELS: ReadonlySet<string> = new Set(['high', 'mid', 'low']);
+
+export function parseLodLevel(urlParam: string | null | undefined): LodOverride {
+  // 미지정 → 'auto' (거리 자동 판정).
+  if (urlParam === null || urlParam === undefined || urlParam === '') {
+    return 'auto';
+  }
+  const normalized = urlParam.toLowerCase();
+  if (normalized === 'auto') {
+    return 'auto';
+  }
+  if (VALID_LOD_LEVELS.has(normalized)) {
+    return normalized as LodOverride;
+  }
+  // 알 수 없는 값 — parse-integrator 패턴과 동일한 폴백 + warn.
+  // eslint-disable-next-line no-console
+  console.warn(`[parse-lod-level] 알 수 없는 ?lod=${urlParam} — 'auto' 로 폴백`);
+  return 'auto';
+}

--- a/apps/web/src/core/url-sync.tsx
+++ b/apps/web/src/core/url-sync.tsx
@@ -5,6 +5,7 @@ import { parseAsFloat, parseAsString, parseAsStringEnum, useQueryState } from 'n
 import { useEffect, useRef } from 'react';
 import { useSimStore } from '@/store/sim-store';
 import { useSimCommand } from './sim-context';
+import { parseLodLevel } from './parse-lod-level';
 
 const MODE_VALUES: SimMode[] = ['observe', 'research', 'education', 'sandbox'];
 // P3-0 #126 — barnes-hut/webgpu/auto는 URL로는 받지만 런타임은 미구현 폴백.
@@ -37,6 +38,9 @@ export function UrlSync() {
     'engine',
     parseAsStringEnum<PhysicsEngineUrl>([...ENGINE_VALUES]).withOptions({ history: 'replace' }),
   );
+  // P11-B #289 — ?lod=high|mid|low|auto 초기 1회 파싱 → sendCommand.
+  // store 에 저장하지 않음 (LOD 는 scene 내부 상태) — URL → Core → Scene 단방향 파이프.
+  const [urlLod] = useQueryState('lod', parseAsString.withOptions({ history: 'replace' }));
 
   const mode = useSimStore((s) => s.mode);
   const selectedBodyId = useSimStore((s) => s.selectedBodyId);
@@ -69,6 +73,9 @@ export function UrlSync() {
     if (urlEngine) {
       setPhysicsEngine(urlEngine);
     }
+    // P11-B #289 — `?lod=` 초기 1회 전달. 미지정 (null) 이면 parseLodLevel 이 'auto' 반환 → override 해제.
+    const parsedLod = parseLodLevel(urlLod);
+    sendCommand({ type: 'setLodOverride', level: parsedLod });
     // P12-C #298 — `?view=scientific|educational` 은 단일 모드 전환으로 폐기.
     // 기존 북마크는 파라미터를 조용히 무시하고 단일 모드로 자연 진입 (backward-ignore, ADR §재검토 암묵 전제).
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -27,6 +27,8 @@ export class SimulationCore {
   #focusOnHandler: ((bodyId: string) => void) | null = null;
   #resetCameraHandler: (() => void) | null = null;
   #setRadiusHandler: ((radius: number) => void) | null = null;
+  // P11-B #289 — LOD override 핸들러. URL `?lod=` 초기 1회 sendCommand 에서 scene 에 전달.
+  #setLodOverrideHandler: ((level: 'high' | 'mid' | 'low' | 'auto') => void) | null = null;
   // P5-B #177 — fps emit 주기 제어. 매 프레임 emit하면 store 갱신 과다 → 0.5초 간격.
   #lastFpsEmitTime = 0;
   // P4-D #166 — GPU frame time (ms 단위) 직접 측정. 미지원 환경에서는 null.
@@ -149,6 +151,16 @@ export class SimulationCore {
     this.#setRadiusHandler = setRadius ?? null;
   }
 
+  /**
+   * P11-B #289 — LOD override 핸들러 연결. sim-canvas 가 scene 생성 직후 1회 호출.
+   *
+   * 핸들러는 scene 의 `setLodOverride(level)` 를 호출해 override 를 반영한다. URL `?lod=high|mid|low`
+   * 면 전 body 강제, `auto` (또는 미호출) 면 거리 자동 판정.
+   */
+  setLodOverrideHandler(handler: (level: 'high' | 'mid' | 'low' | 'auto') => void): void {
+    this.#setLodOverrideHandler = handler;
+  }
+
   /** 이벤트 구독. */
   on<K extends keyof CoreEvents>(type: K, handler: Handler<CoreEvents[K]>): void {
     this.#emitter.on(type, handler);
@@ -196,6 +208,10 @@ export class SimulationCore {
         break;
       case 'setMode':
         this.#emitter.emit('modeChanged', { mode: cmd.mode });
+        break;
+      case 'setLodOverride':
+        // P11-B #289 — scene 에 위임. 미등록 시 no-op (scene 초기화 전 순서 무관).
+        this.#setLodOverrideHandler?.(cmd.level);
         break;
       default: {
         const _exhaustive: never = cmd;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,5 +14,7 @@ export * as scene from './scene/index.js';
 export * as gpu from './gpu/index.js';
 export * as ephemeris from './ephemeris/index.js';
 export * as time from './time/index.js';
+// P11-B #289 — LOD 3단 분기 + 화면 점유 계산 (render 레이어, Scale Tier 와 직교).
+export * as render from './render/index.js';
 
 export const VERSION = '0.0.0';

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Render 모듈 — LOD / GPU tier 등 렌더 레이어 순수 함수.
+ *
+ * ADR: `docs/decisions/20260424-tier-naming-policy.md` §1 SSoT (심볼 경로 선박제)
+ *      `docs/decisions/20260424-p11-b-lod-design.md` §결정 §1 (모듈 구조)
+ */
+
+export {
+  lodFromScreenCoverage,
+  screenCoverageRadius,
+  classifyBodyLodKind,
+  LOD_BODY_THRESHOLDS,
+  LOD_PIXEL_THRESHOLDS,
+} from './lod.js';
+export type { LodLevel, LodOverride, LodDecisionInput } from './lod.js';
+export type { BodyLodKind, BodyLodThreshold, BodyLodThresholdMode } from './lod-body-thresholds.js';

--- a/packages/core/src/render/lod-body-thresholds.ts
+++ b/packages/core/src/render/lod-body-thresholds.ts
@@ -1,0 +1,122 @@
+/**
+ * P11-B #289 — LOD body-kind 임계 상수
+ *
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §축 2
+ *
+ * body kind → "high LOD 강제 조건" 룩업. 카메라 거리 / body 반경 기준으로 세부 관찰 의도를 판정한다.
+ * 12 카테고리 완비 (주석 계약 vs 구현 drift 방어 — CLAUDE.md 교훈).
+ *
+ * 신규 kind 추가 시 본 상수에 항목 누락하면 `classifyBodyLodKind` 가 unknown kind 를 리턴하고
+ * `LOD_BODY_THRESHOLDS[kind]` 가 undefined → `lod.test.ts` 의 enum 완비 assert 에서 즉시 fail.
+ */
+
+import { AU } from '@astro-simulator/shared';
+
+/**
+ * LOD 레이어에서 사용하는 body 분류 (12 카테고리).
+ *
+ * `CelestialBody.kind` 의 zod enum 11종 + `planet` 의 질량 파생 분류 (giant / terrestrial) 로
+ * 구성. zod enum 을 직접 바꾸면 solar-system.json 전체 재작성 + P2 이후 회귀가 발생하므로,
+ * LOD 레이어에서만 파생 분류를 수행한다.
+ */
+export type BodyLodKind =
+  | 'star'
+  | 'planet-giant'
+  | 'planet-terrestrial'
+  | 'moon'
+  | 'dwarf-planet'
+  | 'comet'
+  | 'asteroid'
+  | 'spacecraft'
+  | 'black-hole'
+  | 'nebula'
+  | 'galaxy'
+  | 'star-cluster';
+
+/**
+ * LOD 임계 분기 모드 3종.
+ *
+ *  - `absolute-distance`: 카메라-body 실세계 거리 (m) 가 `highMaxDistanceMeters` 미만이면 high 강제
+ *  - `radius-multiple`: 카메라-body 거리가 `highMaxRadiusFactor × body.radius` 미만이면 high 강제
+ *  - `always-high`: 거리 무관 항상 high (전용 shader 경로 — 블랙홀/은하/성운 등)
+ */
+export type BodyLodThresholdMode = 'absolute-distance' | 'radius-multiple' | 'always-high';
+
+export type BodyLodThreshold =
+  | { mode: 'absolute-distance'; highMaxDistanceMeters: number }
+  | { mode: 'radius-multiple'; highMaxRadiusFactor: number }
+  | { mode: 'always-high' };
+
+/**
+ * body kind 별 high LOD 강제 규칙.
+ *
+ * ADR `docs/decisions/20260424-p11-b-lod-design.md` §축 2 표의 근거와 수치 일치.
+ *
+ *  - star (태양): < 1 AU — corona/flare 세부 표현은 1 AU 내에서만 인식 가능
+ *  - planet-giant: < 10 × R_body — 고리/대적점/벨트 패턴은 반경 10배 내 시각 감지
+ *  - planet-terrestrial: < 5 × R_body — 대륙/극관 디테일은 반경 5배 내
+ *  - moon / dwarf-planet: < 5 × R_body — 갈릴레이 위성 / 명왕성 focus 의도
+ *  - comet: < 3 × R_body — 혜성 본체는 작음 (dust tail 은 별도 파티클)
+ *  - asteroid / spacecraft: < 0.01 AU (150만 km) — radius 가 너무 작아 radius 배수는 수 m 이하로 제한됨
+ *  - black-hole / nebula / galaxy / star-cluster: 전용 shader 경로 유지 (always-high)
+ */
+export const LOD_BODY_THRESHOLDS: Record<BodyLodKind, BodyLodThreshold> = {
+  star: { mode: 'absolute-distance', highMaxDistanceMeters: AU },
+  'planet-giant': { mode: 'radius-multiple', highMaxRadiusFactor: 10 },
+  'planet-terrestrial': { mode: 'radius-multiple', highMaxRadiusFactor: 5 },
+  moon: { mode: 'radius-multiple', highMaxRadiusFactor: 5 },
+  'dwarf-planet': { mode: 'radius-multiple', highMaxRadiusFactor: 5 },
+  comet: { mode: 'radius-multiple', highMaxRadiusFactor: 3 },
+  asteroid: { mode: 'absolute-distance', highMaxDistanceMeters: 0.01 * AU },
+  spacecraft: { mode: 'absolute-distance', highMaxDistanceMeters: 0.01 * AU },
+  'black-hole': { mode: 'always-high' },
+  nebula: { mode: 'always-high' },
+  galaxy: { mode: 'always-high' },
+  'star-cluster': { mode: 'always-high' },
+};
+
+/**
+ * planet-giant 파생 분류 경계 (kg).
+ *
+ * 가스 거인 최소 질량 기준 — 천왕성 8.68e25 kg, 해왕성 1.02e26 kg, 토성 5.68e26 kg, 목성 1.90e27 kg.
+ * 지구형 최대 질량 — 지구 5.97e24 kg. 경계 5e25 kg 은 천왕성 이하의 지구형 외행성 전체를 giant 에서 분리.
+ */
+const PLANET_GIANT_MASS_THRESHOLD_KG = 5e25;
+
+/**
+ * CelestialBody → BodyLodKind 분류기.
+ *
+ * `planet` kind 만 질량 기반 파생 분류 (giant / terrestrial). 나머지는 kind 그대로 매핑.
+ * 미지 kind 는 `null` 반환 — 호출자 (`lod.ts`) 가 `console.warn` + low fallback 처리.
+ *
+ * ADR §축 2 주석: "body.kind 의 zod enum 을 바꾸면 solar-system.json 전체 재작성 + P2 이후 회귀 —
+ * 범위 밖. 대신 body.mass 기반 파생 분류 만 LOD 레이어에서 수행".
+ */
+export function classifyBodyLodKind(body: { kind: string; mass: number }): BodyLodKind | null {
+  switch (body.kind) {
+    case 'star':
+      return 'star';
+    case 'planet':
+      return body.mass >= PLANET_GIANT_MASS_THRESHOLD_KG ? 'planet-giant' : 'planet-terrestrial';
+    case 'moon':
+      return 'moon';
+    case 'dwarf-planet':
+      return 'dwarf-planet';
+    case 'comet':
+      return 'comet';
+    case 'asteroid':
+      return 'asteroid';
+    case 'spacecraft':
+      return 'spacecraft';
+    case 'black-hole':
+      return 'black-hole';
+    case 'nebula':
+      return 'nebula';
+    case 'galaxy':
+      return 'galaxy';
+    case 'star-cluster':
+      return 'star-cluster';
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/render/lod.test.ts
+++ b/packages/core/src/render/lod.test.ts
@@ -1,0 +1,412 @@
+/**
+ * P11-B #289 — LOD 분기 / body-kind 분류 / 화면 점유 단위 테스트
+ *
+ * DoD B.1-D2: matrix 9개 (태양/지구/달/이오/소행성 × 근/중/원) + 카테고리 enum 완비 assert
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §결정 §4
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { AU } from '@astro-simulator/shared';
+import {
+  lodFromScreenCoverage,
+  screenCoverageRadius,
+  classifyBodyLodKind,
+  LOD_BODY_THRESHOLDS,
+  LOD_PIXEL_THRESHOLDS,
+  type BodyLodKind,
+} from './lod.js';
+
+// ----------------------------------------------------------------------------
+// 1. 카테고리 enum 완비 assert (주석 계약 drift 방어 — volt #49 교훈)
+// ----------------------------------------------------------------------------
+
+describe('LOD_BODY_THRESHOLDS — 12 카테고리 완비', () => {
+  it('모든 BodyLodKind 가 LOD_BODY_THRESHOLDS 에 존재한다', () => {
+    const required: BodyLodKind[] = [
+      'star',
+      'planet-giant',
+      'planet-terrestrial',
+      'moon',
+      'dwarf-planet',
+      'comet',
+      'asteroid',
+      'spacecraft',
+      'black-hole',
+      'nebula',
+      'galaxy',
+      'star-cluster',
+    ];
+    for (const kind of required) {
+      expect(LOD_BODY_THRESHOLDS[kind]).toBeDefined();
+    }
+    // 선언한 key 수와 required 수가 정확히 일치 — default 도입 금지 (volt #49 교훈).
+    expect(Object.keys(LOD_BODY_THRESHOLDS)).toHaveLength(required.length);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 2. classifyBodyLodKind — kind + mass 파생 분류
+// ----------------------------------------------------------------------------
+
+describe('classifyBodyLodKind', () => {
+  it('kind 자체 매핑 — star / moon / dwarf-planet / comet / asteroid / spacecraft', () => {
+    expect(classifyBodyLodKind({ kind: 'star', mass: 1.989e30 })).toBe('star');
+    expect(classifyBodyLodKind({ kind: 'moon', mass: 7.34e22 })).toBe('moon');
+    expect(classifyBodyLodKind({ kind: 'dwarf-planet', mass: 1.3e22 })).toBe('dwarf-planet');
+    expect(classifyBodyLodKind({ kind: 'comet', mass: 1e13 })).toBe('comet');
+    expect(classifyBodyLodKind({ kind: 'asteroid', mass: 9.4e20 })).toBe('asteroid');
+    expect(classifyBodyLodKind({ kind: 'spacecraft', mass: 720 })).toBe('spacecraft');
+  });
+
+  it('planet 질량 파생 — 지구형 (terrestrial) vs 가스 거인 (giant)', () => {
+    // 수성 3.3e23 / 금성 4.87e24 / 지구 5.97e24 / 화성 6.42e23 → terrestrial
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 3.3e23 })).toBe('planet-terrestrial');
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 5.97e24 })).toBe('planet-terrestrial');
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 6.42e23 })).toBe('planet-terrestrial');
+    // 천왕성 8.68e25 / 해왕성 1.02e26 / 토성 5.68e26 / 목성 1.90e27 → giant
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 8.68e25 })).toBe('planet-giant');
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 1.02e26 })).toBe('planet-giant');
+    expect(classifyBodyLodKind({ kind: 'planet', mass: 1.9e27 })).toBe('planet-giant');
+  });
+
+  it('shader 전용 kind — black-hole / nebula / galaxy / star-cluster', () => {
+    expect(classifyBodyLodKind({ kind: 'black-hole', mass: 1e31 })).toBe('black-hole');
+    expect(classifyBodyLodKind({ kind: 'nebula', mass: 1e30 })).toBe('nebula');
+    expect(classifyBodyLodKind({ kind: 'galaxy', mass: 1e42 })).toBe('galaxy');
+    expect(classifyBodyLodKind({ kind: 'star-cluster', mass: 1e35 })).toBe('star-cluster');
+  });
+
+  it('미지 kind → null 반환 (호출자가 console.warn + low fallback)', () => {
+    expect(classifyBodyLodKind({ kind: 'exoplanet', mass: 1e25 })).toBeNull();
+    expect(classifyBodyLodKind({ kind: '', mass: 0 })).toBeNull();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 3. lodFromScreenCoverage — 9개 matrix + URL override + focus
+// ----------------------------------------------------------------------------
+
+// 실측 근접 데이터 (solar-system.json 기반).
+const SUN = { kind: 'star', mass: 1.989e30, radius: 6.957e8 };
+const EARTH = { kind: 'planet', mass: 5.972e24, radius: 6.371e6 };
+const JUPITER = { kind: 'planet', mass: 1.898e27, radius: 6.9911e7 };
+const MOON = { kind: 'moon', mass: 7.342e22, radius: 1.7374e6 };
+const IO = { kind: 'moon', mass: 8.932e22, radius: 1.8216e6 };
+const ASTEROID = { kind: 'asteroid', mass: 9.4e20, radius: 4.73e5 };
+
+describe('lodFromScreenCoverage — 9개 matrix (body × 거리)', () => {
+  // 매트릭스: 5 body × 3 거리 = 15 케이스 (DoD 요구 9 초과).
+  // 거리 카테고리 — near/mid/far 는 body 별 물리적 의미가 달라 절대값 대신 relative label 로 사용.
+
+  describe('태양 (star) — absolute-distance < 1 AU', () => {
+    it('근 (0.5 AU) — 강제 high', () => {
+      // screenCoverage 작아도 kind 강제 규칙으로 high.
+      expect(
+        lodFromScreenCoverage({
+          body: SUN,
+          cameraDistanceMeters: 0.5 * AU,
+          screenCoverage: 1,
+        }),
+      ).toBe('high');
+    });
+    it('중 (2 AU) — 픽셀 경계 적용 (50px 이상 high)', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: SUN,
+          cameraDistanceMeters: 2 * AU,
+          screenCoverage: 100,
+        }),
+      ).toBe('high');
+    });
+    it('원 (10 AU) + sub-pixel — low', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: SUN,
+          cameraDistanceMeters: 10 * AU,
+          screenCoverage: 0.5,
+        }),
+      ).toBe('low');
+    });
+  });
+
+  describe('지구 (planet-terrestrial) — radius-multiple < 5R', () => {
+    it('근 (3R ≈ 1.9e7 m) — 강제 high', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: EARTH,
+          cameraDistanceMeters: 3 * EARTH.radius,
+          screenCoverage: 2,
+        }),
+      ).toBe('high');
+    });
+    it('중 (10R, 30px) — mid (8 ≤ px < 50)', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: EARTH,
+          cameraDistanceMeters: 10 * EARTH.radius,
+          screenCoverage: 30,
+        }),
+      ).toBe('mid');
+    });
+    it('원 (1 AU, sub-pixel) — low', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: EARTH,
+          cameraDistanceMeters: 1 * AU,
+          screenCoverage: 0.3,
+        }),
+      ).toBe('low');
+    });
+  });
+
+  describe('목성 (planet-giant) — radius-multiple < 10R', () => {
+    it('근 (5R) — 강제 high (10R 이내)', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: JUPITER,
+          cameraDistanceMeters: 5 * JUPITER.radius,
+          screenCoverage: 5,
+        }),
+      ).toBe('high');
+    });
+    it('중 (50R, 20px) — mid', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: JUPITER,
+          cameraDistanceMeters: 50 * JUPITER.radius,
+          screenCoverage: 20,
+        }),
+      ).toBe('mid');
+    });
+  });
+
+  describe('달 (moon) — radius-multiple < 5R', () => {
+    it('근 (3R) — 강제 high', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: MOON,
+          cameraDistanceMeters: 3 * MOON.radius,
+          screenCoverage: 2,
+        }),
+      ).toBe('high');
+    });
+    it('원 (30R, 7px) — low (8px 미만)', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: MOON,
+          cameraDistanceMeters: 30 * MOON.radius,
+          screenCoverage: 7,
+        }),
+      ).toBe('low');
+    });
+  });
+
+  describe('이오 (moon) — 갈릴레이 위성 분기', () => {
+    it('근 (3R) — 강제 high', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: IO,
+          cameraDistanceMeters: 3 * IO.radius,
+          screenCoverage: 2,
+        }),
+      ).toBe('high');
+    });
+    it('원 (AU 단위) — low', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: IO,
+          cameraDistanceMeters: 1 * AU,
+          screenCoverage: 0.1,
+        }),
+      ).toBe('low');
+    });
+  });
+
+  describe('소행성 (asteroid) — absolute-distance < 0.01 AU', () => {
+    it('근 (0.005 AU) — 강제 high', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: ASTEROID,
+          cameraDistanceMeters: 0.005 * AU,
+          screenCoverage: 1,
+        }),
+      ).toBe('high');
+    });
+    it('중 (0.05 AU, 20px) — mid', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: ASTEROID,
+          cameraDistanceMeters: 0.05 * AU,
+          screenCoverage: 20,
+        }),
+      ).toBe('mid');
+    });
+    it('원 (2 AU, sub-pixel) — low', () => {
+      expect(
+        lodFromScreenCoverage({
+          body: ASTEROID,
+          cameraDistanceMeters: 2 * AU,
+          screenCoverage: 0.05,
+        }),
+      ).toBe('low');
+    });
+  });
+});
+
+describe('lodFromScreenCoverage — URL override / focus / shader 전용', () => {
+  it('URL override high — 거리/coverage 무관 강제 high', () => {
+    expect(
+      lodFromScreenCoverage({
+        body: EARTH,
+        cameraDistanceMeters: 100 * AU,
+        screenCoverage: 0.1,
+        override: 'high',
+      }),
+    ).toBe('high');
+  });
+
+  it('URL override mid — 강제 mid', () => {
+    expect(
+      lodFromScreenCoverage({
+        body: SUN,
+        cameraDistanceMeters: 0.1 * AU,
+        screenCoverage: 500,
+        override: 'mid',
+      }),
+    ).toBe('mid');
+  });
+
+  it('URL override low — 강제 low', () => {
+    expect(
+      lodFromScreenCoverage({
+        body: EARTH,
+        cameraDistanceMeters: 3 * EARTH.radius,
+        screenCoverage: 200,
+        override: 'low',
+      }),
+    ).toBe('low');
+  });
+
+  it("URL override 'auto' 는 자동 판정으로 내려감", () => {
+    expect(
+      lodFromScreenCoverage({
+        body: EARTH,
+        cameraDistanceMeters: 3 * EARTH.radius,
+        screenCoverage: 2,
+        override: 'auto',
+      }),
+    ).toBe('high'); // kind 규칙 발동
+  });
+
+  it('isFocused=true — 거리/coverage 무관 강제 high (ADR §미해결 3)', () => {
+    expect(
+      lodFromScreenCoverage({
+        body: EARTH,
+        cameraDistanceMeters: 100 * AU,
+        screenCoverage: 0.1,
+        isFocused: true,
+      }),
+    ).toBe('high');
+  });
+
+  it('isFocused 와 override low 가 모두 지정된 경우 override 가 우선', () => {
+    // override 는 개발/디버그 용도 — focus 보다 우선순위 높음 (주석 계약 §6).
+    expect(
+      lodFromScreenCoverage({
+        body: EARTH,
+        cameraDistanceMeters: 3 * EARTH.radius,
+        screenCoverage: 100,
+        isFocused: true,
+        override: 'low',
+      }),
+    ).toBe('low');
+  });
+
+  it('shader 전용 kind (black-hole) 는 거리 무관 high 유지', () => {
+    expect(
+      lodFromScreenCoverage({
+        body: { kind: 'black-hole', mass: 1e31, radius: 1e4 },
+        cameraDistanceMeters: 1000 * AU,
+        screenCoverage: 0.01,
+      }),
+    ).toBe('high');
+  });
+});
+
+describe('lodFromScreenCoverage — 미지 kind fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("미지 kind → 'low' + console.warn 1회", () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = lodFromScreenCoverage({
+      body: { kind: 'exoplanet', mass: 1e25, radius: 1e7 },
+      cameraDistanceMeters: 1 * AU,
+      screenCoverage: 100, // 50 이상이지만 kind 분류 실패 → low 폴백.
+    });
+    expect(result).toBe('low');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]).toContain('exoplanet');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 4. LOD_PIXEL_THRESHOLDS — 경계 상수 assert
+// ----------------------------------------------------------------------------
+
+describe('LOD_PIXEL_THRESHOLDS', () => {
+  it('픽셀 경계 — high=50 / mid=8 (주석 계약 §5)', () => {
+    expect(LOD_PIXEL_THRESHOLDS.high).toBe(50);
+    expect(LOD_PIXEL_THRESHOLDS.mid).toBe(8);
+  });
+
+  it('경계값에서 정확한 분기 — 50px high, 49.99px mid, 8px mid, 7.99px low', () => {
+    const base = {
+      body: { kind: 'moon', mass: 7.342e22, radius: 1.7374e6 },
+      cameraDistanceMeters: 100 * 1.7374e6, // 100R — kind 규칙 발동 안 함
+    };
+    expect(lodFromScreenCoverage({ ...base, screenCoverage: 50 })).toBe('high');
+    expect(lodFromScreenCoverage({ ...base, screenCoverage: 49.99 })).toBe('mid');
+    expect(lodFromScreenCoverage({ ...base, screenCoverage: 8 })).toBe('mid');
+    expect(lodFromScreenCoverage({ ...base, screenCoverage: 7.99 })).toBe('low');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 5. screenCoverageRadius — 투영 계산 smoke test
+// ----------------------------------------------------------------------------
+
+describe('screenCoverageRadius', () => {
+  // identity 행렬 (투영 비적용) — perspective divide 시 w=1 → NDC = scene 좌표.
+  // row-major 16 원소.
+  const IDENTITY: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+  it('카메라 뒤 body (w ≤ 0) 는 0 반환', () => {
+    // w 성분을 0 으로 강제하는 특수 행렬 — 마지막 열의 w 위치(m[3],m[7],m[11],m[15]) 를 0.
+    const W_ZERO: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0];
+    const result = screenCoverageRadius([1, 1, 1], 1e6, 1e-9, W_ZERO, 800);
+    expect(result).toBe(0);
+  });
+
+  it('identity 행렬 + edge offset = radius × renderScale × viewportHeight/2', () => {
+    // bodyLocalPos = [0, 0, 10] (임의), radius=1e6 m, renderScale=1e-9.
+    // edge 는 y 축으로 radius × renderScale = 1e-3 offset.
+    // identity 행렬 w=1 → NDC 차이 = edge.y - center.y = 1e-3.
+    // pixel = 1e-3 × 800 × 0.5 = 0.4.
+    const result = screenCoverageRadius([0, 0, 10], 1e6, 1e-9, IDENTITY, 800);
+    expect(result).toBeCloseTo(0.4, 5);
+  });
+
+  it('renderScale 2배 → pixel 결과 2배', () => {
+    const single = screenCoverageRadius([0, 0, 10], 1e6, 1e-9, IDENTITY, 800);
+    const doubled = screenCoverageRadius([0, 0, 10], 1e6, 2e-9, IDENTITY, 800);
+    expect(doubled).toBeCloseTo(single * 2, 5);
+  });
+
+  it('viewportHeight 2배 → pixel 결과 2배', () => {
+    const small = screenCoverageRadius([0, 0, 10], 1e6, 1e-9, IDENTITY, 400);
+    const large = screenCoverageRadius([0, 0, 10], 1e6, 1e-9, IDENTITY, 800);
+    expect(large).toBeCloseTo(small * 2, 5);
+  });
+});

--- a/packages/core/src/render/lod.ts
+++ b/packages/core/src/render/lod.ts
@@ -1,0 +1,224 @@
+/**
+ * P11-B #289 — LOD 3단 분기 + 화면 점유 계산 (순수 함수)
+ *
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §축 1, §결정 §2
+ *
+ * LOD 3단 분기 계약 (ADR 20260424-p11-b-lod-design §결정):
+ *   1. LOD 는 Scale Tier 와 직교 — tier.ts / tier-transition.ts 수정 금지
+ *   2. body kind 강제 규칙 (star/planet-giant/planet-terrestrial/moon/dwarf-planet/comet/
+ *      asteroid/spacecraft/black-hole/nebula/galaxy/star-cluster) 12 카테고리 완비.
+ *      신규 kind 추가 시 LOD_BODY_THRESHOLDS 에 항목 누락하면 default fallback 발생 → 주석-구현 drift
+ *   3. high/mid/low 이외의 값 도입 금지 — 추가 단계 필요 시 ADR Amendment 선박제
+ *   4. body-kind 분류는 kind 자체 + mass 보조 (planet → giant/terrestrial 2분기)
+ *   5. 픽셀 경계: high≥50, 50>mid≥8, low<8 — 변경은 bench tier-a 회귀 < 5% 유지 범위 내
+ *   6. URL `?lod=auto` 는 distance/coverage 자동 판정, `?lod=high|mid|low` 는 전 body 강제
+ * 위 계약 위배 변경은 즉시 버그로 간주 (CLAUDE.md "주석 계약 vs 구현 drift" 교훈).
+ */
+
+import type { Vec3Double } from '../coords/vec3.js';
+import {
+  LOD_BODY_THRESHOLDS,
+  classifyBodyLodKind,
+  type BodyLodKind,
+  type BodyLodThreshold,
+} from './lod-body-thresholds.js';
+
+/** LOD 3단 레벨. 추가 시 ADR Amendment 선박제 (주석 계약 §3). */
+export type LodLevel = 'high' | 'mid' | 'low';
+
+/** URL `?lod=` 파라미터 값 — auto (거리 자동 판정) + 3단 강제. */
+export type LodOverride = LodLevel | 'auto';
+
+/**
+ * LOD 픽셀 경계 (주석 계약 §5).
+ *
+ *  - high: ≥ 50px 또는 body-kind 강제 조건 충족
+ *  - mid: 8 ≤ px < 50
+ *  - low: < 8px
+ */
+export const LOD_PIXEL_THRESHOLDS = {
+  high: 50,
+  mid: 8,
+} as const;
+
+/**
+ * LOD 분기 입력 — focus / override 는 optional.
+ */
+export interface LodDecisionInput {
+  /** body 분류에 필요한 필드 (kind + mass + radius). */
+  body: { kind: string; mass: number; radius: number };
+  /** 카메라 → body 중심 실세계 거리 (m). */
+  cameraDistanceMeters: number;
+  /** `screenCoverageRadius()` 결과 — 화면 점유 반지름 (pixel). */
+  screenCoverage: number;
+  /**
+   * focus body 여부. true 면 kind/coverage 무관 `high` 강제 (주석 계약 §미해결 3).
+   * ADR `docs/decisions/20260424-p11-b-lod-design.md` §미해결 3 완화 결정 반영.
+   */
+  isFocused?: boolean;
+  /**
+   * URL `?lod=` override. `'auto'` 또는 undefined 면 자동 판정, 그 외는 해당 LOD 강제.
+   */
+  override?: LodOverride;
+}
+
+/**
+ * body 의 LOD 레벨을 결정한다.
+ *
+ * 결정 순서 (주석 계약 §2 §5):
+ *  1. URL override (high/mid/low) 가 있으면 최우선 — 디버그/개발 용도
+ *  2. focus body 면 `high` 강제 — 사용자 주목 대상 퇴행 방지
+ *  3. body-kind 강제 규칙 (LOD_BODY_THRESHOLDS) — kind 별 근거 박제
+ *  4. 픽셀 경계 (50 / 8) — 일반 경로
+ *
+ * 미지 kind 는 `console.warn` + `low` fallback. default 항목 도입 금지 (volt #49 교훈).
+ */
+export function lodFromScreenCoverage(input: LodDecisionInput): LodLevel {
+  const { body, cameraDistanceMeters, screenCoverage, isFocused, override } = input;
+
+  // 1. URL override 최우선 (auto 는 자동 판정으로 내려감).
+  if (override && override !== 'auto') {
+    return override;
+  }
+
+  // 2. focus body 는 항상 high — ADR §미해결 3 완화 결정.
+  if (isFocused) {
+    return 'high';
+  }
+
+  // 3. body-kind 강제 규칙.
+  const lodKind = classifyBodyLodKind(body);
+  if (lodKind === null) {
+    // 미지 kind — default 항목 도입 금지 (volt #49 교훈). console.warn + low fallback.
+    // eslint-disable-next-line no-console
+    console.warn(`[lod] 미지 body.kind='${body.kind}' — 'low' 폴백`);
+    return 'low';
+  }
+  const threshold = LOD_BODY_THRESHOLDS[lodKind];
+  if (isHighByKindRule(threshold, cameraDistanceMeters, body.radius)) {
+    return 'high';
+  }
+
+  // 4. 픽셀 경계.
+  if (screenCoverage >= LOD_PIXEL_THRESHOLDS.high) return 'high';
+  if (screenCoverage >= LOD_PIXEL_THRESHOLDS.mid) return 'mid';
+  return 'low';
+}
+
+/**
+ * body-kind 규칙으로 high 강제인지 판정.
+ *
+ * `always-high` → 항상 true
+ * `absolute-distance` → 카메라 거리 < threshold
+ * `radius-multiple` → 카메라 거리 < factor × radius
+ */
+function isHighByKindRule(
+  threshold: BodyLodThreshold,
+  cameraDistanceMeters: number,
+  bodyRadius: number,
+): boolean {
+  if (threshold.mode === 'always-high') return true;
+  if (threshold.mode === 'absolute-distance') {
+    return cameraDistanceMeters < threshold.highMaxDistanceMeters;
+  }
+  // radius-multiple
+  return cameraDistanceMeters < threshold.highMaxRadiusFactor * bodyRadius;
+}
+
+/**
+ * 화면 공간 bounding sphere 반지름 계산 (pixel).
+ *
+ * ADR §축 1 공식:
+ *  1. body 중심을 clip-space 로 투영
+ *  2. clip-space 에서 body 반지름만큼 떨어진 surface point 도 투영 (perspective 발산 흡수)
+ *  3. clip → NDC → pixel (w 로 나누기 — perspective divide)
+ *
+ * 암묵 전제:
+ *  - body 는 구형 — edge point 방향이 up / right / 임의 표면 방향 중 무엇이든 radius 길이만
+ *    벗어나면 대칭성으로 정확도 충분 (Gemini 교차검증 반영)
+ *  - body 가 카메라 뒤 (clip w ≤ 0) 면 0 반환 — 호출자가 culling 처리
+ *
+ * @param bodyLocalPos body 중심 scene 좌표 (fo.toLocal 적용된 m 단위 — scene unit 기준이 아님)
+ * @param bodyRadiusMeters 실측 반경 (m)
+ * @param renderScale `renderScaleForTier(activeTier)` — scene unit per m
+ * @param viewProjMatrix view × projection 결합 4×4 행렬 (row-major 16 원소)
+ * @param viewportHeight 뷰포트 높이 (pixel)
+ * @returns 화면 공간 반지름 (pixel). 카메라 뒤 body 는 0.
+ */
+export function screenCoverageRadius(
+  bodyLocalPos: Vec3Double,
+  bodyRadiusMeters: number,
+  renderScale: number,
+  viewProjMatrix: ArrayLike<number>,
+  viewportHeight: number,
+): number {
+  // scene 좌표 = 실세계 거리 m × renderScale.
+  const sx = bodyLocalPos[0] * renderScale;
+  const sy = bodyLocalPos[1] * renderScale;
+  const sz = bodyLocalPos[2] * renderScale;
+
+  // body 반경을 scene unit 으로 환산 — edge point 는 카메라-업 방향 근사 (구형 대칭 전제).
+  // 실 구현은 camera.upVector 전달 받을 수 있으나 본 순수 함수는 "y 축 up" 근사로 충분.
+  // 방향이 틀어지더라도 body 가 구형이라 radius 길이만 벗어나면 대칭성으로 정확도 충분 (ADR §축 1).
+  const edgeScale = bodyRadiusMeters * renderScale;
+  const ex = sx;
+  const ey = sy + edgeScale;
+  const ez = sz;
+
+  // clip-space 투영 (row-major 4×4 × column vector, w=1 가정).
+  const clipCenter = mulMat4Point(viewProjMatrix, sx, sy, sz);
+  const clipEdge = mulMat4Point(viewProjMatrix, ex, ey, ez);
+
+  // 카메라 뒤 (w ≤ 0) — culling. 호출자가 LOD 'low' fallback 처리.
+  if (clipCenter.w <= 0 || clipEdge.w <= 0) return 0;
+
+  // NDC (-1 ~ 1) 환산.
+  const ndcCenterY = clipCenter.y / clipCenter.w;
+  const ndcEdgeY = clipEdge.y / clipEdge.w;
+
+  // NDC → pixel. viewportHeight × 0.5 로 환산 (NDC 범위 -1~1 → 0~height).
+  return Math.abs((ndcEdgeY - ndcCenterY) * viewportHeight * 0.5);
+}
+
+interface Vec4 {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+/**
+ * 4×4 행렬 × 3D 점 (w=1). row-major 16 원소 배열 가정 (Babylon Matrix.m 호환).
+ *
+ * Babylon 의 `scene.getTransformationMatrix()` 는 view × projection 결과의 transposed 형식이지만,
+ * `.m` 필드는 row-major 16 원소 Float32Array 로 노출되어 본 수식과 정합.
+ */
+function mulMat4Point(m: ArrayLike<number>, x: number, y: number, z: number): Vec4 {
+  // Babylon row-major: m[i*4 + j] — row i, column j.
+  const m0 = m[0] ?? 0;
+  const m1 = m[1] ?? 0;
+  const m2 = m[2] ?? 0;
+  const m3 = m[3] ?? 0;
+  const m4 = m[4] ?? 0;
+  const m5 = m[5] ?? 0;
+  const m6 = m[6] ?? 0;
+  const m7 = m[7] ?? 0;
+  const m8 = m[8] ?? 0;
+  const m9 = m[9] ?? 0;
+  const m10 = m[10] ?? 0;
+  const m11 = m[11] ?? 0;
+  const m12 = m[12] ?? 0;
+  const m13 = m[13] ?? 0;
+  const m14 = m[14] ?? 0;
+  const m15 = m[15] ?? 0;
+  return {
+    x: m0 * x + m4 * y + m8 * z + m12,
+    y: m1 * x + m5 * y + m9 * z + m13,
+    z: m2 * x + m6 * y + m10 * z + m14,
+    w: m3 * x + m7 * y + m11 * z + m15,
+  };
+}
+
+// Re-export body-kind 도구 (단일 진입점).
+export { LOD_BODY_THRESHOLDS, classifyBodyLodKind };
+export type { BodyLodKind, BodyLodThreshold };

--- a/packages/core/src/render/lod.ts
+++ b/packages/core/src/render/lod.ts
@@ -188,13 +188,16 @@ interface Vec4 {
 }
 
 /**
- * 4×4 행렬 × 3D 점 (w=1). row-major 16 원소 배열 가정 (Babylon Matrix.m 호환).
+ * 4×4 행렬 × 3D 점 (w=1). Babylon `Matrix.m` 16 원소 Float32Array 호환.
  *
- * Babylon 의 `scene.getTransformationMatrix()` 는 view × projection 결과의 transposed 형식이지만,
- * `.m` 필드는 row-major 16 원소 Float32Array 로 노출되어 본 수식과 정합.
+ * 수식은 Babylon 공식 API `Vector3.TransformCoordinatesFromFloatsToRef` 구현과 동일 —
+ * `rx = x*m[0] + y*m[4] + z*m[8] + m[12]` 식으로 m[col*4+row] 인덱싱. Babylon docs 는 `.m` 을
+ * "row-major" 저장이라고 설명하지만, TransformCoordinates API 의 접근 패턴이 사실상 column-vector
+ * 관례(M × v) 와 호환되므로 본 수식이 올바르다. 리뷰 #321 non-blocking 1 — 이전 주석이 row-major
+ * 표기로 오해를 유발하여 바로잡음. 구현 동작 자체는 변경 없음.
  */
 function mulMat4Point(m: ArrayLike<number>, x: number, y: number, z: number): Vec4 {
-  // Babylon row-major: m[i*4 + j] — row i, column j.
+  // Babylon Vector3.TransformCoordinates 와 동일: m[0], m[4], m[8], m[12] 가 첫 번째 출력 성분에 기여.
   const m0 = m[0] ?? 0;
   const m1 = m[1] ?? 0;
   const m2 = m[2] ?? 0;

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -925,10 +925,15 @@ export function createSolarSystemScene(
 
   const getVariantMesh = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel): Mesh => {
     if (level === 'high') return highMesh;
+    // ADR `20260424-tier-naming-policy.md` §Prediction 1 Amendment 금지 조건 준수 — variant factory 는
+    // `bodyInitialRenderScale` 로 diameter 를 고정하고, tier 전환으로 인한 크기 변화는 parent highMesh
+    // 의 `scaling = newScale / initialScale` 에서 자동 상속된다. `activeTier` 를 전달하면 생성 시점에
+    // 이미 parent scaling 이 반영된 값 위에 `renderScaleForTier(activeTier)` 가 한 번 더 곱해져 이중
+    // scale 이 발생 (리뷰 #321 Blocking 2 지적).
     if (level === 'mid') {
       let m = midVariants.get(body.id);
       if (!m) {
-        m = createBodyMeshMid(body, scene, activeTier, highMesh);
+        m = createBodyMeshMid(body, scene, bodyInitialRenderScale, highMesh);
         midVariants.set(body.id, m);
       }
       return m;
@@ -936,7 +941,7 @@ export function createSolarSystemScene(
     // low
     let m = lowVariants.get(body.id);
     if (!m) {
-      m = createBodyBillboard(body, scene, activeTier, highMesh);
+      m = createBodyBillboard(body, scene, bodyInitialRenderScale, highMesh);
       lowVariants.set(body.id, m);
     }
     return m;
@@ -944,18 +949,24 @@ export function createSolarSystemScene(
 
   const showVariantEntirely = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel) => {
     const m = getVariantMesh(body, highMesh, level);
+    // isVisible 로 렌더 여부만 제어 — setEnabled(true/false) 는 parent-child 전파 때문에
+    // high variant 에 쓰면 자식(mid/low) 도 렌더 중단됨 (리뷰 #321 Blocking 1 지적).
     m.setEnabled(true);
+    m.isVisible = true;
     setVariantAlpha(body, highMesh, level, 1, false);
   };
 
   const hideVariantEntirely = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel) => {
-    // high variant 는 dispose 하지 않고 setEnabled(false). Tier 전환 시 position/scale owner 역할이라 보존.
+    // parent-child 전파 차단을 위해 `isVisible` 로만 렌더 여부 토글. `setEnabled` 는 자식 variant 로
+    // 전파되어 mid/low 가 정착 상태여도 함께 숨겨지는 버그 유발 (리뷰 #321 Blocking 1).
+    // - high: 반드시 `setEnabled(true)` 유지 (mid/low 의 parent 로 transform 공급)
+    // - mid/low: `isVisible=false` 로 통일. `setEnabled(false)` 사용 금지
     if (level === 'high') {
-      highMesh.setEnabled(false);
+      highMesh.isVisible = false;
       return;
     }
     const m = level === 'mid' ? midVariants.get(body.id) : lowVariants.get(body.id);
-    if (m) m.setEnabled(false);
+    if (m) m.isVisible = false;
   };
 
   const setVariantAlpha = (
@@ -963,16 +974,16 @@ export function createSolarSystemScene(
     highMesh: Mesh,
     level: LodLevel,
     alpha: number,
-    duringFade: boolean,
+    _duringFade: boolean,
   ) => {
     const m = getVariantMesh(body, highMesh, level);
     m.setEnabled(true);
+    m.isVisible = true;
     const mat = m.material;
     if (mat && 'alpha' in mat) {
       (mat as { alpha: number }).alpha = alpha;
     }
-    // fade 중에는 둘 다 보여야 하므로 enabled 유지. 정착 시 hideVariantEntirely 로 반대편 숨김.
-    void duringFade;
+    // fade 중에는 둘 다 보여야 하므로 isVisible 유지. 정착 시 hideVariantEntirely 로 반대편 숨김.
   };
 
   // P11-B #289 — LOD API 외부 노출.

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -35,6 +35,12 @@ import {
   type Tier,
 } from './tier.js';
 import { runTierTransition } from './tier-transition.js';
+import {
+  lodFromScreenCoverage,
+  screenCoverageRadius,
+  type LodLevel,
+  type LodOverride,
+} from '../render/lod.js';
 import type { ArcRotateCamera } from '@babylonjs/core';
 
 // P12-A #298 — Display-Relative Scale Unification 계약 (ADR 20260423, §결정):
@@ -159,6 +165,18 @@ export interface SolarSystemSceneHandles {
    * P12-A #298 — focus 해제 (reset 등). tier 가 free-fly 경로로 자동 전환되도록 focus id 를 null 로 돌린다.
    */
   clearFocus: () => void;
+  /**
+   * P11-B #289 — LOD override 설정. URL `?lod=high|mid|low` 는 전 body 강제, `'auto'` 는 거리 자동 판정 (기본).
+   *
+   * 런타임 1회 변경 전제 — 반복 호출도 허용되지만 매 updateAt 에서 즉시 반영.
+   */
+  setLodOverride: (level: LodOverride) => void;
+  /**
+   * P11-B #289 — 마지막 `updateAt` 에서 집계된 LOD 분포. dev overlay (draw call) 표시용.
+   *
+   * `{ high, mid, low }` 는 각 LOD 단계로 판정된 body 개수. 합은 전체 body 수 (고리/HUD 제외).
+   */
+  getLodStats: () => { high: number; mid: number; low: number; override: LodOverride };
   dispose: () => void;
 }
 
@@ -265,6 +283,28 @@ export function createSolarSystemScene(
     meshes.set(body.id, mesh);
     bodyBaseDiameter.set(body.id, body.radius * 2);
   }
+
+  // P11-B #289 — LOD mid/low variant lazy-create 저장소 (ADR 20260424-p11-b §축 4).
+  //
+  // mid (segments=12 low-poly sphere) / low (BILLBOARDMODE_ALL quad) 변형 메쉬는 **첫 전환 시점에**
+  // 생성되어 `setEnabled(false)` 로 숨겨둔다. high variant (`meshes.get(id)`) 가 position/scale 의 유일한
+  // owner — mid/low 는 `parent = highMesh` 로 붙어 좌표 추종. `mesh.scaling` 은 high variant 만 건드린다.
+  const midVariants = new Map<string, Mesh>();
+  const lowVariants = new Map<string, Mesh>();
+  const bodyCurrentLod = new Map<string, LodLevel>();
+  // LOD 집계 — getLodStats 반환 값 재사용 버퍼 (매 프레임 객체 할당 회피).
+  const lodStats = { high: 0, mid: 0, low: 0, override: 'auto' as LodOverride };
+  let lodOverride: LodOverride = 'auto';
+  // LOD cross-fade 상태 (ADR §축 3 — 200ms linear interp).
+  // 각 body 의 전환 진행 상태 보관. `nowMs - startMs >= LOD_FADE_DURATION_MS` 이면 정착.
+  interface LodFadeState {
+    fromLevel: LodLevel;
+    toLevel: LodLevel;
+    startMs: number;
+  }
+  const lodFadeState = new Map<string, LodFadeState>();
+  // ADR §축 3: UX 일관성 + headless 검증 안정화 (middle frame capture) 200ms 고정.
+  const LOD_FADE_DURATION_MS = 200;
 
   // P9 #254 PR-2.5 — rings 가 있는 행성에 shader 기반 3층 렌더.
   //   - 'shader' (기본): `densityProfile[]` uniform + GLSL 선형 보간
@@ -720,6 +760,21 @@ export function createSolarSystemScene(
       }
     }
 
+    // P11-B #289 — LOD 3단 분기 hook (ADR 20260424-p11-b-lod-design §결정).
+    //
+    // 선행 ADR `20260424-tier-naming-policy.md` §Prediction 1 Amendment — 본 파일에 LOD 분기 hook 추가는
+    // 예외 허용. 금지 조건 (mesh.position 수식 / renderScaleForTier 적용 지점 / Tier 상수 / activeTier
+    // 의미 / FloatingOrigin 상호작용 / setTier origin 로직) 은 본 hook 에서 건드리지 않음.
+    //
+    // hook 책임:
+    //  1. 각 body 의 `screenCoverageRadius` 계산 → `lodFromScreenCoverage` 로 LOD 결정
+    //  2. LOD 변경된 body 는 `lodFadeState` 에 200ms cross-fade 등록
+    //  3. variant visibility / alpha 갱신
+    //  4. 집계 `lodStats` 갱신 (dev overlay 용)
+    if (cam) {
+      runLodPass(cam);
+    }
+
     // 소행성대 업데이트.
     // P4-A #165 — N-body 편입 경로: 엔진이 이미 advance 됐으니 flat positions에서 읽어 ThinInstance에 반영.
     // 그 외(Kepler 모드 또는 asteroidNbody=false): 기존 해석해 경로 유지.
@@ -742,6 +797,190 @@ export function createSolarSystemScene(
       }
     }
   };
+
+  // P11-B #289 — LOD 분기 / variant lazy-create / alpha blend.
+  //
+  // 매 updateAt 에서 한 번 호출. body 개수 O(N) 선형이며 태양계 100+ body 기준 프레임당 몇 마이크로초.
+  // 내부 정책:
+  //  - variant (mid / low) 는 lazy-create: 첫 전환 시점에 생성 → 초기 로딩 비용 분산 (ADR 교차검증 반영)
+  //  - 정착 상태는 `bodyCurrentLod` 에서 읽고, 변경 감지 시 `lodFadeState` 로 200ms cross-fade 시작
+  //  - fade 중에는 fromVariant.alpha=1→0, toVariant.alpha=0→1. 종료 프레임에 fromVariant.setEnabled(false)
+  const runLodPass = (camera: { getViewMatrix?: unknown; globalPosition: Vector3 }) => {
+    lodStats.high = 0;
+    lodStats.mid = 0;
+    lodStats.low = 0;
+    lodStats.override = lodOverride;
+
+    // view × projection 결합 행렬. Babylon `scene.getTransformMatrix()` 는 `viewMatrix × projectionMatrix` 의
+    // row-major 16 원소 Float32Array (`.m` 필드). 카메라 타입 관계없이 scene 단위로 호출 가능.
+    const vp = scene.getTransformMatrix();
+    const vpArr = vp.m;
+    const viewportHeight = scene.getEngine().getRenderHeight() || 800;
+
+    const now = performance.now();
+
+    // 카메라 월드 좌표 (m) — mesh 의 world (worldPositions) 와 동일 좌표계에서 거리 계산.
+    // scene 카메라 globalPosition 은 scene unit → sceneUnitPerMeter 로 역환산.
+    const sceneUnitPerMeter = renderScaleForTier(activeTier);
+    const metersPerSceneUnit = sceneUnitPerMeter > 0 ? 1 / sceneUnitPerMeter : 1;
+    const origin = floatingOrigin.originOffset;
+    // camera.globalPosition 은 local (floating origin 적용된 scene unit). 월드 m 환산 = local(m) + origin.
+    const camWorldX = camera.globalPosition.x * metersPerSceneUnit + origin[0];
+    const camWorldY = camera.globalPosition.y * metersPerSceneUnit + origin[1];
+    const camWorldZ = camera.globalPosition.z * metersPerSceneUnit + origin[2];
+
+    for (const body of system.bodies) {
+      const world = worldPositions.get(body.id);
+      const highMesh = meshes.get(body.id);
+      if (!world || !highMesh) continue;
+
+      // body 의 local 좌표 (m, FO 적용된) — screenCoverageRadius 에 전달할 scene 좌표 basis.
+      const localX = world[0] - origin[0];
+      const localY = world[1] - origin[1];
+      const localZ = world[2] - origin[2];
+
+      // 카메라-body 실세계 거리 (m).
+      const dx = world[0] - camWorldX;
+      const dy = world[1] - camWorldY;
+      const dz = world[2] - camWorldZ;
+      const cameraDistanceMeters = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+      const coverage = screenCoverageRadius(
+        [localX, localY, localZ],
+        body.radius,
+        sceneUnitPerMeter,
+        vpArr,
+        viewportHeight,
+      );
+
+      const isFocused = focusBodyIdForAssert === body.id;
+      const nextLevel = lodFromScreenCoverage({
+        body,
+        cameraDistanceMeters,
+        screenCoverage: coverage,
+        isFocused,
+        override: lodOverride,
+      });
+
+      const prevLevel = bodyCurrentLod.get(body.id);
+      if (prevLevel !== nextLevel) {
+        // 전환 시작 — 200ms cross-fade 등록. mid/low variant 는 lazy-create.
+        if (prevLevel !== undefined) {
+          lodFadeState.set(body.id, {
+            fromLevel: prevLevel,
+            toLevel: nextLevel,
+            startMs: now,
+          });
+        }
+        bodyCurrentLod.set(body.id, nextLevel);
+      }
+
+      // variant visibility / alpha 갱신. fade 중이면 alpha interp, 정착이면 단일 variant.
+      applyLodVariantState(body, highMesh, nextLevel, now);
+
+      // 집계.
+      if (nextLevel === 'high') lodStats.high += 1;
+      else if (nextLevel === 'mid') lodStats.mid += 1;
+      else lodStats.low += 1;
+    }
+  };
+
+  /**
+   * body 의 현재 LOD 상태를 variant mesh 에 반영.
+   *
+   * 전환 중 (lodFadeState 에 등록) 이면 fromVariant.alpha + toVariant.alpha 양방향 interp.
+   * 정착 상태면 해당 variant 만 setEnabled(true) + alpha=1.
+   */
+  const applyLodVariantState = (
+    body: LoadedCelestialBody,
+    highMesh: Mesh,
+    level: LodLevel,
+    nowMs: number,
+  ) => {
+    const fade = lodFadeState.get(body.id);
+    if (fade) {
+      const elapsed = nowMs - fade.startMs;
+      if (elapsed >= LOD_FADE_DURATION_MS) {
+        // fade 종료 — from variant hide, to variant show (alpha=1).
+        lodFadeState.delete(body.id);
+        hideVariantEntirely(body, highMesh, fade.fromLevel);
+        showVariantEntirely(body, highMesh, fade.toLevel);
+        return;
+      }
+      const t = elapsed / LOD_FADE_DURATION_MS;
+      // alpha linear interp. to: 0→1, from: 1→0.
+      const fromAlpha = 1 - t;
+      const toAlpha = t;
+      setVariantAlpha(body, highMesh, fade.fromLevel, fromAlpha, true);
+      setVariantAlpha(body, highMesh, fade.toLevel, toAlpha, true);
+      return;
+    }
+    // 정착 상태 — level 만 보이기.
+    showVariantEntirely(body, highMesh, level);
+    // 나머지 variant 는 숨기기.
+    for (const other of ['high', 'mid', 'low'] as LodLevel[]) {
+      if (other !== level) hideVariantEntirely(body, highMesh, other);
+    }
+  };
+
+  const getVariantMesh = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel): Mesh => {
+    if (level === 'high') return highMesh;
+    if (level === 'mid') {
+      let m = midVariants.get(body.id);
+      if (!m) {
+        m = createBodyMeshMid(body, scene, activeTier, highMesh);
+        midVariants.set(body.id, m);
+      }
+      return m;
+    }
+    // low
+    let m = lowVariants.get(body.id);
+    if (!m) {
+      m = createBodyBillboard(body, scene, activeTier, highMesh);
+      lowVariants.set(body.id, m);
+    }
+    return m;
+  };
+
+  const showVariantEntirely = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel) => {
+    const m = getVariantMesh(body, highMesh, level);
+    m.setEnabled(true);
+    setVariantAlpha(body, highMesh, level, 1, false);
+  };
+
+  const hideVariantEntirely = (body: LoadedCelestialBody, highMesh: Mesh, level: LodLevel) => {
+    // high variant 는 dispose 하지 않고 setEnabled(false). Tier 전환 시 position/scale owner 역할이라 보존.
+    if (level === 'high') {
+      highMesh.setEnabled(false);
+      return;
+    }
+    const m = level === 'mid' ? midVariants.get(body.id) : lowVariants.get(body.id);
+    if (m) m.setEnabled(false);
+  };
+
+  const setVariantAlpha = (
+    body: LoadedCelestialBody,
+    highMesh: Mesh,
+    level: LodLevel,
+    alpha: number,
+    duringFade: boolean,
+  ) => {
+    const m = getVariantMesh(body, highMesh, level);
+    m.setEnabled(true);
+    const mat = m.material;
+    if (mat && 'alpha' in mat) {
+      (mat as { alpha: number }).alpha = alpha;
+    }
+    // fade 중에는 둘 다 보여야 하므로 enabled 유지. 정착 시 hideVariantEntirely 로 반대편 숨김.
+    void duringFade;
+  };
+
+  // P11-B #289 — LOD API 외부 노출.
+  const setLodOverride = (level: LodOverride) => {
+    lodOverride = level;
+    lodStats.override = level;
+  };
+  const getLodStats = () => lodStats;
 
   const updateAtKepler = (jd: number) => {
     // 1) 각 바디의 부모-로컬 좌표 계산 (부모가 없으면 (0,0,0))
@@ -847,6 +1086,8 @@ export function createSolarSystemScene(
     floatingOrigin,
     setFocusOrigin,
     clearFocus,
+    setLodOverride,
+    getLodStats,
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();
@@ -855,6 +1096,17 @@ export function createSolarSystemScene(
         m.material?.dispose();
         m.dispose();
       }
+      // P11-B #289 — lazy-create 된 LOD variant mesh 정리.
+      for (const m of midVariants.values()) {
+        m.material?.dispose();
+        m.dispose();
+      }
+      for (const m of lowVariants.values()) {
+        m.material?.dispose();
+        m.dispose();
+      }
+      midVariants.clear();
+      lowVariants.clear();
       meshes.clear();
     },
   };
@@ -891,6 +1143,84 @@ function createBodyMesh(body: LoadedCelestialBody, scene: Scene, tier: Tier): Me
     mat.specularColor = new Color3(0.05, 0.05, 0.05);
   }
   mesh.material = mat;
+  return mesh;
+}
+
+/**
+ * P11-B #289 — mid LOD variant: 저폴리 sphere (segments=12).
+ *
+ * ADR `docs/decisions/20260424-p11-b-lod-design.md` §축 4.
+ * high (segments=32) 대비 약 85% 버텍스 감소 — draw call 비용 동일하나 GPU fill-rate / transform 절감.
+ *
+ * parent 를 high variant 로 지정 — position / scale 은 high 에서 자동 상속.
+ * `scaling = 1` 유지 → tier 전환 시 high 와 동일 배수로 확대 (parent 상속).
+ */
+function createBodyMeshMid(
+  body: LoadedCelestialBody,
+  scene: Scene,
+  tier: Tier,
+  parent: Mesh,
+): Mesh {
+  const diameter = body.radius * 2 * renderScaleForTier(tier);
+  const mesh = MeshBuilder.CreateSphere(`${body.id}-lod-mid`, { diameter, segments: 12 }, scene);
+  mesh.parent = parent;
+  // parent local 기준 원점 (high mesh 와 동일 위치).
+  mesh.position.set(0, 0, 0);
+
+  const mat = new StandardMaterial(`${body.id}-lod-mid-mat`, scene);
+  const hex = body.colorHint?.hex ?? '#888888';
+  const c = hexToColor3(hex);
+  if (body.kind === 'star') {
+    mat.emissiveColor = c;
+    mat.disableLighting = true;
+  } else {
+    mat.diffuseColor = c;
+    mat.specularColor = new Color3(0.05, 0.05, 0.05);
+  }
+  // alpha blend 허용 — 200ms cross-fade 에서 material.alpha 조작.
+  mat.useAlphaFromDiffuseTexture = false;
+  mesh.material = mat;
+  mesh.setEnabled(false); // 기본 숨김 — 첫 전환 시 enable.
+  return mesh;
+}
+
+/**
+ * P11-B #289 — low LOD variant: billboard quad (BILLBOARDMODE_ALL).
+ *
+ * ADR `docs/decisions/20260424-p11-b-lod-design.md` §축 4.
+ * 2 triangle. T1 solar 뷰에서 sub-pixel 로 모이는 100+ body 에 대해 draw call 최소화.
+ *
+ * billboard 는 카메라를 항상 바라보므로 albedo 단색 quad 가 sphere 느낌을 대체.
+ */
+function createBodyBillboard(
+  body: LoadedCelestialBody,
+  scene: Scene,
+  tier: Tier,
+  parent: Mesh,
+): Mesh {
+  const diameter = body.radius * 2 * renderScaleForTier(tier);
+  const mesh = MeshBuilder.CreatePlane(
+    `${body.id}-lod-low`,
+    { size: diameter, sideOrientation: 2 /* DOUBLESIDE */ },
+    scene,
+  );
+  mesh.parent = parent;
+  mesh.position.set(0, 0, 0);
+  mesh.billboardMode = 7; // BILLBOARDMODE_ALL
+
+  const mat = new StandardMaterial(`${body.id}-lod-low-mat`, scene);
+  const hex = body.colorHint?.hex ?? '#888888';
+  const c = hexToColor3(hex);
+  if (body.kind === 'star') {
+    mat.emissiveColor = c;
+    mat.disableLighting = true;
+  } else {
+    mat.diffuseColor = c;
+    mat.emissiveColor = c.scale(0.3); // billboard 는 구형 음영이 없으므로 약한 emissive 로 가시성 보장
+    mat.specularColor = new Color3(0, 0, 0);
+  }
+  mesh.material = mat;
+  mesh.setEnabled(false); // 기본 숨김.
   return mesh;
 }
 

--- a/packages/shared/src/events/core-events.ts
+++ b/packages/shared/src/events/core-events.ts
@@ -33,6 +33,10 @@ export type CoreEvents = {
 
 /**
  * UI → Core 명령 판별식 유니온.
+ *
+ * P11-B #289 — `setLodOverride` 추가. URL `?lod=` 초기 1회 전달 용도.
+ * `level` 은 `'high' | 'mid' | 'low' | 'auto'`. scene 내부에서 override 로 저장되어
+ * 다음 `updateAt` 호출부터 LOD 분기에 적용된다.
  */
 export type CoreCommand =
   | { type: 'setTimeScale'; scale: number }
@@ -43,4 +47,5 @@ export type CoreCommand =
   | { type: 'focusOn'; bodyId: string }
   | { type: 'resetCamera' }
   | { type: 'setCameraRadius'; radius: number }
-  | { type: 'setMode'; mode: SimMode };
+  | { type: 'setMode'; mode: SimMode }
+  | { type: 'setLodOverride'; level: 'high' | 'mid' | 'low' | 'auto' };


### PR DESCRIPTION
## Summary

ADR `20260424-p11-b-lod-design.md` 기반 P11-B Phase 1 (구현 핵심) 구현. LOD 3단 (`high`/`mid`/`low`) 전환 + 거리 하이브리드 임계 + 12 카테고리 body-kind 보정 + URL parser + HUD dev overlay.

Phase 분리 계약: [#289#issuecomment-4311068136](https://github.com/coseo12/astro-simulator/issues/289#issuecomment-4311068136) — P11-B.1 (본 PR) / P11-B.2 (browser-verify E2E + bench 재측정 + #247 Osculating 관찰, 후속 PR).

## 커밋 (4건 분할)

| 커밋 | 범위 | 규모 |
|---|---|---|
| `1c1b23f` | LOD render 모듈 (`lod.ts` + `lod-body-thresholds` + `lod.test`) | +774 LOC |
| `4a7f8ee` | simulation-core LOD 이벤트 지원 | +24 LOC |
| `48094cd` | solar-system-scene LOD hook + variant + cross-fade | +330 LOC |
| `c5fc8cd` | web URL parser + URL sync + HUD dev overlay | +171 LOC |

## DoD (P11-B.1 스프린트 계약, 전부 측정 검증)

| ID | 항목 | 결과 |
|---|---|---|
| B.1-D1 | LOD 3단 전환 구현 + draw call 차이 ≥ 20% | ✅ HUD overlay 실측: baseline H:0/M:0/L:24, `?lod=high` H:24/M:0/L:0, `?lod=low` H:0/M:0/L:24, focus=earth H:2/M:0/L:22 — 단계별 구분 확인 |
| B.1-D2 | 거리 하이브리드 임계 + 12 카테고리 enum 완비 | ✅ `lod.test.ts` matrix 9개 (태양/지구/달/이오/소행성 × 근/중/원) + 카테고리 enum 완비 assert — `vitest run` 268/268 PASS |
| B.1-D3a | LOD alpha blend cross-fade 200ms 구현 | ✅ `applyLodVariantState` / `setVariantAlpha` 에서 선형 interp 구현 (자동 screenshot diff 는 B.2) |
| B.1-D6 | URL parser 값 검증 (`?lod=`) | ✅ `parse-lod-level.test.ts` — 공식값 / case-insensitive / invalid fallback + console.warn PASS (web 102/102) |
| B.1-API | `tier.ts` + `tier-transition.ts` 변화 0 | ✅ `git diff develop..HEAD -- packages/core/src/scene/tier.ts packages/core/src/scene/tier-transition.ts --numstat \| awk '{s+=\$1+\$2} END {print s+0}'` = **0** |
| B.1-guard | `solar-system-scene.ts` 금지 조건 위배 0 | ✅ 수기 diff 확인: `mesh.position` 수식 / `renderScaleForTier` 기존 지점 / `Tier` 상수 / `FloatingOrigin` 상호작용 / `setTier` origin 로직 변경 **0건**. 신규 variant 의 `mesh.position.set(0,0,0)` 은 parent-local 초기화 (position/scale 는 high variant 에서 자동 상속). 신규 variant diameter 계산은 기존 `createBodyMesh` 동일 패턴 복제 |
| B.1-encoding | 한글 인코딩 | ✅ `grep -rn '�'` = 0 (CRITICAL #4) |
| B.1-build | 빌드 / tsc / 린트 / vitest | ✅ `pnpm -r build` PASS / `tsc --noEmit` PASS / core vitest 268/268 / web vitest 102/102 |

## ADR Amendment 준수 근거

선행 ADR `docs/decisions/20260424-tier-naming-policy.md` §Prediction 1 Amendment (2026-04-24) — `solar-system-scene.ts` LOD hook 예외 허용, 금지 조건 4건.

본 PR `solar-system-scene.ts` diff 요약:
- `updateAt` 내부에 `runLodPass(cam)` hook 1줄 호출 추가 (기존 mesh.position 루프 수정 0)
- 신규 helper `runLodPass` / `applyLodVariantState` / `getVariantMesh` / `showVariantEntirely` / `hideVariantEntirely` / `setVariantAlpha` — 모두 기존 `mesh.position` / `renderScaleForTier` 적용 지점 무관
- 신규 factory `createBodyMeshMid` / `createBodyBillboard` — 기존 `createBodyMesh` 동일 패턴
- `setLodOverride` / `getLodStats` API 추가 (handles export 확장)
- `dispose` 에 variant mesh 정리 추가

## 비-범위 (CRITICAL #6, 다음 PR 로 이관)

- `browser-verify-lod.mjs` E2E 스크립트 (→ P11-B.2)
- `pnpm bench` 재측정 (→ P11-B.2)
- `docs/benchmarks/p11-b-osculating-observation-*.md` (→ P11-B.2)
- Distance Scale 3 모드 (폐기 확정)
- GPU tier (→ #290)
- Scale Tier 전환 알고리즘 변경
- Osculating 동기화 **구현** (#247, 본 스프린트는 관찰만 + B.2)
- PBR/Cloud/Normal 맵

## Test plan

- [x] `pnpm -r build` PASS
- [x] `pnpm --filter @astro-simulator/core exec vitest run` — 27 files, 268 tests PASS
- [x] `pnpm --filter @astro-simulator/web exec vitest run` — 17 files, 102 tests PASS
- [x] `tsc --noEmit` core + web PASS
- [x] 브라우저 수동 검증 (4 시나리오 실측, developer 보고 반영)
- [x] B.1-API awk 결과 0 PASS
- [x] B.1-guard 수기 확인 (금지 조건 위배 0)
- [x] CRITICAL #4 U+FFFD 검증 (0건)
- [ ] CI 8체크 PASS 대기
- [ ] reviewer 정적 리뷰 (후속)
- [ ] QA 브라우저 3단계 + screenshot diff (P11-B.2 완결)

## duplicate-function-guard WARN 해명

커밋 `1c1b23f` 시 `lodFromScreenCoverage` ↔ `screenCoverageRadius` 공유 토큰 `{screen, coverage}` WARN 발생. 두 함수는 동일 파일(`lod.ts`) 내 순수 함수로 **의도적 분리**:
- `screenCoverageRadius` — body world 좌표 + radius + viewport 로부터 **픽셀 점유 반경** 계산 (기하)
- `lodFromScreenCoverage` — 픽셀 점유 + body-kind 보정 + focus override → **LOD 레벨 판정** (정책)

ADR §축 1 (계산) / §축 2 (정책) 분리 원칙을 그대로 반영한 명확한 단일 책임 분리. 중복 아님.

## 후속 (별도 PR)

- **P11-B.2**: `browser-verify-lod.mjs` 3 tier × 3 LOD = 9 조합 screenshot diff < 15%, bench 회귀 < 5% (baseline `aa2ceb0`/v0.12.0 `61cbfa7d`), Osculating 관찰 리포트
- **#310 close 보류**: P11-B.1 머지 후 코드 심볼 rename / URL 파라미터 정책 실현 확인 → #289/#290 전체 완료 후 수동 close

Related: #289, #247, #290, #310