### PR TITLE
chore(release): v0.13.1 — R1 후속 F-1 (#337) 부트스트래핑 인프라

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.13.1] — 2026-04-26
+
+> **R1 후속 F-1 (#337) 부트스트래핑 인프라 단독 릴리스** — `r1:baseline-bootstrap` workflow 를 default branch (`main`) 에 도달시켜 `workflow_dispatch` 트리거 가능 상태로 진입 (volt #45 함정 회피). 행동 변화는 `SKIP_LOCAL=1` 1건 + 워크플로 신규. R1 후속 F-2 (#348) 는 본 릴리스 머지 + dispatch + baseline 갱신 PR 머지 후 별도 진입 (chicken-and-egg).
+
 ### Behavior Changes
 
-- **R1 UI 회귀 가드 baseline CI Linux 전환 인프라 — 부트스트래핑 단계** ([#337](https://github.com/coseo12/astro-simulator/issues/337)) — `.github/workflows/r1-baseline-bootstrap.yml` (`workflow_dispatch`, ubuntu-latest 캡처 + `peter-evans/create-pull-request`) 신규. `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화: `BASE_URL` 환경변수 계약 헤더 주석 박제 + `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 (6 라인 변경). `r1-ui-regions.mjs` 0 라인 변경. baseline 12 PNG 는 본 PR 머지 후 `r1:baseline-bootstrap` workflow_dispatch 1회 실행으로 자동 갱신 PR 생성 (Linux 캡처본 교체). 로컬 macOS 검증 시 폰트 차이 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰. **`ci.yml` 의 r1-guard step 통합은 본 PR 비-범위** — chicken-and-egg 회피 (Linux baseline 갱신 PR 머지 후 별도 후속 PR 에서 통합. `pnpm build` 가 detect-and-test job 에 없는 wasm-pack 의존을 끌어오는 추가 위험도 후속 PR 에서 wasm-pack 설치 step 분리로 해소). ADR `20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26
+- **R1 UI 회귀 가드 baseline CI Linux 전환 인프라 — 부트스트래핑 단계** ([#337](https://github.com/coseo12/astro-simulator/issues/337), PR [#347](https://github.com/coseo12/astro-simulator/pull/347)) — `.github/workflows/r1-baseline-bootstrap.yml` (`workflow_dispatch`, ubuntu-latest 캡처 + `peter-evans/create-pull-request`) 신규. `apps/web/scripts/r1-ui-regression-guard.mjs` 매개변수화: `BASE_URL` 환경변수 계약 헤더 주석 박제 + `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 (6 라인 변경). `r1-ui-regions.mjs` 0 라인 변경. baseline 12 PNG 는 본 릴리스 머지 후 `r1:baseline-bootstrap` workflow_dispatch 1회 실행으로 자동 갱신 PR 생성 (Linux 캡처본 교체). 로컬 macOS 검증 시 폰트 차이 false positive 가능 — `SKIP_LOCAL=1` env var 또는 CI 결과 신뢰. **`ci.yml` 의 r1-guard step 통합은 본 PR 비-범위** — chicken-and-egg 회피 (Linux baseline 갱신 PR 머지 후 별도 후속 PR 에서 통합. `pnpm build` 가 detect-and-test job 에 없는 wasm-pack 의존을 끌어오는 추가 위험도 후속 PR 에서 wasm-pack 설치 step 분리로 해소). ADR `20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26
 
 ## [0.13.0] — 2026-04-26
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/physics-wasm",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/shared",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "Shared types, constants, and event definitions for astro-simulator",
   "type": "module",


### PR DESCRIPTION
## Summary

- **CHANGELOG promote**: [Unreleased] → [0.13.1] — 2026-04-26
- **5 워크스페이스 package.json bump**: 0.13.0 → 0.13.1
- **분류**: PATCH — CI 인프라 + 스크립트 매개변수화. 행동 변화는 `SKIP_LOCAL=1 + macOS darwin` 즉시 PASS 종료 1건뿐
- **단일 목적**: `r1-baseline-bootstrap.yml` workflow 를 default branch (`main`) 에 도달시켜 `workflow_dispatch` 트리거 가능 상태로 진입 (volt #45 함정 회피)

## Behavior Changes

`SKIP_LOCAL=1` 환경변수로 macOS darwin 에서 r1-ui-regression-guard.mjs 즉시 PASS 종료. 그 외 모든 변경은 신규 워크플로 / 매개변수화된 환경변수 계약 / 신규 ADR 로 기존 동작 영향 없음.

## Procedure (이 PR 머지 → develop tip → release PR → main → tag → dispatch)

1. ✅ **본 PR (chore/release-v0.13.1 → develop)** — CHANGELOG promote + package version bump
2. ⏳ **release PR (develop → main, `--merge` 방식)** — gitflow 정석. squash 금지
3. ⏳ `git push origin main:develop` (fast-forward 동기화)
4. ⏳ `git tag v0.13.1 && gh release create v0.13.1`
5. ⏳ Actions UI → `r1:baseline-bootstrap` → Run workflow (target_branch=develop)
6. ⏳ 자동 생성된 baseline 갱신 PR (Linux 캡처 12장) 검토 + 머지
7. ⏳ #337 close + #348 architect ADR 진입 (chicken-and-egg 해소)

## Test plan

- [ ] CI `detect-and-test` PASS
- [ ] U+FFFD 0건 (CHANGELOG 한국어 promote)
- [ ] 머지 후 develop 의 워크플로 파일과 일치 (drift 없음)
- [ ] 본 PR 의 변경 6 파일 외 누락 없음 (volt #13 lint-staged 가드)

## 사전 점검 결과 (반영 완료)

- `default_workflow_permissions`: `read` → `write` (peter-evans/create-pull-request 권한 보강)
- `can_approve_pull_request_reviews`: `true` ✅

## Refs

- 후속 단계 추적: #337 (F-1) / #348 (F-2)
- ADR: `docs/decisions/20260425-r1-ui-pixel-diff-guard.md` §Amendment 2026-04-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)