### PR TITLE
chore(release): v0.13.0 prep — CHANGELOG 박제 + 워크스페이스 버전업

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
-> **R1 사이클 (2026-04-25)** — Roadmap v3 "Incremental Body-by-Body Build" 첫 스프린트. 태양 가시성 복구 + 회귀 가드 인프라. 5 PR 머지.
+## [0.13.0] — 2026-04-26
+
+> **R1 사이클 (2026-04-25 ~ 2026-04-26)** — Roadmap v3 "Incremental Body-by-Body Build" 첫 스프린트. 태양 가시성 복구 + 회귀 가드 인프라. 8 PR 머지 (#330, #331, #332, #338, #339, #340, #342, #344).
 
 ### Fix
 
@@ -59,7 +61,7 @@ PR [#332](https://github.com/coseo12/astro-simulator/pull/332) (`6e7382e`) — �
 
 ### Notes
 
-- R1 후속 5건 ([#333](https://github.com/coseo12/astro-simulator/issues/333), [#334](https://github.com/coseo12/astro-simulator/issues/334), [#335](https://github.com/coseo12/astro-simulator/issues/335), #336, [#337](https://github.com/coseo12/astro-simulator/issues/337)) — R2 (수성) 진입 전 처리 권고. #336 / #333 완료, 3건 잔존
+- R1 후속 5건 ([#333](https://github.com/coseo12/astro-simulator/issues/333), [#334](https://github.com/coseo12/astro-simulator/issues/334), [#335](https://github.com/coseo12/astro-simulator/issues/335), [#336](https://github.com/coseo12/astro-simulator/issues/336), [#337](https://github.com/coseo12/astro-simulator/issues/337)) — R2 (수성) 진입 전 처리 권고. #333 / #334 / #335 / #336 완료, **#337 (CI Linux baseline 부트스트래핑) 만 잔존**
 - 109건 `상위에서 삭제됨` 분류 (harness v3.6.0 자가 점검 결과) — 별도 라운드 처리 권고. `.claude/skills/capture-volt/SKILL.md` / `.claude/commands/volt.md` 보존 우선
 
 #### Behavior Changes (CHANGELOG 소급 박제 자체)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/physics-wasm",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/shared",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Shared types, constants, and event definitions for astro-simulator",
   "type": "module",


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: `[Unreleased]` → `[0.13.0] — 2026-04-26` 박제. 새 빈 `[Unreleased]` 헤더 생성
- **5 워크스페이스 package.json**: 0.12.0 → 0.13.0 (root / apps/web / packages/core / packages/physics-wasm / packages/shared)
- **Notes 정정**: R1 후속 #333/#334/#335/#336 모두 CLOSED 확인. "3건 잔존" → "#337 만 잔존"

이 PR 머지 후 `develop → main` 단일 release PR 진행 예정.

## 분류

**MINOR** — v0.12.0 → v0.13.0

CHANGELOG `[0.13.0]` §분류 표 기준:
- MINOR 4건: PR #332 (UI 행동 + 회귀 가드 인프라), #338 (harness 게이트), #342 (#333 Phase 2), #344 (#334+#335 store-scene 통합)
- PATCH 4건: #330, #331, #339, #340 (docs/chore)
- breaking change 0건

## Behavior Changes

본 PR 자체는 문서/버전 메타데이터만 — 코드/에이전트 행동 변화 없음. 실 행동 변화는 v0.13.0 release PR (develop → main) 본문에 정리 예정.

## Test plan

- [x] `git grep -n '"version":' -- '*package.json'` 5 건 모두 0.13.0
- [x] `grep -rn '�'` U+FFFD 0건
- [x] CHANGELOG `[0.13.0]` 헤더 + 새 `[Unreleased]` 빈 헤더 확인
- [x] `git show --stat HEAD` 6 파일 반영 (lint-staged silent partial commit 가드)

## 참고

- 다음 단계: `develop → main` release PR (`--merge` / squash 금지)
- Notes 정정 근거: `gh issue view {333,334,335,336}` 모두 state=CLOSED 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)