### PR TITLE
[#337] R1 baseline CI Linux 부트스트래핑 — workflow + mjs 매개변수화 (구현)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,33 @@ jobs:
         if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('scripts/verify-no-scientific-grep.mjs') != ''
         run: pnpm run --if-present verify:no-scientific-grep
 
+      # R1 #337 — UI 회귀 가드 (4 영역 × 3 viewport pixel diff).
+      # baseline 은 r1:baseline-bootstrap workflow 가 Linux CI 환경에서 1회 캡처.
+      # ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment 2026-04-26
+      - name: R1 UI 회귀 가드 (r1-guard)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != ''
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          pnpm build
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          WEB_PID=$!
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+          BASE_URL=http://localhost:3001 node apps/web/scripts/r1-ui-regression-guard.mjs
+          GUARD_EXIT=$?
+          kill $WEB_PID || true
+          exit $GUARD_EXIT
+
+      - name: R1 diff 이미지 업로드 (실패 시)
+        if: failure() && hashFiles('apps/web/scripts/__diff__/r1/**/*.png') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: r1-pixel-diff-${{ github.run_id }}
+          path: apps/web/scripts/__diff__/r1/
+          retention-days: 7
+
       # --- yarn 경로 (pnpm-lock 없을 때만) ---
       # yarn berry (v2+) vs classic (v1) 감지:
       # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,33 +59,6 @@ jobs:
         if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('scripts/verify-no-scientific-grep.mjs') != ''
         run: pnpm run --if-present verify:no-scientific-grep
 
-      # R1 #337 — UI 회귀 가드 (4 영역 × 3 viewport pixel diff).
-      # baseline 은 r1:baseline-bootstrap workflow 가 Linux CI 환경에서 1회 캡처.
-      # ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment 2026-04-26
-      - name: R1 UI 회귀 가드 (r1-guard)
-        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != ''
-        run: |
-          pnpm exec playwright install --with-deps chromium
-          pnpm build
-          pnpm --filter @astro-simulator/web start -p 3001 &
-          WEB_PID=$!
-          for i in {1..30}; do
-            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
-            sleep 2
-          done
-          BASE_URL=http://localhost:3001 node apps/web/scripts/r1-ui-regression-guard.mjs
-          GUARD_EXIT=$?
-          kill $WEB_PID || true
-          exit $GUARD_EXIT
-
-      - name: R1 diff 이미지 업로드 (실패 시)
-        if: failure() && hashFiles('apps/web/scripts/__diff__/r1/**/*.png') != ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: r1-pixel-diff-${{ github.run_id }}
-          path: apps/web/scripts/__diff__/r1/
-          retention-days: 7
-
       # --- yarn 경로 (pnpm-lock 없을 때만) ---
       # yarn berry (v2+) vs classic (v1) 감지:
       # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)

--- a/.github/workflows/r1-baseline-bootstrap.yml
+++ b/.github/workflows/r1-baseline-bootstrap.yml
@@ -1,0 +1,125 @@
+name: r1:baseline-bootstrap
+
+# CRITICAL — workflow_dispatch 2단계 함정 (volt #45):
+#
+# (1) default branch 종속:
+#     - 본 workflow 가 main (또는 develop) 에 머지된 후에만 GitHub Actions UI 에 dispatch 버튼이 표시됨
+#     - feature 브랜치에서 push 만으로는 실행 불가
+#     - 절차: PR 머지 → main/develop 반영 확인 → Actions UI → "r1:baseline-bootstrap" → "Run workflow" 클릭
+#
+# (2) PR 자동 생성 권한:
+#     - peter-evans/create-pull-request 는 Settings → Actions → General → "Workflow permissions" →
+#       "Allow GitHub Actions to create and approve pull requests" 가 ON 이어야 작동
+#     - 기본값 OFF — 첫 dispatch 전 1회 enable 필요
+#     - 또는 CLI: gh api -X PUT /repos/coseo12/astro-simulator/actions/permissions/workflow \
+#         -f default_workflow_permissions=write \
+#         -F can_approve_pull_request_reviews=true
+#
+# DoD 매핑: #337 부트스트래핑 1회 dispatch 검증 (volt #45 함정 회피)
+#
+# 본 workflow 는 ubuntu-latest 컨테이너에서 R1 UI 회귀 가드 baseline 12장
+# (4 영역 × 3 viewport) 을 Linux 환경 기준으로 캡처하고 `peter-evans/create-pull-request`
+# 로 develop 대상 갱신 PR 을 자동 생성한다.
+#
+# ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment 2026-04-26 §결정 2
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'PR base 브랜치 (기본 develop)'
+        default: 'develop'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+
+      - name: Playwright Chrome (Linux) 설치
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 앱 빌드
+        run: pnpm build
+
+      - name: 웹 서버 기동 (백그라운드)
+        run: |
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          echo "WEB_PID=$!" >> $GITHUB_ENV
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+
+      - name: R1 baseline 12장 캡처 (Linux)
+        env:
+          BASE_URL: http://localhost:3001
+        run: node apps/web/scripts/r1-ui-regression-guard.mjs --update
+
+      - name: 서버 종료
+        if: always()
+        run: kill $WEB_PID || true
+
+      - name: baseline diff 확인
+        run: |
+          git status --porcelain apps/web/scripts/__baselines__/r1/
+          echo "---"
+          git diff --stat apps/web/scripts/__baselines__/r1/ || true
+
+      - name: baseline 갱신 PR 생성
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ inputs.target_branch }}
+          branch: chore/r1-baseline-linux-${{ github.run_id }}
+          commit-message: |
+            chore(r1-guard): #337 baseline 을 Linux CI 캡처본으로 전환
+
+            workflow_dispatch run_id=${{ github.run_id }}
+            ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment 2026-04-26
+          title: 'chore(r1-guard): [#337] R1 baseline Linux CI 캡처본 전환'
+          body: |
+            ## Summary
+
+            `r1:baseline-bootstrap` workflow 가 ubuntu-latest 환경에서 R1 UI 회귀 가드
+            baseline 12장 (4 영역 × 3 viewport) 을 재캡처. 기존 macOS 캡처본을 Linux
+            CI 캡처본으로 교체하여 PR check (`ci.yml` r1-guard step) 의 false positive
+            (폰트 렌더링 차이) 회피.
+
+            - trigger: `workflow_dispatch`
+            - run_id: ${{ github.run_id }}
+            - environment: `gh-actions-ubuntu-chromium`
+            - ADR: [`20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26](docs/decisions/20260425-r1-ui-pixel-diff-guard.md#amendment-2026-04-26--ci-linux-통합-정책-결정-337)
+
+            ## Behavior Changes
+
+            - R1 회귀 가드 baseline 이 macOS → Linux CI 캡처본으로 전환됨
+            - 로컬 macOS 검증 시 폰트 차이로 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰
+
+            ## Test plan
+
+            - [ ] 머지 후 임의 PR 에서 `ci.yml` 의 r1-guard step PASS 확인
+            - [ ] 고의적 false positive PR (예: shortcut 라벨 1글자 변경) 로 r1-guard 가 실제 fail 하는지 실증 후 revert (메인 ADR §결과·재검토 조건 메타 가드)
+
+            Closes #337
+          labels: |
+            type:infra
+            priority:medium
+          delete-branch: true

--- a/.github/workflows/r1-baseline-bootstrap.yml
+++ b/.github/workflows/r1-baseline-bootstrap.yml
@@ -51,6 +51,24 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      # physics-wasm 워크스페이스가 wasm-pack 의존 — `pnpm build` 의 root recursive 가
+      # core → physics-wasm 경로로 wasm-pack 호출. bench-baseline-remeasure.yml 검증 패턴 차용.
+      - name: Rust 툴체인 설정
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
       - name: 의존성 설치
         run: pnpm install --frozen-lockfile
 
@@ -118,7 +136,8 @@ jobs:
             - [ ] 머지 후 임의 PR 에서 `ci.yml` 의 r1-guard step PASS 확인
             - [ ] 고의적 false positive PR (예: shortcut 라벨 1글자 변경) 로 r1-guard 가 실제 fail 하는지 실증 후 revert (메인 ADR §결과·재검토 조건 메타 가드)
 
-            Closes #337
+            Refs #337
+            (#337 close 는 후속 이슈 #348 (ci.yml r1-guard step 통합) 완료 후 메인 오케스트레이터가 수동 처리)
           labels: |
             type:infra
             priority:medium

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ screenshots/
 # QA 회귀 가드 아티팩트 (p329-qa-focus-lod-guard.mjs 산출물 등)
 apps/web/scripts/__artifacts__/
 
+# R1 UI 회귀 가드 — 실패 시 생성되는 diff PNG (CI artifact 업로드 후 폐기, ADR Amendment 2026-04-26)
+apps/web/scripts/__diff__/
+
 # .claude/ 는 harness 관리 파일이므로 tracked — 런타임 생성 파일만 선별 ignore
 .claude/scheduled_tasks.lock
 .claude/logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Semantic Versioning을 따른다.
 
 ### Behavior Changes
 
-- **R1 UI 회귀 가드 baseline CI Linux 전환 인프라** ([#337](https://github.com/coseo12/astro-simulator/issues/337)) — `.github/workflows/r1-baseline-bootstrap.yml` (`workflow_dispatch`, ubuntu-latest 캡처 + `peter-evans/create-pull-request`) 신규 + `.github/workflows/ci.yml` `detect-and-test` job 에 r1-guard step 2개 추가 (실행 + 실패 시 diff 이미지 `actions/upload-artifact` 업로드). `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화: `BASE_URL` 환경변수 계약 헤더 주석 박제 + `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 (5 라인 변경). `r1-ui-regions.mjs` 0 라인 변경. baseline 12 PNG 는 본 PR 머지 후 `r1:baseline-bootstrap` workflow_dispatch 1회 실행으로 자동 갱신 PR 생성 (Linux 캡처본 교체). 로컬 macOS 검증 시 폰트 차이 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰. ADR `20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26
+- **R1 UI 회귀 가드 baseline CI Linux 전환 인프라 — 부트스트래핑 단계** ([#337](https://github.com/coseo12/astro-simulator/issues/337)) — `.github/workflows/r1-baseline-bootstrap.yml` (`workflow_dispatch`, ubuntu-latest 캡처 + `peter-evans/create-pull-request`) 신규. `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화: `BASE_URL` 환경변수 계약 헤더 주석 박제 + `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 (6 라인 변경). `r1-ui-regions.mjs` 0 라인 변경. baseline 12 PNG 는 본 PR 머지 후 `r1:baseline-bootstrap` workflow_dispatch 1회 실행으로 자동 갱신 PR 생성 (Linux 캡처본 교체). 로컬 macOS 검증 시 폰트 차이 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰. **`ci.yml` 의 r1-guard step 통합은 본 PR 비-범위** — chicken-and-egg 회피 (Linux baseline 갱신 PR 머지 후 별도 후속 PR 에서 통합. `pnpm build` 가 detect-and-test job 에 없는 wasm-pack 의존을 끌어오는 추가 위험도 후속 PR 에서 wasm-pack 설치 step 분리로 해소). ADR `20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26
 
 ## [0.13.0] — 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+### Behavior Changes
+
+- **R1 UI 회귀 가드 baseline CI Linux 전환 인프라** ([#337](https://github.com/coseo12/astro-simulator/issues/337)) — `.github/workflows/r1-baseline-bootstrap.yml` (`workflow_dispatch`, ubuntu-latest 캡처 + `peter-evans/create-pull-request`) 신규 + `.github/workflows/ci.yml` `detect-and-test` job 에 r1-guard step 2개 추가 (실행 + 실패 시 diff 이미지 `actions/upload-artifact` 업로드). `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화: `BASE_URL` 환경변수 계약 헤더 주석 박제 + `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 (5 라인 변경). `r1-ui-regions.mjs` 0 라인 변경. baseline 12 PNG 는 본 PR 머지 후 `r1:baseline-bootstrap` workflow_dispatch 1회 실행으로 자동 갱신 PR 생성 (Linux 캡처본 교체). 로컬 macOS 검증 시 폰트 차이 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰. ADR `20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26
+
 ## [0.13.0] — 2026-04-26
 
 > **R1 사이클 (2026-04-25 ~ 2026-04-26)** — Roadmap v3 "Incremental Body-by-Body Build" 첫 스프린트. 태양 가시성 복구 + 회귀 가드 인프라. 8 PR 머지 (#330, #331, #332, #338, #339, #340, #342, #344).

--- a/apps/web/scripts/r1-ui-regression-guard.mjs
+++ b/apps/web/scripts/r1-ui-regression-guard.mjs
@@ -11,7 +11,11 @@
  *   node apps/web/scripts/r1-ui-regression-guard.mjs --viewport=1280x720
  *   node apps/web/scripts/r1-ui-regression-guard.mjs --measure-sun-coverage  # 점유율만 측정
  *
- * ADR `docs/decisions/20260425-r1-ui-pixel-diff-guard.md` §결정 4.
+ * 환경변수 계약:
+ *   BASE_URL    — 웹 서버 URL (기본 http://localhost:3000, CI 에서 http://localhost:3001 등 오버라이드 가능)
+ *   SKIP_LOCAL  — '1' + macOS darwin 한정 즉시 PASS 종료 (Linux baseline 과 폰트 차이 false positive 회피)
+ *
+ * ADR `docs/decisions/20260425-r1-ui-pixel-diff-guard.md` §결정 4 + §Amendment 2026-04-26.
  */
 
 import { chromium } from 'playwright';
@@ -237,6 +241,8 @@ async function runForViewport(browser, viewport) {
 }
 
 async function main() {
+  // SKIP_LOCAL=1 + darwin — Linux baseline 폰트 차이 false positive 회피 (ADR Amendment 2026-04-26 §결정 1).
+  if (process.env.SKIP_LOCAL === '1' && process.platform === 'darwin') process.exit(0);
   ensureDirSync(BASELINE_DIR);
   ensureDirSync(DIFF_DIR);
 

--- a/docs/decisions/20260425-r1-ui-pixel-diff-guard.md
+++ b/docs/decisions/20260425-r1-ui-pixel-diff-guard.md
@@ -604,3 +604,95 @@ git diff develop...HEAD -- apps/web/scripts/r1-ui-regression-guard.mjs apps/web/
   ```
 
 ---
+
+## Amendment v2 2026-04-26 — chicken-and-egg + wasm-pack 실측 발견 박제 (#347, #348)
+
+- **상태**: Accepted (Amendment v2)
+- **날짜**: 2026-04-26 (Amendment 1 박제 직후 약 1시간 내 실측)
+- **결정자**: 메인 오케스트레이터 (PR #347 다운스트림 CI fail 분석)
+- **트리거**: PR [#347](https://github.com/coseo12/astro-simulator/pull/347) commit `eadce1e` 1차 구현 후 `detect-and-test` CI FAIL 실측 — Amendment 1 의 부트스트래핑 절차 (a)~(e) 가 두 가지 잠재 fail 을 명시적으로 짚지 않았음
+- **메인 ADR §결정 본문 보존**: 본 v2 도 §결정 1~5 / Amendment 1 §결정 1~4 어떤 항목도 변경하지 않는다. **부트스트래핑 절차 한계 박제** + **미래 R-Phase 사전 진단 체크리스트** 만 추가
+
+### 발견 사항 — Amendment 1 §결정 2 (workflow 책임 분리) + §Developer 인계의 잠재 fail
+
+#### Fail 1 — wasm-pack 의존 (workspace recursive build)
+
+`r1-baseline-bootstrap.yml` 및 `ci.yml` `detect-and-test` 의 r1-guard step 모두 `pnpm build` (= `pnpm -r build`) 를 호출. monorepo 의존 그래프상:
+
+```
+apps/web (next build) → packages/core → packages/physics-wasm (wasm-pack build)
+```
+
+`physics-wasm` 워크스페이스가 `wasm-pack` 호출. **`r1-baseline-bootstrap.yml` 자체와 `ci.yml` `detect-and-test` job 모두 wasm-pack 미설치** (현재 `verify-and-rust` job 만 보유). 결과:
+
+```
+packages/physics-wasm build: sh: 1: wasm-pack: not found
+ELIFECYCLE Command failed with exit code 1.
+```
+
+Amendment 1 §결정 2 의 "workflow 책임 분리 + 권한 최소화" 가 정합한 설계지만, **wasm-pack 토폴로지 의존을 명시하지 않아** 부트스트래핑 dispatch 즉시 fail 위험 잠재. PR #347 reviewer ([#issuecomment-4321651885](https://github.com/coseo12/astro-simulator/pull/347#issuecomment-4321651885)) BLOCK-1 으로 발견 → commit `d687072` 에서 `dtolnay/rust-toolchain` + `Swatinem/rust-cache` + `taiki-e/install-action wasm-pack@0.14.0` 3 step 추가로 해소.
+
+#### Fail 2 — chicken-and-egg (baseline 미정합 시점의 ci.yml step)
+
+Amendment 1 §결정 2 의 부트스트래핑 절차 (a) PR 머지 → (b) workflow_dispatch → (c) baseline 갱신 PR 머지 가정. (a) 단계의 PR 자체가 `ci.yml` r1-guard step 을 추가하면 **macOS baseline 으로 Linux CI 가 검증** → mismatch ≤ 0.5% 초과 fail 매우 유력. (a) 단계의 ci.yml step 자체가 **chicken 위치**.
+
+PR #347 commit `eadce1e` 가 ci.yml step 추가를 시도했고, wasm-pack fail 로 chicken-and-egg 가 표면화되기 전에 차단됐으나, wasm-pack 해결 후에도 같은 패턴 fail 이 재발할 위험.
+
+### 결정 — 후보 (ii) 채택 + 후속 이슈 분리
+
+PR #347 코멘트 ([#issuecomment-4321641705](https://github.com/coseo12/astro-simulator/pull/347#issuecomment-4321641705)) 에서 후보 (ii) 채택 (commit `70324b8`):
+
+- 본 PR 에서 ci.yml r1-guard step 2개 보류 (workflow + mjs 매개변수화 + .gitignore + CHANGELOG 만 머지)
+- 후속 이슈 [#348](https://github.com/coseo12/astro-simulator/issues/348) ([R1 후속 F-2] ci.yml r1-guard step 통합 — chicken-and-egg + wasm-pack 의존 해소) 신규 — PR #347 머지 + 부트스트래핑 (b)~(c) 완료 후 진행
+
+후보 (iii) `continue-on-error: true` / 후보 (iv) 별도 job 분리 모두 기각 — 후보 (ii) 가 Amendment 1 §결정 2 의 "단계 분리" 와 자연스럽게 정합.
+
+### Amendment 1 부트스트래핑 절차의 한계 박제
+
+Amendment 1 §결정 2 의 부트스트래핑 절차 (a)~(e) 는 **단일 PR 로 workflow + ci.yml step 통합** 을 가정. 본 Amendment v2 가 박제하는 정정 흐름:
+
+1. **PR1 (본 PR #347 후속)** — workflow + mjs 매개변수화 + .gitignore + CHANGELOG (ci.yml step 제외) 머지
+2. **부트스트래핑 (b)** — `r1:baseline-bootstrap` workflow_dispatch 1회 실행 (이때 본 v2 의 wasm-pack 3 step 이 dispatch fail 차단)
+3. **부트스트래핑 (c)** — 자동 생성된 baseline 갱신 PR (12 PNG Linux 캡처본 교체) 머지
+4. **PR2 (후속 이슈 #348)** — ci.yml r1-guard step 통합 + wasm-pack 설치 step (또는 별도 job 분리) — 이 시점 Linux baseline 정합 상태이므로 step 통합이 자연스럽게 PASS
+5. **메타 가드 실증** — 고의적 false positive PR 로 r1-guard fail 검증 후 revert (메인 ADR §결과·재검토 조건)
+
+### 미래 R-Phase 사전 진단 체크리스트 (R2~R10 인프라 재사용 시)
+
+본 Amendment v2 의 핵심 박제 — 동일 패턴 발견 반복 회피:
+
+1. **회귀 가드 인프라 도입 시 baseline + step 통합의 chicken-and-egg 인지 의무**
+   - 단일 PR 로 완결시키려는 관성 vs 부트스트래핑 단계 분리
+   - 체크 질문: "본 PR 의 step 이 동시에 추가하는 baseline 의 OS/환경 정합성 확인 안 된 시점에 동작 가능한가?"
+   - 정합성 미확보 시 → step 추가는 baseline 갱신 PR 머지 후 별도 PR 분리 의무
+
+2. **monorepo recursive build 의 의존성 매핑**
+   - `pnpm build` ≠ `pnpm --filter <pkg> build` — recursive 가 다른 워크스페이스의 binary 의존 (wasm-pack, cargo, rustc, protoc 등) 을 끌어옴
+   - CI job 별 binary 의존 매트릭스 사전 확인:
+     ```bash
+     # 의존 그래프 추적
+     pnpm --filter <target-pkg>... why <suspected-pkg>
+     # 또는 package.json 의 build 스크립트 grep
+     grep -rn '"build":' packages/*/package.json apps/*/package.json
+     ```
+   - 새 workflow/job 도입 전 **빌드 트리 binary 의존 매트릭스 박제** 의무 (예: web → core → physics-wasm → wasm-pack ⊃ rustc)
+
+3. **다운스트림 실측이 최종 가드** (CLAUDE.md `### 다운스트림 실측이 최종 가드 — upstream 3중 방어 blindspot` 의 추가 사례)
+   - architect ADR + developer self-compare + reviewer 정적 분석 3중 방어 통과해도 다운스트림 CI 실측에서만 드러나는 결함 존재
+   - PR #347 사례: developer macOS 로컬 검증 (`pnpm start -p 3001` HTTP 200, `SKIP_LOCAL=1 + macOS` 즉시 PASS, 단위 테스트 441 PASS) 가 wasm-pack/chicken-and-egg 를 잡지 못한 blindspot
+   - 메인 오케스트레이터의 다운스트림 CI 결과 직접 확인 의무 (CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료`) 의 핵심 가치 입증
+
+### Volt 캡처 후보 (별도 처리)
+
+본 Amendment v2 의 발견은 다음 volt 교훈으로 캡처 권고:
+
+- **회귀 가드 인프라 도입의 chicken-and-egg 패턴** — baseline 정합성 + step 통합 + 의존성 매핑 3축 사전 진단. 본 ADR Amendment v2 + PR #347 commit history (`eadce1e` → `70324b8` → `d687072`) 가 trace
+- **monorepo recursive build 의존성 누락 (workspace binary 의존)** — `pnpm build` vs `pnpm --filter` 의 의존 그래프 차이. CI job 구조 사전 매핑 의무
+- **upstream 3중 방어 blindspot 의 추가 사례** — volt #195 (CLAUDE.md 박제) 의 구체 사례 1건 추가
+
+### 재검토 트리거 추가 (메인 ADR §결과·재검토 조건 보강)
+
+- R2~R10 의 회귀 가드 인프라 도입 시 본 Amendment v2 §사전 진단 체크리스트 적용 → 동일 패턴 재발 시 체크리스트 미준수 사실 박제
+- 후속 이슈 #348 머지 후 부트스트래핑 절차 (a)~(e) 정합 동작 실증 — Amendment 1 §결정 2 의 절차 검증
+
+---

--- a/docs/decisions/20260425-r1-ui-pixel-diff-guard.md
+++ b/docs/decisions/20260425-r1-ui-pixel-diff-guard.md
@@ -383,3 +383,224 @@ git diff develop...HEAD -- apps/web/scripts/r1-ui-regression-guard.mjs
 - DOM 시맨틱 회귀 검증 — PM Q2 옵션 C 미선택 (R1 비-범위)
 - 시각 회귀의 자동 자가 치유 — `--update` 는 명시적 사용자 의도 표명 (자동 갱신 금지)
 - 신규 라이브러리 추가 — `pixelmatch` / `pngjs` / `sharp` / `playwright` 만 사용
+
+---
+
+## Amendment 2026-04-26 — CI Linux 통합 정책 결정 (#337)
+
+- **상태**: Accepted (Amendment)
+- **날짜**: 2026-04-26
+- **결정자**: architect (#337 위임)
+- **트리거**: PR #332 reviewer F-1 분리 — R1 baseline 12장이 macOS 14 / Apple Silicon / Chrome channel 로 캡처되어 CI Linux 환경 폰트 렌더링 차이로 false positive 위험
+- **메인 ADR §결정 본문 보존**: 본 Amendment 는 §결정 1~5 어떤 항목도 변경하지 않는다. 알고리즘 (pixelmatch 0.1) / 임계값 (0.5%) / 영역 정의 / 디렉토리 구조 / 부트스트래핑 절차 모두 유효. 본 Amendment 는 **OS 매트릭스 축 추가** + **CI workflow 책임 분리**만 다룬다.
+
+### 배경 — 메인 ADR §위험·미해결 4번 항목 구체화
+
+메인 ADR §위험·미해결 4번 ("CI 환경 폰트") 은 baseline 을 "CI 환경에서 1회 캡처" 권고로 종결했다. 그러나 R1 PR #332 머지 시점에 부트스트래핑 절차 단순화 권고 (메인 ADR §Developer 인계 4 대안) 를 채택해 **로컬 macOS 환경에서 baseline 을 박제**했다. 결과:
+
+- 12 PNG (`apps/web/scripts/__baselines__/r1/{1280x720,1920x1080,375x667}/{top-nav,shortcut-bar,hud-top-right,hud-bottom-right}.png`) 모두 macOS 캡처
+- CI Linux 통합 시점에 폰트 렌더링 (macOS San Francisco vs Linux DejaVu/Noto) 차이가 4 영역 모두에 nontrivial 영향 — 특히 텍스트 비율이 높은 `top-nav`, `hud-top-right` 가 위험
+- 본 Amendment 는 이 격차를 어떻게 흡수할지 **3 후보 비교 + 결정**
+
+### 후보 비교 — Baseline OS 매트릭스 정책
+
+| 후보  | 내용                                                                               | macOS 로컬 검증           | CI Linux 검증 | baseline 매트릭스 크기 | r1-ui-regression-guard.mjs 변경 라인 | 평가                                                                 |
+| ----- | ---------------------------------------------------------------------------------- | ------------------------- | ------------- | ---------------------- | ------------------------------------ | -------------------------------------------------------------------- |
+| **A** | macOS baseline 유지 + CI 임계값 완화 (`mismatch ≤ 1.0%~2.0%`)                      | ✓                         | △ (관대)      | 12 (현재 유지)         | 0 (env var 또는 CLI flag 추가만)     | 단순. 진짜 회귀 감지력 약화 — 1글자 텍스트 변경이 임계값 안에 묻힘   |
+| **B** | Linux baseline 으로 전환 + macOS 로컬은 보조 (CI 우선)                             | △ (관대 또는 별도 임계값) | ✓             | 12 (Linux 로 1회 갱신) | 0 (baseline 만 교체)                 | CI 정합성 1순위. 로컬 macOS 검증에서 false positive — 개발 흐름 마찰 |
+| **C** | OS 별 baseline 매트릭스 (`__baselines__/r1/{linux,macos}/{viewport}/{region}.png`) | ✓                         | ✓             | 24 (2 배)              | ≤ 5 (OS detect + 경로 분기)          | 가장 robust. 매트릭스 2배 (디스크 / 갱신 부담)                       |
+
+### 결정 1 — 후보 B (Linux baseline 전환 + macOS 로컬은 보조)
+
+**선택 근거**:
+
+1. **CI 가 진실의 원천 (Source of Truth)** — PR check 가 회귀 감지의 1차 게이트. 메인 ADR §결과·재검토 조건의 "회귀 가드 자체의 회귀 가드 (메타)" 가 요구하는 "고의적 false positive PR 로 가드 fail 실증" 도 CI 환경에서 수행. 로컬은 보조 검증
+2. **회귀 감지력 보존** — 후보 A 의 임계값 완화 (0.5% → 1.0%) 는 1글자 텍스트 변경 / 작은 icon 변경을 흡수해 **회귀 가드의 본질적 가치를 훼손**. 메인 ADR §축 2 의 임계값 0.5% 결정 근거 (1글자 텍스트 변경 검출 보장) 와 충돌
+3. **매트릭스 크기 단순성** — 후보 C 의 24장 매트릭스는 mjs 코드 변경 (OS detect + 경로 분기), CI workflow 복잡도 (matrix strategy), 갱신 시 양쪽 동기화 부담 등 비용이 높다. 1인 개발 + AI 페어 컨텍스트에서 ROI 낮음
+4. **로컬 macOS 검증의 false positive 처리** — macOS 개발자가 로컬에서 `pnpm r1-guard` 실행 시 폰트 차이로 mismatch 가 0.5% 를 초과할 수 있다. 다음 3가지 대응 패턴 박제 (개발자 선택):
+   - (a) **CI 결과만 신뢰** — 로컬 실행은 스킵, PR push 후 CI 결과만 확인 (권고)
+   - (b) **`SKIP_LOCAL=1` env var** — `r1-ui-regression-guard.mjs` 가 `SKIP_LOCAL=1` 시 즉시 PASS 종료 (CLI flag 추가 ≤ 5 라인)
+   - (c) **로컬에서 docker / podman 으로 Linux 컨테이너 실행** — 가장 정합성 높지만 셋업 비용 (선택사항, 비-범위)
+
+**대안 (후보 C) 채택 조건 — 재검토 트리거**:
+
+- macOS 개발자 mismatch false positive 비율이 PR 당 평균 ≥ 2 회 (개발 흐름 심각 마찰)
+- macOS 로컬에서 회귀를 **먼저 발견하는** 사례가 누적 (CI 가 항상 1차 게이트라는 전제 무너짐)
+- 모바일 / 태블릿 등 OS 매트릭스가 viewport 매트릭스와 곱셈으로 폭발 — 그 시점엔 후보 C 보다 viewport 우선 분리 ADR 검토
+
+### 결정 2 — CI Workflow 분리: bootstrap (workflow_dispatch) vs PR check (자동)
+
+**책임 직교화 — 2 workflow 분리**:
+
+| Workflow                                                                               | 트리거                                                | 실행 빈도                        | 책임                                                                                         |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------- |
+| **`.github/workflows/r1-baseline-bootstrap.yml`** (신규)                               | `workflow_dispatch` 만                                | 부트스트래핑 / 갱신 시 1회       | Linux 환경에서 12 PNG 캡처 + `peter-evans/create-pull-request` 로 baseline 갱신 PR 자동 생성 |
+| **`.github/workflows/ci.yml`** `detect-and-test` job 의 신규 step (기존 workflow 확장) | `pull_request` (develop/main) + `push` (develop/main) | 모든 PR + 모든 main/develop push | `pnpm r1-guard` 실행. 실패 시 `__diff__/r1/` 을 `actions/upload-artifact` 로 업로드          |
+
+**선택 근거**:
+
+1. **`bench-baseline-remeasure.yml` 패턴 재사용** — 기존 인프라가 동일 모델 (workflow_dispatch + matrix run + create-pull-request) 사용. 패턴 검증 + 컨벤션 일관성
+2. **부트스트래핑은 1회성 / PR check 는 상시** — 2 workflow 의 빈도 / 권한 / 비용이 다름. 단일 workflow 에 condition 분기로 합치면 복잡도 증가, 권한 (PR 자동 생성) 가 PR check 에도 적용되는 위험
+3. **bootstrap workflow 는 별도 job 으로 격리** — `r1-baseline-bootstrap.yml` 은 `permissions: contents:write, pull-requests:write` 필요 (PR 자동 생성). `ci.yml` 의 detect-and-test 는 read-only 권한이면 충분. 권한 최소화 원칙
+4. **PR check 통합 위치** — 기존 `ci.yml` 의 `detect-and-test` job 에 신규 step 추가 (별도 workflow 신설 안 함). 이유: 동일 PR 에 대해 detect-and-test 의 `pnpm test` 가 이미 실행되고 그 직후 `pnpm r1-guard` 만 추가하면 됨. 신규 workflow 신설 시 `pnpm install` / `playwright install` 중복 실행 비용 발생
+
+### 결정 3 — `r1-ui-regression-guard.mjs` 매개변수화 (후보 B 채택 후)
+
+**현재 상태** (`apps/web/scripts/r1-ui-regression-guard.mjs` line 31):
+
+```javascript
+const BASELINE_DIR = path.join(__dirname, '__baselines__', 'r1');
+```
+
+**후보 B 채택 시 변경**: **0 라인** (baseline 디렉토리 그대로 사용, Linux 캡처본으로 PNG 만 교체).
+
+선택 근거:
+
+- 후보 B 는 매트릭스 OS 차원 추가가 아닌 **단일 baseline 의 OS 변경**. 디렉토리 구조 (`__baselines__/r1/{viewport}/{region}.png`) 그대로
+- 후보 C 였다면 OS detect 로직 (`process.platform === 'linux' ? 'linux' : 'macos'`) + 경로 분기 (≤ 5 라인) 필요. 후보 B 에선 불필요
+- 단, **선택사항으로 `SKIP_LOCAL=1` env var 지원** 추가 가능 (≤ 5 라인 — `if (process.env.SKIP_LOCAL === '1' && process.platform === 'darwin') process.exit(0);`). developer 가 PR 시점 판단
+
+**Concrete Prediction**:
+
+> 후보 B 채택 후 `r1-ui-regression-guard.mjs` 의 변경 라인 = **0 ~ 5** (선택적 SKIP_LOCAL 지원 한정). `r1-ui-regions.mjs` 변경 = 0. baseline 12 PNG 가 Linux 캡처본으로 교체되며 git diff 상 binary diff. CI workflow 변경: `r1-baseline-bootstrap.yml` 신규 (≈ 100 라인), `ci.yml` 신규 step 추가 (≈ 15 라인 — `pnpm r1-guard` + diff 업로드).
+
+검증 절차 (Developer PR 에서 자동 재현):
+
+```bash
+git diff develop...HEAD -- apps/web/scripts/r1-ui-regression-guard.mjs apps/web/scripts/r1-ui-regions.mjs
+# 변경 라인 합 ≤ 5 (mjs) + 0 (regions) 이어야 Prediction 성공
+```
+
+### 결정 4 — workflow_dispatch 사전 조건 박제 (volt #45 함정 회피)
+
+**`r1-baseline-bootstrap.yml` 상단 주석에 사전 조건 명시 의무**:
+
+```yaml
+# CRITICAL — workflow_dispatch 2단계 함정 (volt #45):
+#
+# (1) default branch 종속:
+#     - 본 workflow 가 main (또는 develop) 에 머지된 후에만 GitHub Actions UI 에 dispatch 버튼이 표시됨
+#     - feature 브랜치에서 push 만으로는 실행 불가
+#     - 절차: PR 머지 → main 반영 확인 → Actions UI → "r1-baseline-bootstrap" → "Run workflow" 클릭
+#
+# (2) PR 자동 생성 권한:
+#     - peter-evans/create-pull-request 는 Settings → Actions → General → "Workflow permissions" →
+#       "Allow GitHub Actions to create and approve pull requests" 가 ON 이어야 작동
+#     - 기본값 OFF — 첫 dispatch 전 1회 enable 필요
+#     - 또는 CLI: gh api -X PUT /repos/coseo12/astro-simulator/actions/permissions/workflow \
+#         -f default_workflow_permissions=write \
+#         -F can_approve_pull_request_reviews=true
+#
+# DoD 매핑: #337 부트스트래핑 1회 dispatch 검증 (volt #45 함정 회피)
+```
+
+**선택 근거**: volt #45 (workflow_dispatch 2단계 함정) 의 박제 의무 패턴. workflow 도입 PR DoD 에 "default branch 반영 후 dispatch 검증" 명시 → developer 가 R1 PR 머지 후 1회 실행 결과를 PR 본문에 박제.
+
+### Developer 인계 (Amendment 추가분)
+
+**시작 지점**:
+
+1. **사전 조건 검증** (workflow 작성 전):
+   ```bash
+   # PR 자동 생성 권한 현재 상태 확인
+   gh api repos/coseo12/astro-simulator/actions/permissions/workflow
+   # can_approve_pull_request_reviews 가 false 면 enable 필요
+   ```
+2. **`.github/workflows/r1-baseline-bootstrap.yml` 신규 작성** — `bench-baseline-remeasure.yml` 패턴 따라:
+   - `on: workflow_dispatch` 만 (push/PR 트리거 금지 — 비용 + 권한)
+   - `permissions: contents:write, pull-requests:write`
+   - steps: checkout / pnpm setup / Node 20 / Playwright Chrome (Linux) / 앱 빌드 / 웹 서버 기동 / `node apps/web/scripts/r1-ui-regression-guard.mjs --update` / git diff 확인 / `peter-evans/create-pull-request@v7` 로 baseline 갱신 PR 자동 생성
+   - PR base = `develop`, branch = `chore/r1-baseline-linux-${{ github.run_id }}`
+3. **`.github/workflows/ci.yml` `detect-and-test` job 에 step 추가** — pnpm 경로 직후 (line ~60 `verify:no-scientific-grep` step 옆):
+
+   ```yaml
+   - name: R1 UI 회귀 가드 (r1-guard)
+     if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != ''
+     run: |
+       pnpm exec playwright install --with-deps chromium
+       pnpm --filter @astro-simulator/web start -p 3001 &
+       WEB_PID=$!
+       for i in {1..30}; do
+         if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+         sleep 2
+       done
+       BASE_URL=http://localhost:3001 node apps/web/scripts/r1-ui-regression-guard.mjs
+       kill $WEB_PID || true
+
+   - name: R1 diff 이미지 업로드 (실패 시)
+     if: failure() && hashFiles('apps/web/scripts/__diff__/r1/**/*.png') != ''
+     uses: actions/upload-artifact@v4
+     with:
+       name: r1-pixel-diff-${{ github.run_id }}
+       path: apps/web/scripts/__diff__/r1/
+       retention-days: 7
+   ```
+
+   - **NOTE**: `pnpm --filter @astro-simulator/web start` 가 실제 동작하는지 확인 필요 (R1 PR 본문 + `package.json` scripts 검증). 작동 안 하면 `pnpm build && pnpm exec serve` 또는 `next start` 등 대체
+
+4. **부트스트래핑 절차** (volt #45 회피):
+   - (a) PR `feature/337-r1-ci-linux-baseline-design` 머지 (workflow 파일 main 반영)
+   - (b) GitHub Actions UI → "r1-baseline-bootstrap" → "Run workflow" → develop 대상 dispatch
+   - (c) workflow 가 자동 생성한 baseline 갱신 PR 머지 (Linux 캡처 12장이 macOS 12장 교체)
+   - (d) 임의 PR 에서 `ci.yml` 의 r1-guard step 이 PASS 하는지 실증
+   - (e) **고의적 false positive PR** (예: shortcut 라벨 1글자 변경) 로 r1-guard 가 실제 fail 하는지 실증 후 revert (메인 ADR §결과·재검토 조건 메타 가드 충족)
+5. **CHANGELOG 박제** — Behavior Changes 섹션에 "R1 UI 회귀 가드 baseline 이 macOS → Linux CI 캡처본으로 전환. 로컬 macOS 검증 시 폰트 차이로 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰" 명시
+
+**참조 문서**:
+
+- 본 ADR (메인 + Amendment)
+- `bench-baseline-remeasure.yml` (패턴 참조)
+- volt #45 (workflow_dispatch 2단계 함정), volt #48 (CI 통과 ≠ 테스트 실행)
+
+**비-범위 (절대 손대지 말 것)**:
+
+- 메인 ADR §결정 1~5 본문 — Amendment 는 §결정 본문 변경 안 함 (OS 매트릭스 축 추가만)
+- pixel diff 임계값 변경 (0.5% → 1.0%) — 후보 A 미선택. 임계값 변경 필요 시 별도 amendment
+- 다른 R-Phase (R2~R10) baseline 캡처 — 본 인프라 도입 후 동일 패턴 재사용
+- macOS 개발 환경 폐기 — 후보 B 는 "CI 우선" 이지 "macOS 금지" 아님 (보조 검증 + 선택적 SKIP_LOCAL)
+
+### 교차검증 반영 사항
+
+본 Amendment 박제 직후 cross-validate 1회 (Gemini 2.5 Pro, 2026-04-26 08:16Z). outcome=applied. 로그: `.claude/logs/cross-validate-architecture-20260426-171643.log`.
+
+**Claude 자체 편향 4종 셀프 체크** (CLAUDE.md `## 교차검증`):
+
+- **낙관적 일정**: 통과 — mjs 변경 ≤ 5 라인 / workflow 신규 ≈ 100 라인 / ci.yml step 추가 ≈ 15 라인 보수적 추정
+- **결합 간과**: 통과 — `r1-baseline-bootstrap.yml` (workflow_dispatch + PR 자동 생성) ↔ `ci.yml` (PR check) 책임 직교화로 자동 동기화
+- **폐기 프레이밍**: 통과 — 후보 A/C 단순 폐기 아닌 재검토 트리거 박제 (false positive ≥ 2/PR 시 후보 C)
+- **순수주의** (호출 프롬프트 명시 질문): **부분 기각** — Gemini 가 "후보 B 채택은 실용적이고 현명" + "SKIP_LOCAL 까지 마련한 것은 뛰어난 통찰" 로 평가. 1인 개발 + AI 페어 컨텍스트에서 macOS 마찰 < CI 정합성 우선이라는 Claude 판단을 외부 시각이 지지
+
+**합의** — Claude 설계와 일치 + 본 Amendment 에 즉시 반영:
+
+- **Workflow 책임 분리** (§결정 2) — Gemini 가 "각 책임과 권한을 명확히 분리하여 구조적 완성도를 높였습니다" 합의. 생산자(`r1-baseline-bootstrap.yml`)-소비자(`ci.yml`) 패턴 명시
+- **CI 환경을 Source of Truth (§결정 1, 후보 B)** — Gemini 가 "실용적이고 현명한 결정. 로컬 macOS 환경 마찰을 예측하고 SKIP_LOCAL 회피 전략까지 마련한 것은 뛰어난 통찰" 강하게 합의
+- **워크플로우 권한 최소화** (§결정 2) — Gemini 가 "Baseline 생성 워크플로우에만 contents:write/pull-requests:write 부여, ci.yml 은 read-only 유지는 훌륭한 보안 설계" 합의
+- **재검토 트리거 박제** (§결정 1 대안 채택 조건) — Gemini 가 "재검토 조건의 구체성 (false positive 비율, CI 5분 초과 등) 이 노후화 대응 제도적 장치" 합의
+
+**이견 수용 (Gemini 고유 발견 — 본 Amendment 에 즉시 반영)**:
+
+- **`.gitignore` 에 `apps/web/scripts/__diff__/` 추가 (Gemini 개선 제안 1)** — Claude 원안 누락. CI 실패 시 생성되는 diff 이미지가 로컬 개발 환경에 잔존해 의도치 않은 커밋 위험. **수용** — Developer 인계 단계에 `.gitignore` 항목 추가 명시 박제
+- **`BASE_URL` 환경변수 계약 명시 (Gemini 개선 제안 2)** — Claude 원안은 `r1-ui-regression-guard.mjs` 라인 33 의 default 값 (`http://localhost:3000`) 만 박제. CI step 에서 `BASE_URL=http://localhost:3001` 오버라이드 시 환경변수 계약이 명시적이지 않음. **수용** — mjs 헤더 주석에 `BASE_URL` 계약 명시 의무를 Developer 인계에 추가
+
+**Claude 재분석으로 기각한 Gemini 제안**:
+
+- **Animation timing 회귀 감지 (`getAnimations().map(a => a.finished)`)** — 메인 ADR §재검토 트리거 4 에 이미 박제 ("pixel diff 가 missing 한 회귀 (예: animation timing 변경) 가 발생 — DOM 시맨틱 회귀 검증 추가 도입 ADR"). 본 Amendment 범위 밖 + 메인 ADR 의 R1 비-범위 (DOM 시맨틱 회귀 미도입). **기각 근거**: 메인 ADR 본문 검토 누락
+- **Retina/HiDPI `deviceScaleFactor: 1` 고정** — `r1-ui-regression-guard.mjs` 라인 131 에 이미 박제 (`deviceScaleFactor: 1`). **기각 근거**: 코드 미검토. 후보 B 채택으로 CI Linux 가 표준 해상도이므로 추가 보강 불필요
+
+**고유 발견 (후속 분리)**:
+
+- **fork PR 보안 가드 (`if: github.repository == 'owner/repo'`)** — 현재 astro-simulator 는 단일 owner repo + private dev 컨텍스트. fork PR 시나리오 부재. 본 Amendment 범위 밖 (보안 강화). **분리 권고**: future fork-friendly 전환 시점에 검토. 우선순위: low
+- **신규 viewport 추가 가이드라인 (`__baselines__/{width}x{height}/...` 컨벤션 문서화)** — R1 비-범위 (R2~R10 진입 시점에 결정). 메인 ADR §결과·재검토 조건 에 viewport 매트릭스 폭발 시 후보 C 재검토 트리거 박제됨. **분리 권고**: R2 PR 진입 시점에 가이드라인 ADR. 우선순위: low
+
+### 교차검증 반영 → §Developer 인계 보강 (이견 수용)
+
+위 "이견 수용" 2건은 §Developer 인계 의 단계에 다음 항목으로 추가:
+
+- **추가 단계 (mjs 작성/수정 시)**: `apps/web/scripts/r1-ui-regression-guard.mjs` 헤더 주석에 환경변수 계약 명시 — `BASE_URL` (기본 `http://localhost:3000`, CI 에서 `http://localhost:3001` 등 오버라이드 가능), `SKIP_LOCAL=1` (선택사항, macOS darwin 한정 즉시 PASS)
+- **추가 단계 (`.gitignore` 보강)**:
+  ```
+  # R1 UI 회귀 가드 — 실패 시 생성되는 diff PNG (CI artifact 업로드 후 폐기)
+  apps/web/scripts/__diff__/
+  ```
+
+---


### PR DESCRIPTION
## Summary

ADR [`20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26](docs/decisions/20260425-r1-ui-pixel-diff-guard.md#amendment-2026-04-26--ci-linux-통합-정책-결정-337) (commit `dac2874`) 의 4 결정을 구현. macOS 캡처본 R1 baseline 12장을 Linux CI 캡처본으로 전환할 **부트스트래핑 인프라 + PR check 통합 + mjs 매개변수화**.

본 PR 범위:
- `.github/workflows/r1-baseline-bootstrap.yml` 신규 (workflow_dispatch + `peter-evans/create-pull-request@v7`)
- `.github/workflows/ci.yml` `detect-and-test` job 에 r1-guard step 2개 추가 (실행 + 실패 시 diff artifact 업로드)
- `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화 (헤더 주석 + SKIP_LOCAL 1줄)
- `r1-ui-regions.mjs` **0 라인 변경**
- `.gitignore` `apps/web/scripts/__diff__/` 추가 (Gemini 교차검증 합의)
- CHANGELOG `[Unreleased]` Behavior Changes 박제

본 PR 범위 밖 (PR 머지 후 부트스트래핑 PR 에서 자동):
- baseline 12 PNG (Linux 캡처본) 교체 — Actions UI 에서 `r1:baseline-bootstrap` workflow_dispatch 1회 실행 → 자동 PR

## Behavior Changes

- **R1 UI 회귀 가드 baseline 이 macOS → Linux CI 캡처본으로 전환 예정** (본 PR 머지 + workflow_dispatch 후 발효)
- **로컬 macOS 검증 시 폰트 차이로 false positive 가능** — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰
- **모든 PR 에서 r1-guard step 자동 실행** (`ci.yml` `detect-and-test` job) — 실패 시 diff PNG artifact 7일 보존

## DoD 매핑 (이슈 #337 §수용 기준)

- [x] (architect 박제 — `dac2874`) baseline 갱신 정책 결정 (후보 B) + ADR Amendment
- [x] (developer) CI workflow `.github/workflows/r1-baseline-bootstrap.yml` 신규
- [x] (developer) PR check 로 r1-ui-regression-guard.mjs 통합 (`ci.yml` step)
- [x] (developer) 실패 시 diff PNG `actions/upload-artifact` 산출물 박제
- [x] (developer) workflow_dispatch 사전 조건 박제 (workflow 상단 주석)
- [ ] (qa/사용자) Linux CI 환경에서 12 PNG 1차 캡처 + diff 산출물 PR 본문 박제 — **본 PR 머지 후 workflow_dispatch 1회 실행으로 자동 처리**
- [ ] (qa/사용자) default branch 반영 후 1차 dispatch 검증 (volt #45 함정 회피)

## Concrete Prediction 결과 (ADR Amendment §결정 3)

```bash
$ git diff develop...HEAD -- apps/web/scripts/r1-ui-regression-guard.mjs apps/web/scripts/r1-ui-regions.mjs
```

| 파일 | 추가 | 삭제 | 순 변경 | Prediction | 결과 |
|---|---|---|---|---|---|
| `r1-ui-regression-guard.mjs` | 7 | 1 | +6 | ≤ 5 라인 (SKIP_LOCAL 한정) | **부분 충족** |
| `r1-ui-regions.mjs` | 0 | 0 | 0 | 0 라인 | **충족** ✓ |

분석:
- **코드 변경 (SKIP_LOCAL) 한정**: 2 라인 (주석 1 + `if` 1) → ≤ 5 라인 **충족** ✓
- **헤더 주석 (BASE_URL 환경변수 계약)**: 4 라인 (5 추가 - 1 삭제) — Concrete Prediction 분모 외. ADR Amendment §Developer 인계 보강 (이견 수용 / Gemini 개선 제안 2) 이 명시한 추가 변경:
  > **추가 단계 (mjs 작성/수정 시)**: `apps/web/scripts/r1-ui-regression-guard.mjs` 헤더 주석에 환경변수 계약 명시 — `BASE_URL` (기본 `http://localhost:3000`, CI 에서 `http://localhost:3001` 등 오버라이드 가능), `SKIP_LOCAL=1` (선택사항, macOS darwin 한정 즉시 PASS)

결론: ADR Amendment §결정 3 의 Concrete Prediction "≤ 5 라인 (선택적 SKIP_LOCAL 지원 한정)" 의 **선택적 SKIP_LOCAL 한정 분모로는 2 라인 ≤ 5 충족**. 헤더 주석은 ADR Amendment 자체가 별도 추가 변경으로 명시한 영역.

## 위험·미해결

### `pnpm --filter @astro-simulator/web start -p 3001` 동작 검증 (architect 코멘트 §위험·미해결)

- **검증 결과**: ✓ **정상 동작**
- 검증 절차:
  ```bash
  pnpm --filter @astro-simulator/web start -p 3001 &
  WEB_PID=$!
  sleep 6
  curl -sf -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3001/ko
  # → HTTP 200
  kill $WEB_PID
  ```
- 로그 발췌:
  ```
  > @astro-simulator/web@0.13.0 start /Users/seo/project/space/apps/web
  > next start -p 3001
  ▲ Next.js 16.2.3
  - Local:         http://localhost:3001
  ✓ Ready in 147ms
  ```
- 결론: ci.yml 의 `pnpm --filter @astro-simulator/web start -p 3001` 명령 그대로 사용. 대체 명령 (`next start` 직접 호출 등) 필요 없음.

### CI Linux 폰트 패키지

- Playwright `--with-deps chromium` 이 `fonts-noto` 등 기본 폰트 설치하나 CJK 폰트 누락 시 baseline 텍스트 깨짐 가능
- 부트스트래핑 1회 실행 후 자동 생성된 PR 의 baseline 12장 시각 검수 의무 (qa 단계)

### 부트스트래핑 직후 ci.yml 자동 사용

- `peter-evans/create-pull-request` 가 자동 생성한 PR 머지 후 ci.yml 의 r1-guard 가 새 baseline 으로 회귀 검증 → 격차 0 검증 필요 (qa 단계)

## Test plan

### 1. 로컬 (이미 완료)

- [x] typecheck PASS / build PASS / 단위 테스트 441 PASS (web 138 + core 299 + shared 4)
- [x] YAML 파싱 OK (`r1-baseline-bootstrap.yml` + `ci.yml`)
- [x] agent SSoT drift 없음 (`scripts/verify-agent-ssot.sh`)
- [x] U+FFFD (한글 깨짐) 없음
- [x] `pnpm --filter @astro-simulator/web start -p 3001` HTTP 200
- [x] `SKIP_LOCAL=1` + macOS 즉시 PASS (exit 0)

### 2. 본 PR 머지 후 부트스트래핑 절차 (volt #45 회피, ADR Amendment §Developer 인계 4)

- [ ] (a) 본 PR `feature/337-r1-ci-linux-baseline-design` 머지 (workflow 파일 develop 반영)
- [ ] (b) develop → main release PR 또는 develop 자체에서 직접 dispatch (default branch 종속)
- [ ] (c) GitHub Actions UI → "r1:baseline-bootstrap" → "Run workflow" → develop 대상 dispatch
- [ ] (d) workflow 가 자동 생성한 baseline 갱신 PR 머지 (Linux 캡처 12장이 macOS 12장 교체)
- [ ] (e) 임의 PR 에서 `ci.yml` 의 r1-guard step 이 PASS 하는지 실증
- [ ] (f) **메타 가드** — 고의적 false positive PR (예: shortcut 라벨 1글자 변경) 로 r1-guard 가 실제 fail 하는지 실증 후 revert (메인 ADR §결과·재검토 조건)

### 3. 사전 조건 검증 (이미 완료)

- [x] `gh api repos/coseo12/astro-simulator/actions/permissions/workflow` → `can_approve_pull_request_reviews: true`
- [x] `default_workflow_permissions: read` — workflow 자체에 `permissions:` 블록 명시로 elevate

## 참조

- ADR: [`docs/decisions/20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26](docs/decisions/20260425-r1-ui-pixel-diff-guard.md#amendment-2026-04-26--ci-linux-통합-정책-결정-337)
- Architect 코멘트: https://github.com/coseo12/astro-simulator/issues/337#issuecomment-...
- 패턴 참조: `.github/workflows/bench-baseline-remeasure.yml` (workflow_dispatch + create-pull-request)
- 교훈: volt #45 (workflow_dispatch 2단계 함정), volt #48 (CI 통과 ≠ 테스트 실행)

Tracks: #337