### PR TITLE
chore(scripts): [#290] P11-C QA 진단 스크립트 박제 + 임시 벤치 폐기

### DIFF
--- a/apps/web/scripts/p290-diag-visibility.mjs
+++ b/apps/web/scripts/p290-diag-visibility.mjs
@@ -1,0 +1,57 @@
+// 행성 가시성 진단 — 관찰/연구 모드 + 기본 focus 상태 + mesh 수 + tier 상태 + 콘솔 로그
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:3000';
+const mkdir = (await import('fs')).mkdirSync;
+const path = (await import('path')).default;
+const OUT = '/tmp/p290-diag';
+try {
+  mkdir(OUT, { recursive: true });
+} catch {}
+
+const browser = await chromium.launch({ headless: false, channel: 'chrome' });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await ctx.newPage();
+
+const logs = [];
+page.on('console', (m) => logs.push({ type: m.type(), text: m.text() }));
+page.on('pageerror', (e) => logs.push({ type: 'pageerror', text: String(e.message) }));
+
+const scenarios = [
+  { name: 'default', url: BASE + '/' },
+  { name: 'observe', url: BASE + '/?mode=observe' },
+  { name: 'research', url: BASE + '/?mode=research' },
+  { name: 'focus-earth', url: BASE + '/?focus=earth' },
+  { name: 'focus-jupiter', url: BASE + '/?focus=jupiter' },
+  { name: 'focus-mars', url: BASE + '/?focus=mars' },
+];
+
+for (const s of scenarios) {
+  logs.length = 0;
+  await page.goto(s.url, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForTimeout(1500);
+  const state = await page.evaluate(() => {
+    const w = window;
+    const store = w.__simStore?.getState?.();
+    const canvas = document.querySelector('canvas');
+    return {
+      gpuTier: w.__gpuTier,
+      activeTier: store?.activeTier,
+      focusBodyId: store?.focusBodyId,
+      mode: store?.mode,
+      lodStats: store?.lodStats ?? w.__lodStats ?? null,
+      scene: w.__sceneDebug?.() ?? null,
+      canvasSize: canvas ? { w: canvas.clientWidth, h: canvas.clientHeight } : null,
+    };
+  });
+  await page.screenshot({ path: path.join(OUT, `${s.name}.png`), fullPage: false });
+  const errs = logs.filter((l) => l.type === 'error' || l.type === 'pageerror');
+  const warns = logs.filter((l) => l.type === 'warning');
+  console.log(`\n=== ${s.name} (${s.url}) ===`);
+  console.log('  state:', JSON.stringify(state, null, 2));
+  console.log(`  errors: ${errs.length}`);
+  errs.slice(0, 5).forEach((e) => console.log(`    - [${e.type}] ${e.text}`));
+  console.log(`  warnings: ${warns.length}`);
+  warns.slice(0, 5).forEach((w) => console.log(`    - ${w.text}`));
+}
+
+await browser.close();

--- a/apps/web/scripts/p290-qa-console-errs.mjs
+++ b/apps/web/scripts/p290-qa-console-errs.mjs
@@ -1,0 +1,21 @@
+// L1 console error 내용 캡처
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:3000';
+(async () => {
+  const browser = await chromium.launch({ headless: false, channel: 'chrome' });
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  const errs = [];
+  const warns = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error') errs.push({ text: m.text(), loc: m.location() });
+    if (m.type() === 'warning') warns.push(m.text());
+  });
+  await page.goto(BASE + '/', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForFunction(() => typeof window.__gpuTier !== 'undefined', { timeout: 10000 });
+  console.log('errors:');
+  for (const e of errs) console.log('  -', e.text, '@', JSON.stringify(e.loc));
+  console.log('warnings(first 10):');
+  for (const w of warns.slice(0, 10)) console.log('  -', w);
+  await browser.close();
+})();

--- a/apps/web/scripts/p290-qa-idle-fps.mjs
+++ b/apps/web/scripts/p290-qa-idle-fps.mjs
@@ -1,0 +1,33 @@
+// tier-c idle fps 실 Chrome (headed) 측정 — D5 재검증
+import { chromium } from 'playwright';
+const BASE = 'http://localhost:3000';
+(async () => {
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: false, channel: 'chrome' });
+  } catch {
+    browser = await chromium.launch({ headless: false });
+  }
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  await page.goto(BASE + '/?gpu=c', { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForFunction(
+    () => typeof window.__gpuTier !== 'undefined' && typeof window.__simStore !== 'undefined',
+    { timeout: 10000 },
+  );
+  const samples = [];
+  for (let i = 0; i < 10; i++) {
+    await page.waitForTimeout(1000);
+    const fps = await page.evaluate(() => window.__simStore?.getState()?.fps);
+    if (typeof fps === 'number') samples.push(fps);
+  }
+  const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+  const min = Math.min(...samples);
+  const tier = await page.evaluate(() => window.__gpuTier);
+  const forceLod = await page.evaluate(() => window.__gpuTierForceLod);
+  console.log(`tier=${tier} forceLod=${forceLod}`);
+  console.log(`samples=${samples.map((v) => v.toFixed(1)).join(',')}`);
+  console.log(`avg=${avg.toFixed(2)} min=${min.toFixed(2)}`);
+  console.log(`DoD #5 (≥30) = ${min >= 30 ? 'PASS' : 'FAIL'}`);
+  await browser.close();
+})();

--- a/apps/web/scripts/p290-qa-real-chrome.mjs
+++ b/apps/web/scripts/p290-qa-real-chrome.mjs
@@ -1,0 +1,140 @@
+// P11-C #290 QA — 실 Chrome(headed) 3단계 검증 + 추가 케이스 (A 대문자, ?focus 조합)
+// volt #33 방어: headless software WebGPU false positive 회피
+
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE_URL ?? 'http://localhost:3000';
+const SCR = '/tmp/p327-screenshots';
+
+async function launchHeaded() {
+  // 실제 Chrome channel 사용 (system Chrome). 없으면 Chromium 대체.
+  try {
+    return await chromium.launch({ headless: false, channel: 'chrome' });
+  } catch {
+    return await chromium.launch({ headless: false });
+  }
+}
+
+async function readEngineState(page) {
+  return await page.evaluate(() => ({
+    tier: window.__gpuTier,
+    forceLod: window.__gpuTierForceLod ?? null,
+    notice: window.__simStore?.getState()?.engineNotice ?? null,
+  }));
+}
+
+async function visit(browser, url, label, { captureConsole = true } = {}) {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  const errs = [];
+  const warns = [];
+  if (captureConsole) {
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(m.text());
+      if (m.type() === 'warning') warns.push(m.text());
+    });
+  }
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 });
+  await page.waitForFunction(() => typeof window.__gpuTier !== 'undefined', { timeout: 10_000 });
+  const state = await readEngineState(page);
+  await page.screenshot({ path: `${SCR}/${label}.png`, fullPage: false });
+  return { page, ctx, state, errs, warns };
+}
+
+async function main() {
+  const browser = await launchHeaded();
+  const report = {};
+  try {
+    // Level 1 — auto detect
+    {
+      const r = await visit(browser, `${BASE}/`, 'L1-auto');
+      report.L1 = { ...r.state, consoleErrors: r.errs.length };
+      console.log(`[L1] auto → tier=${r.state.tier} errors=${r.errs.length}`);
+      await r.ctx.close();
+    }
+
+    // Level 2 — URL overrides (a, b, c, A 대문자, invalid)
+    report.L2 = {};
+    for (const q of ['a', 'b', 'c', 'A', 'invalid']) {
+      const r = await visit(browser, `${BASE}/?gpu=${q}`, `L2-gpu-${q}`);
+      const warnMatched = r.warns.filter((w) => w.includes('parse-gpu-tier'));
+      report.L2[q] = {
+        tier: r.state.tier,
+        forceLod: r.state.forceLod,
+        notice: r.state.notice,
+        errs: r.errs.length,
+        warns: warnMatched,
+      };
+      console.log(
+        `[L2] ?gpu=${q} → tier=${r.state.tier} forceLod=${r.state.forceLod ?? '(none)'} warn=${warnMatched.length}`,
+      );
+      await r.ctx.close();
+    }
+
+    // Level 3 — URL 조합: ?gpu=c&focus=earth (도메인 흐름)
+    {
+      const r = await visit(browser, `${BASE}/?gpu=c&focus=earth`, 'L3-gpu-c-focus-earth');
+      report.L3 = { ...r.state, consoleErrors: r.errs.length };
+      console.log(`[L3] gpu=c&focus=earth → tier=${r.state.tier} errors=${r.errs.length}`);
+      await r.ctx.close();
+    }
+
+    // Level 3b — ?gpu=b 에서 tier-c 강제 LOD 없음 확인
+    {
+      const r = await visit(browser, `${BASE}/?gpu=b`, 'L3b-gpu-b-no-forceLod');
+      report.L3b = { ...r.state };
+      console.log(`[L3b] gpu=b forceLod=${r.state.forceLod ?? '(none)'} (기대: none)`);
+      await r.ctx.close();
+    }
+
+    // Promise race 재현 시도 — tier-c 로 진입 후 HMR-like 네비게이션 반복
+    {
+      const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+      const page = await ctx.newPage();
+      const errs = [];
+      page.on('console', (m) => {
+        if (m.type() === 'error') errs.push(m.text());
+      });
+      let consistent = true;
+      for (let i = 0; i < 5; i++) {
+        await page.goto(`${BASE}/?gpu=c&t=${i}`, { waitUntil: 'networkidle', timeout: 30_000 });
+        await page.waitForFunction(() => typeof window.__gpuTier !== 'undefined', {
+          timeout: 10_000,
+        });
+        const s = await readEngineState(page);
+        console.log(
+          `  [race-${i}] tier=${s.tier} forceLod=${s.forceLod ?? '(none)'} notice=${s.notice?.key ?? '(none)'}`,
+        );
+        if (s.tier !== 'c' || s.forceLod !== 'low') consistent = false;
+      }
+      report.raceReproduction = { attempts: 5, consistent, errors: errs.length };
+      await ctx.close();
+    }
+
+    // Level 3c — ?gpu=c 진입 후 scene 렌더 확인 (canvas 존재)
+    {
+      const r = await visit(browser, `${BASE}/?gpu=c`, 'L3c-gpu-c-canvas');
+      const hasCanvas = await r.page.evaluate(() => !!document.querySelector('canvas'));
+      const pixelCheck = await r.page.evaluate(() => {
+        const c = document.querySelector('canvas');
+        if (!c) return null;
+        return { width: c.width, height: c.height };
+      });
+      report.L3c = { ...r.state, hasCanvas, pixelCheck, errs: r.errs.length };
+      console.log(
+        `[L3c] canvas=${hasCanvas} size=${pixelCheck?.width}x${pixelCheck?.height} errors=${r.errs.length}`,
+      );
+      await r.ctx.close();
+    }
+
+    console.log('\n=== JSON ===');
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- P11-C #290 / #327 작업 중 추가한 진단·QA 스크립트 4개를 회귀 가드용으로 정식 추적
- 이미 추적 중인 \`p290-browser-verify.mjs\` 와 동일 패턴 — working tree 잔여 정리
- phase 라벨 없는 임시 벤치 산출물 \`docs/benchmarks/2026-04-24T08-*.json\` 3개 폐기 (untracked → 삭제)

## 추가되는 스크립트

| 파일 | 용도 |
|---|---|
| \`p290-diag-visibility.mjs\` | 행성 가시성 진단 (관찰/연구 모드 + tier + 콘솔 로그) — R1 (#329) 태양 가시성 진단에도 재활용 가능 |
| \`p290-qa-console-errs.mjs\` | 콘솔 에러 캡처 (범용) |
| \`p290-qa-idle-fps.mjs\` | tier-c idle fps 회귀 가드 (P11-C DoD #5 ≥30) |
| \`p290-qa-real-chrome.mjs\` | 실 Chrome 3단계 검증 (volt #33 headless software WebGPU false positive 방어) |

## 폐기되는 산출물

\`docs/benchmarks/2026-04-24T08-{07-48-309Z, 08-13-897Z, 08-39-518Z}.json\` 3개:
- 모두 \`"phase": "unlabeled"\` — 의미 박제 안 된 로컬 임시 측정
- 정식 측정은 phase 라벨 박제하여 별도 PR 로 커밋하는 정책

## 검증

- [x] 빌드 영향 없음 (스크립트는 빌드 entry 미포함, dev/test 와 무관)
- [x] U+FFFD 검증 통과 (CRITICAL #4)
- [x] base=develop (CRITICAL #1)
- [x] working tree clean (untracked 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)