### PR TITLE
[#334+#335] R1 store-scene 동기화 단일 경로 통합 — setCameraHandlers 폐기 + setCameraRadiusHandler 도입

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ PR [#332](https://github.com/coseo12/astro-simulator/pull/332) (`6e7382e`) — �
 - PR [#339](https://github.com/coseo12/astro-simulator/pull/339): PATCH (ADR amendment, 문서 보강만)
 - PR [#340](https://github.com/coseo12/astro-simulator/pull/340): PATCH (CHANGELOG 소급 박제, 문서 보강만)
 - PR [#342](https://github.com/coseo12/astro-simulator/pull/342) (#333 Phase 2): **MINOR** (billboard `bodyScale` 분리 — 시각 행동 변화 + drift 방어 단위 테스트 9 케이스)
-- PR [#346](https://github.com/coseo12/astro-simulator/pull/346) (#334 + #335): **MINOR** (`setCameraHandlers` → `setCameraRadiusHandler` 내부 API 리네이밍 + 시그니처 단순화 + 행동 변화 — 이중 호출 1회로 단일화)
+- PR [#344](https://github.com/coseo12/astro-simulator/pull/344) (#334 + #335): **MINOR** (`setCameraHandlers` → `setCameraRadiusHandler` 내부 API 리네이밍 + 시그니처 단순화 + 행동 변화 — 이중 호출 1회로 단일화)
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Semantic Versioning을 따른다.
 ### Fix
 
 - **billboard variant `bodyScale` 분리** ([#333](https://github.com/coseo12/astro-simulator/issues/333), Phase 2) — `createBodyBillboard` 의 `diameter` 식에서 `bodyScale` 곱셈 제거. sphere/mid variant 는 그대로 유지 (시각 과장 책임 단독). billboard 는 sub-pixel draw call 절감 책임 단독 — 책임 직교화. focus 강제 해제 + 1 AU+ 카메라 거리 + 픽셀 경계 부족 edge case 에서 거대 quad 회귀 차단 (PR [#332](https://github.com/coseo12/astro-simulator/pull/332) 검증 중 발견된 시각 회귀의 근본 해결). ADR `20260425-r1-sun-visualization.md` §"Phase 2 결정 (#333)" amendment 참조. 신규 단위 테스트 (`packages/core/src/scene/body-scale-variants.test.ts`, 9 케이스) drift 방어
+- **store-scene 동기화 단일 경로 통합** ([#334](https://github.com/coseo12/astro-simulator/issues/334) + [#335](https://github.com/coseo12/astro-simulator/issues/335)) — `SimulationCore.setCameraHandlers(focus, reset, setRadius)` → `setCameraRadiusHandler(setRadius)` 단일 인자로 단순화 + 리네이밍. focus / resetCamera 콜백 폐기 → `useSimStore.subscribe(selectedBodyId)` 분기가 scene focus / 카메라 reset 단일 책임. `syncFocusToScene(bodyId)` helper 추출 (마운트 직후 1회 sync 와 subscribe 분기 식 공유, DRY). `case 'focusOn'` / `case 'resetCamera'` 의 `bodySelected` event emit 은 보존 — store sync 경로 (core-adapter → setSelectedBody) 의존. **이중 호출 해소**: 클릭 시 `controller.focusOn` 1회만 호출 (이전 2회). `setSelectedBody(null)` 시 `controller.reset` 1회 (이전 2회 또는 미래 info-panel close 누락 가능성). PR #332 Phase 1 fix `acfcb74` 의 임시 해결책 (subscribe + setCameraHandlers 이중 경로) 을 정식 통합으로 대체. ADR `20260425-r1-store-scene-sync-unification.md` §결정 1~6. 회귀 가드: `simulation-core-camera-sync.test.ts` 6 케이스 (이벤트 emit / 핸들러 호출 횟수 / `setCameraHandlers` 부활 방지)
 
 ### Chore
 
@@ -54,6 +55,7 @@ PR [#332](https://github.com/coseo12/astro-simulator/pull/332) (`6e7382e`) — �
 - PR [#339](https://github.com/coseo12/astro-simulator/pull/339): PATCH (ADR amendment, 문서 보강만)
 - PR [#340](https://github.com/coseo12/astro-simulator/pull/340): PATCH (CHANGELOG 소급 박제, 문서 보강만)
 - PR [#342](https://github.com/coseo12/astro-simulator/pull/342) (#333 Phase 2): **MINOR** (billboard `bodyScale` 분리 — 시각 행동 변화 + drift 방어 단위 테스트 9 케이스)
+- PR [#346](https://github.com/coseo12/astro-simulator/pull/346) (#334 + #335): **MINOR** (`setCameraHandlers` → `setCameraRadiusHandler` 내부 API 리네이밍 + 시그니처 단순화 + 행동 변화 — 이중 호출 1회로 단일화)
 
 ### Notes
 

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -334,8 +334,35 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           }
         }
 
+        // R1 #334+#335 — store-scene 동기화 단일 경로 helper.
+        //
+        // ADR `20260425-r1-store-scene-sync-unification.md` §결정 4.
+        // 마운트 직후 1회 sync 와 subscribe 분기가 동일 식 사용 → DRY (`syncFocusToScene` 1곳 수정으로
+        // 두 진입점 일관 변경). 신규 진입점 추가 시 (예: 모바일 swipe gesture) 도 본 helper 재사용.
+        //
+        // 의도:
+        //  - id !== null  → solar.setFocusOrigin(id) + controller.focusOn(mesh) (mesh 존재 시)
+        //  - id === null  → solar.clearFocus() + controller.reset(35)
+        //                   ("focus 해제 = 카메라 reset" 박제 — ADR §결정 3).
+        const syncFocusToScene = (bodyId: string | null) => {
+          if (bodyId !== null) {
+            const mesh = solar.meshes.get(bodyId);
+            if (mesh) {
+              // P11-A #288 — Floating Origin primary shift (ADR §1-B).
+              // focus 전환과 **동일 프레임** 에 origin 을 해당 body 월드 좌표로 이동.
+              solar.setFocusOrigin(bodyId);
+              controller.focusOn({ mesh });
+            }
+          } else {
+            // P12-A #298 — focus 해제 → tier 는 free-fly 경로로 판정.
+            solar.clearFocus();
+            controller.reset(35);
+          }
+        };
+
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)
         // + 질량 배수 변경 → setBodyMassMultiplier (#107)
+        // + selectedBodyId 변경 → syncFocusToScene (R1 #334+#335 — scene focus / camera 단일 책임)
         // (P12-C #298 — viewMode 구독 삭제: 단일 모드 전환)
         unsubEngine = useSimStore.subscribe((state, prev) => {
           if (state.physicsEngine !== prev.physicsEngine) {
@@ -352,59 +379,33 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
               if (prev.massMultipliers[k] !== v) solar.setBodyMassMultiplier(k, v);
             }
           }
-          // R1 #329 — selectedBodyId ↔ scene focus 동기화.
-          // url-sync.tsx 의 setSelectedBody(URL `?focus=`) 만으로는 scene 의 setFocusOrigin
-          // 호출이 누락되어 lodFromScreenCoverage 의 isFocused 분기가 false 가 되고,
-          // 1 AU 이상 거리에서 star kind 가 픽셀 경계로 떨어지면서 low billboard 거대 quad
-          // 회귀가 발생했음 (PR #332 검증 중 발견). 클릭 핸들러와 동일 경로로 sync.
+          // R1 #334+#335 — selectedBodyId ↔ scene focus 동기화 (단일 진실원).
+          //
+          // 클릭 / URL / programmatic 진입 모두 동일 흐름:
+          //   sendCommand({ type: 'focusOn' | 'resetCamera' })
+          //     → simulation-core 가 'bodySelected' event emit
+          //     → core-adapter 가 store.setSelectedBody(id) 호출
+          //     → 본 subscribe 가 변화 감지 → syncFocusToScene(id) 호출 (단일 호출).
+          //
+          // 이전 (Phase 1 fix `acfcb74`): subscribe 분기 + setCameraHandlers focus/reset 콜백 이중 경로.
+          // 이중 호출로 `controller.focusOn` 의 `Animation.CreateAndStartAnimation × 2` 가 2회 폐기 + 재시작.
           if (state.selectedBodyId !== prev.selectedBodyId) {
-            if (state.selectedBodyId) {
-              const mesh = solar.meshes.get(state.selectedBodyId);
-              if (mesh) {
-                solar.setFocusOrigin(state.selectedBodyId);
-                controller.focusOn({ mesh });
-              }
-            } else {
-              solar.clearFocus();
-              controller.reset(35);
-            }
+            syncFocusToScene(state.selectedBodyId);
           }
         });
-        instance.setCameraHandlers(
-          (bodyId: string) => {
-            const mesh = solar.meshes.get(bodyId);
-            if (mesh) {
-              // P11-A #288 — Floating Origin primary shift (ADR §1-B).
-              // focus 전환과 **동일 프레임** 에 origin 을 해당 body 월드 좌표로 이동.
-              // 이후 `updateAt` 이 body 를 scene 원점 근처에서 렌더 → float32 jitter 제거.
-              solar.setFocusOrigin(bodyId);
-              controller.focusOn({ mesh });
-            }
-          },
-          () => {
-            // P12-A #298 — reset 시 focus 해제 → tier 는 free-fly 경로로 판정.
-            solar.clearFocus();
-            controller.reset(35);
-          },
-          (radius: number) => {
-            camera.radius = radius;
-          },
-        );
+        // R1 #334+#335 — `setCameraRadiusHandler` 단일 인자 (focus/reset 콜백 폐기 — ADR §결정 2).
+        instance.setCameraRadiusHandler((radius: number) => {
+          camera.radius = radius;
+        });
 
-        // R1 #329 — 마운트 직후 selectedBodyId 가 이미 있으면 1회 초기 sync.
-        // URL `?focus=sun` 으로 진입하는 케이스: url-sync.tsx 의 useEffect 가 setSelectedBody
-        // 를 먼저 호출하더라도 위 subscribe 는 sim-canvas 마운트 후의 변화만 잡으므로,
-        // 마운트 시점 store snapshot 을 명시적으로 1회 적용해야 첫 프레임부터 high LOD 진입.
-        {
-          const initialSelected = useSimStore.getState().selectedBodyId;
-          if (initialSelected) {
-            const mesh = solar.meshes.get(initialSelected);
-            if (mesh) {
-              solar.setFocusOrigin(initialSelected);
-              controller.focusOn({ mesh });
-            }
-          }
-        }
+        // R1 #334+#335 — 마운트 직후 selectedBodyId 가 이미 있으면 helper 로 1회 초기 sync.
+        //
+        // URL `?focus=sun` 진입 케이스: url-sync.tsx 의 useEffect 가 sendCommand({ type:'focusOn' }) +
+        // setSelectedBody(urlFocus) 호출하지만, sim-canvas 마운트 시점에는 두 호출 모두 이미 끝나
+        // store snapshot 에 selectedBodyId 가 박혀있다. 위 subscribe 는 마운트 후의 변화만 감지하므로
+        // 마운트 직후 명시적 1회 sync 로 첫 프레임부터 high LOD 진입.
+        // ADR `20260425-r1-store-scene-sync-unification.md` §축 3 후보 B.
+        syncFocusToScene(useSimStore.getState().selectedBodyId);
 
         // P12-A #298 — Tier 하이브리드 트리거 자동 판정 (Q7=7-d2).
         //

--- a/packages/core/src/engine/simulation-core-camera-sync.test.ts
+++ b/packages/core/src/engine/simulation-core-camera-sync.test.ts
@@ -1,0 +1,99 @@
+/**
+ * R1 #334+#335 — store-scene 동기화 단일 경로 통합 회귀 가드.
+ *
+ * ADR `docs/decisions/20260425-r1-store-scene-sync-unification.md` §결정 6.
+ *
+ * 본 테스트는 `SimulationCore.command` 가 'focusOn' / 'resetCamera' 호출 시
+ * **scene-side 핸들러를 호출하지 않고 event 만 emit** 하는지 검증한다.
+ *
+ * 회귀 시나리오 (방어 대상):
+ *  - `setCameraHandlers(focus, reset, ...)` 같은 시그니처가 부활해 콜백이 등록되면
+ *    sim-canvas subscribe 와 함께 이중 경로가 재생성된다.
+ *  - 본 테스트는 `setCameraRadiusHandler` 만 노출되고, command 처리 시 핸들러 호출 없이
+ *    event 만 발생하는 단일 진실원 계약을 박제.
+ *
+ * 단위 테스트 범위 (Babylon mock 비용 회피):
+ *  - SimulationCore 의 command 처리 + event emission 만 검증.
+ *  - scene / camera 실제 동작은 통합 또는 E2E (`p329-qa-focus-lod-guard.mjs`) 가 별도 가드.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { SimulationCore } from './simulation-core.js';
+
+// SimulationCore 생성자는 canvas 참조만 저장 — start() 호출 안 하면 Babylon 초기화 X.
+const makeCanvas = () => ({}) as unknown as HTMLCanvasElement;
+
+describe('SimulationCore store-scene sync (R1 #334+#335)', () => {
+  it('focusOn 명령은 bodySelected event 1회만 emit (scene 콜백 호출 없음)', () => {
+    const core = new SimulationCore(makeCanvas());
+    const onBodySelected = vi.fn();
+    core.on('bodySelected', onBodySelected);
+
+    core.command({ type: 'focusOn', bodyId: 'sun' });
+
+    // event 1회 — store sync 단일 경로 보장
+    expect(onBodySelected).toHaveBeenCalledTimes(1);
+    expect(onBodySelected).toHaveBeenCalledWith({ id: 'sun' });
+
+    core.dispose();
+  });
+
+  it('resetCamera 명령은 bodySelected({ id: null }) event 1회만 emit', () => {
+    const core = new SimulationCore(makeCanvas());
+    const onBodySelected = vi.fn();
+    core.on('bodySelected', onBodySelected);
+
+    core.command({ type: 'resetCamera' });
+
+    expect(onBodySelected).toHaveBeenCalledTimes(1);
+    expect(onBodySelected).toHaveBeenCalledWith({ id: null });
+
+    core.dispose();
+  });
+
+  it('setCameraRadius 명령은 등록된 핸들러를 1회만 호출 (focus 핸들러 부재 — 폐기됨)', () => {
+    const core = new SimulationCore(makeCanvas());
+    const setRadius = vi.fn();
+    core.setCameraRadiusHandler(setRadius);
+
+    core.command({ type: 'setCameraRadius', radius: 42 });
+
+    expect(setRadius).toHaveBeenCalledTimes(1);
+    expect(setRadius).toHaveBeenCalledWith(42);
+
+    core.dispose();
+  });
+
+  it('setCameraRadiusHandler 미등록 시 setCameraRadius 명령은 no-op (핸들러 호출 없음)', () => {
+    const core = new SimulationCore(makeCanvas());
+
+    expect(() => core.command({ type: 'setCameraRadius', radius: 100 })).not.toThrow();
+
+    core.dispose();
+  });
+
+  it('focusOn → resetCamera 연쇄 호출 시 event 2회 (각 1회씩)', () => {
+    const core = new SimulationCore(makeCanvas());
+    const onBodySelected = vi.fn();
+    core.on('bodySelected', onBodySelected);
+
+    core.command({ type: 'focusOn', bodyId: 'earth' });
+    core.command({ type: 'resetCamera' });
+
+    expect(onBodySelected).toHaveBeenCalledTimes(2);
+    expect(onBodySelected).toHaveBeenNthCalledWith(1, { id: 'earth' });
+    expect(onBodySelected).toHaveBeenNthCalledWith(2, { id: null });
+
+    core.dispose();
+  });
+
+  it('public API 회귀 가드 — setCameraHandlers 가 부활하지 않는다 (focus/reset 콜백 폐기)', () => {
+    const core = new SimulationCore(makeCanvas());
+    // setCameraHandlers 는 ADR §결정 2 에 의해 setCameraRadiusHandler 로 리네이밍됨.
+    // 본 assert 는 회귀 시 (예: 향후 작업자가 `setCameraHandlers` 를 다시 추가) 즉시 실패.
+    expect((core as unknown as Record<string, unknown>).setCameraHandlers).toBeUndefined();
+    // 신규 API 는 존재해야 함.
+    expect(typeof core.setCameraRadiusHandler).toBe('function');
+
+    core.dispose();
+  });
+});

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -148,7 +148,7 @@ export class SimulationCore {
    * UI 가 store `selectedBodyId` 변화를 subscribe 하여 scene focus / 카메라 reset 을 단일 책임으로 처리.
    * 본 핸들러는 `setCameraRadius` programmatic 줌 (예: 향후 줌 슬라이더) 경로 보존용.
    *
-   * 이전 시그니처 `setCameraHandlers(focusOn, resetCamera, setRadius)` 는 본 PR (#346) 에서 제거.
+   * 이전 시그니처 `setCameraHandlers(focusOn, resetCamera, setRadius)` 는 본 PR (#344) 에서 제거.
    */
   setCameraRadiusHandler(setRadius: (radius: number) => void): void {
     this.#setRadiusHandler = setRadius;

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -24,8 +24,9 @@ export class SimulationCore {
   #emitter: Emitter<CoreEvents> = mitt<CoreEvents>();
   #time: TimeController;
   #lastFrameTime: number | null = null;
-  #focusOnHandler: ((bodyId: string) => void) | null = null;
-  #resetCameraHandler: (() => void) | null = null;
+  // R1 #334+#335 — store-scene 동기화 단일 경로 통합 (ADR `20260425-r1-store-scene-sync-unification.md`).
+  // focus / resetCamera 콜백은 폐기 — UI 가 store `selectedBodyId` 변화를 subscribe 하여 단일 책임.
+  // `setCameraRadius` 콜백만 유지 (programmatic 카메라 줌 — `setCameraRadius` command 경유).
   #setRadiusHandler: ((radius: number) => void) | null = null;
   // P11-B #289 — LOD override 핸들러. URL `?lod=` 초기 1회 sendCommand 에서 scene 에 전달.
   #setLodOverrideHandler: ((level: 'high' | 'mid' | 'low' | 'auto') => void) | null = null;
@@ -140,15 +141,17 @@ export class SimulationCore {
     return null;
   }
 
-  /** 카메라 명령 핸들러 연결 — C6 CameraController와 연결 */
-  setCameraHandlers(
-    focusOn: (bodyId: string) => void,
-    resetCamera: () => void,
-    setRadius?: (radius: number) => void,
-  ): void {
-    this.#focusOnHandler = focusOn;
-    this.#resetCameraHandler = resetCamera;
-    this.#setRadiusHandler = setRadius ?? null;
+  /**
+   * R1 #334+#335 — 카메라 반지름 핸들러 연결 (`setCameraRadius` command 경유).
+   *
+   * ADR `20260425-r1-store-scene-sync-unification.md` §결정 1~3 — focus/resetCamera 콜백은 폐기되고
+   * UI 가 store `selectedBodyId` 변화를 subscribe 하여 scene focus / 카메라 reset 을 단일 책임으로 처리.
+   * 본 핸들러는 `setCameraRadius` programmatic 줌 (예: 향후 줌 슬라이더) 경로 보존용.
+   *
+   * 이전 시그니처 `setCameraHandlers(focusOn, resetCamera, setRadius)` 는 본 PR (#346) 에서 제거.
+   */
+  setCameraRadiusHandler(setRadius: (radius: number) => void): void {
+    this.#setRadiusHandler = setRadius;
   }
 
   /**
@@ -196,11 +199,13 @@ export class SimulationCore {
         this.#emitter.emit('timeChanged', { julianDate: cmd.julianDate });
         break;
       case 'focusOn':
-        this.#focusOnHandler?.(cmd.bodyId);
+        // R1 #334+#335 — focusOn 콜백 폐기. event emit 만으로 store sync (core-adapter → setSelectedBody)
+        // → sim-canvas subscribe 분기가 scene focus / camera 단일 책임으로 처리.
+        // ADR `20260425-r1-store-scene-sync-unification.md` §결정 1.
         this.#emitter.emit('bodySelected', { id: cmd.bodyId });
         break;
       case 'resetCamera':
-        this.#resetCameraHandler?.();
+        // R1 #334+#335 — resetCamera 콜백 폐기. event emit 으로 selectedBodyId=null sync 트리거.
         this.#emitter.emit('bodySelected', { id: null });
         break;
       case 'setCameraRadius':

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -156,7 +156,8 @@ export interface SolarSystemSceneHandles {
    * `CameraController.focusOn(mesh)` 와 동일 시점에 호출. 해당 body 의 월드 좌표로 origin 즉시 재배치
    * → focus body 는 scene 원점 근처에서 렌더되어 float32 jitter 제거. `bodyId` 미존재 시 no-op.
    *
-   * **호출 타이밍**: `setCameraHandlers` focus 콜백에서 `controller.focusOn` 과 같은 프레임에 호출.
+   * **호출 타이밍**: sim-canvas `syncFocusToScene` helper 에서 `controller.focusOn` 과 같은 프레임에 호출
+   * (R1 #334+#335 — store-scene 동기화 단일 경로 통합. ADR `20260425-r1-store-scene-sync-unification.md`).
    * 내부적으로 `updateAt` 이 다음 프레임에 origin 반영된 local 좌표로 mesh.position 을 재기록하므로
    * focus animation (300ms) 중에도 일관된 좌표계 유지.
    */


### PR DESCRIPTION
## 요약

PR #332 Phase 1 fix (`acfcb74`) 의 **임시 해결책** (subscribe + setCameraHandlers 이중 경로) 을 **정식 단일 경로 통합** 으로 대체. ADR [`docs/decisions/20260425-r1-store-scene-sync-unification.md`](docs/decisions/20260425-r1-store-scene-sync-unification.md) §결정 1~6 그대로 적용.

- **#334 (B-1 이중 호출 해소)**: 클릭 시 `controller.focusOn` 2회 → 1회
- **#335 (B-2 잠재 위험 해소)**: `setSelectedBody(null)` 시 카메라 reset 단일 책임 (subscribe 가 처리)

Closes #334
Closes #335

## 변경 사항

### `packages/core/src/engine/simulation-core.ts`
- `#focusOnHandler` / `#resetCameraHandler` 필드 + 두 핸들러 호출 라인 (`case 'focusOn'` / `case 'resetCamera'`) **삭제**
- `setCameraHandlers(focus, reset, setRadius?)` → **`setCameraRadiusHandler(setRadius)`** 단일 인자로 리네이밍 + 시그니처 단순화 (Gemini 교차검증 1순위 권고 수용 — ADR §결정 2)
- `bodySelected` event emit 은 보존 (core-adapter → setSelectedBody → subscribe 단일 sync 경로 의존)

### `apps/web/src/components/sim-canvas.tsx`
- **`syncFocusToScene(bodyId)` helper 추출** — 마운트 직후 1회 sync 와 subscribe 분기가 동일 식 공유 (DRY, ADR §결정 4)
- `useSimStore.subscribe` 분기 — `selectedBodyId` 변화 감지 시 `syncFocusToScene` 1회 호출 (단일 진실원)
- `instance.setCameraRadiusHandler((r) => camera.radius = r)` — focus/reset 콜백 인자 폐기
- 마운트 직후 1회 초기 sync 도 helper 사용

### `packages/core/src/scene/solar-system-scene.ts`
- `setFocusOrigin` JSDoc 의 "호출 타이밍" 설명을 `syncFocusToScene` helper 기반으로 갱신 (주석-구현 drift 방지)

### `packages/core/src/engine/simulation-core-camera-sync.test.ts` (신규)
- 6 회귀 가드 테스트:
  - `focusOn` 명령 → `bodySelected` event 1회 emit (scene 콜백 호출 없음)
  - `resetCamera` 명령 → `bodySelected({ id: null })` 1회 emit
  - `setCameraRadius` 명령 → 등록 핸들러 1회 호출
  - `setCameraRadiusHandler` 미등록 시 `setCameraRadius` 명령 no-op (throw 없음)
  - `focusOn` → `resetCamera` 연쇄 시 event 2회 (각 1회씩)
  - **public API 회귀 가드** — `setCameraHandlers` 부활 시 즉시 실패 (\`expect(...setCameraHandlers).toBeUndefined()\`)

### `CHANGELOG.md`
- `[Unreleased]` → `Fix` 항목 박제 + 분류 항목 추가 (PR #346 MINOR)

## 호출 흐름 (변경 후)

\`\`\`
사용자 클릭 / URL ?focus=sun / programmatic API
  ↓
sendCommand({ type: 'focusOn', bodyId })
  ↓
simulation-core.ts: case 'focusOn'
  └─ this.#emitter.emit('bodySelected', { id: cmd.bodyId })  ← scene 호출 0회
       ↓
core-adapter.ts: onBodySelected → store.setSelectedBody(id)
       ↓
sim-canvas.tsx: useSimStore.subscribe (단일 진실원)
  └─ syncFocusToScene(state.selectedBodyId)
      ├─ id !== null → solar.setFocusOrigin(id) + controller.focusOn(mesh)  (1회)
      └─ id === null → solar.clearFocus() + controller.reset(35)            (1회)
\`\`\`

## DoD (#334 + #335 + ADR)

- [x] `setCameraHandlers` → `setCameraRadiusHandler` 리네이밍 (시그니처 단순화)
- [x] subscribe 단일 경로 책임 (selectedBodyId !== null / === null 분기)
- [x] 마운트 직후 1회 sync 가 helper 사용 (DRY)
- [x] `syncFocusToScene` helper 추출
- [x] **이중 호출 해소 검증** — 클릭 시 `controller.focusOn` 1회만 호출 (이전 2회) — 회귀 가드 테스트 박제
- [x] **잠재 위험 해소 (#335)** — `setSelectedBody(null)` 시 카메라 점프 1회 (이전 2회 또는 누락 가능성)
- [x] 회귀 가드 테스트 6 케이스 추가
- [x] R1 산출물 회귀 0:
  - `verify-r1-tier-untouched.sh` PASS (Q3=C 가드)
  - `r1-ui-regression-guard.mjs` 12/12 mismatch **0.000%** (1280×720 / 1920×1080 / 375×667 × top-nav / shortcut-bar / hud-top-right / hud-bottom-right)
  - `p329-qa-focus-lod-guard.mjs` PASS (channel:'chrome', sphere 시그니처 + LOD high=1)
- [x] `pnpm typecheck` PASS (4/4 workspace)
- [x] `pnpm test:unit` PASS — 442 tests (신규 6 포함)
- [x] **CRITICAL #4** 한글 인코딩 — `grep -rn '�' <수정 파일>` 0건
- [x] `pnpm sync:prettierignore:check` drift 0 (121개 경로 동기화)

## ADR Concrete Prediction (R2~R10 코드 변경 0 박제)

R2 (수성), R3 (금성) ... R10 (해왕성+) 추가 시 다음 파일 변경 0 라인:
- `apps/web/src/components/sim-canvas.tsx` — `solar.meshes.get(state.selectedBodyId)` 일반화
- `packages/core/src/engine/simulation-core.ts` — `bodyId: string` 일반화
- `apps/web/src/core/core-adapter.ts` — 0 라인

R2 PR 시 `git diff --stat` 으로 실증 의무 (ADR §결과·재검토 조건).

## 분류 — MINOR

- 행동 변화: 클릭 시 카메라 애니메이션 1회 (이전 2회) — 시각 회귀 미발견 (UI guard 12/12 PASS) 지만 frame timing 변화
- 내부 API breaking: `setCameraHandlers` 시그니처 제거 — sim-canvas 외부 호출처 0 (grep 확인) 이지만 발견적 안전 마진 위해 MINOR

## 비-범위 (ADR 박제)

- `url-sync.tsx:77-78` `sendCommand + setSelectedBody` 양방향 호출 단순화 — ADR §"비-범위 보호 가드" 박제
- R2~R10 body 추가 — Concrete Prediction 검증은 다음 R-Phase

## Test Plan

- [x] 자동 회귀 가드 (typecheck / test:unit / r1-guard / p329-qa-focus-lod-guard / verify-r1-tier-untouched / sync:prettierignore) 모두 PASS
- [ ] **사용자 검증 필요** — 실 Chrome GUI 3단계 검증 (정적 / 인터랙션 / 흐름) — sub-agent 는 headless / 자동 가드만 수행. CRITICAL #3 적용