### PR TITLE
[#348] R1 후속 F-2 ci.yml r1-guard step 5개 통합 — wasm-pack + r1-guard + diff upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,58 @@ jobs:
         if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('scripts/verify-no-scientific-grep.mjs') != ''
         run: pnpm run --if-present verify:no-scientific-grep
 
+      # ============================================================
+      # R1 UI 회귀 가드 — wasm-pack + Playwright + pixel diff
+      # ============================================================
+      # ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment v3 2026-04-26
+      # 의존성:
+      #   - physics-wasm 워크스페이스 → wasm-pack (root recursive `pnpm build` 트리거)
+      #   - apps/web → next start (Playwright BASE_URL 타깃)
+      #   - apps/web/scripts/__baselines__/r1/ Linux 캡처본 12장 (PR #351 머지 후 정합)
+
+      - name: Rust 툴체인 설정 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != '' && hashFiles('rust-toolchain.toml') != ''
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: R1 UI 회귀 가드 (r1-guard)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != ''
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          pnpm build
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          WEB_PID=$!
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+          BASE_URL=http://localhost:3001 node apps/web/scripts/r1-ui-regression-guard.mjs
+          GUARD_EXIT=$?
+          kill $WEB_PID || true
+          exit $GUARD_EXIT
+
+      - name: R1 diff 이미지 업로드 (실패 시)
+        if: failure() && hashFiles('apps/web/scripts/__diff__/r1/**/*.png') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: r1-pixel-diff-${{ github.run_id }}
+          path: apps/web/scripts/__diff__/r1/
+          retention-days: 7
+
       # --- yarn 경로 (pnpm-lock 없을 때만) ---
       # yarn berry (v2+) vs classic (v1) 감지:
       # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)


### PR DESCRIPTION
## Summary

R1 후속 F-2 (#348) — `.github/workflows/ci.yml` `detect-and-test` job 에 R1 UI 회귀 가드 step 5개를 통합. ADR `docs/decisions/20260425-r1-ui-pixel-diff-guard.md` §Amendment v3 의 결정 yaml 매트릭스를 그대로 채택.

- **wasm-pack 후보 A 채택** — `dtolnay/rust-toolchain` + `Swatinem/rust-cache` + `taiki-e/install-action wasm-pack@0.14.0` 3 step (verify-and-rust + r1-baseline-bootstrap workflow 동일 패턴 재사용 — workflow_dispatch run [`24956759573`](https://github.com/coseo12/astro-simulator/actions/runs/24956759573) 2m1s 완주로 검증)
- **step 위치** — `verify:no-scientific-grep` step (line 60) 직후 (R1 회귀 가드 그룹화)
- **이슈 #348 본문 yaml 대비 보강** — `if:` 가드에 `rust-toolchain.toml` / `packages/physics-wasm/Cargo.toml` 검사 / `pnpm build` 보존 / `exit \$GUARD_EXIT` 명시

## ADR 참조

- 본 PR 의 박제 근거: [`docs/decisions/20260425-r1-ui-pixel-diff-guard.md`](../blob/develop/docs/decisions/20260425-r1-ui-pixel-diff-guard.md) §Amendment v3 2026-04-26 (commit `9481c9d`, PR #354)
- Builds on: #347 (workflow + mjs 매개변수화), #351 (Linux baseline 12 PNG 갱신), #354 (ADR Amendment v3)

## Concrete Prediction 검증 (architect ADR)

ADR §"Concrete Prediction (보수)" 항목:

| 예측 | 실측 | 결과 |
|---|---|---|
| ci.yml +35~40 라인 | **+52 라인** | △ 약간 초과 (그룹 헤더 주석 6줄 + 5 step 풀 형태 yaml 인라인) |
| 다른 파일 0 라인 | **0 파일 (ci.yml 단일)** | ✓ PASS |
| 다음 R-Phase 회귀 가드 추가 시 step 매트릭스 변경 ≤ 2 라인 | (R2 도입 시점 검증) | (deferred) |

```
$ git diff origin/develop..HEAD --stat
 .github/workflows/ci.yml | 52 ++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 52 insertions(+)
```

라인 수 약간 초과 사유: ADR yaml 본문이 그룹 헤더 주석 6줄 (R1 UI 회귀 가드 / 의존성 / physics-wasm / apps/web / Linux baseline) 을 포함하고, 5 step 모두 (Rust toolchain `with: { toolchain, targets }` + Rust cache `with: { workspaces }` + wasm-pack `with: { tool }` + r1-guard 13줄 run script + diff upload `with: { name, path, retention-days }`) 를 채택. 파일 수 0 / 단일 파일 변경 의도는 정확히 충족.

## Test Plan

- [x] 분기점 검증 — `feature/348-r1-guard-ci-step-integration` 가 `origin/develop` tip (`9481c9d`) 에서 분기 (CLAUDE.md sub-agent stale 분기 회피)
- [x] YAML syntax — `python3 yaml.safe_load` PASS
- [x] 한글 인코딩 — `grep -c '�' .github/workflows/ci.yml` → 0
- [x] 단일 파일 변경 — `git diff --stat` 1 file
- [ ] **본 PR 의 CI 자체가 r1-guard step 을 실행** — pass 시 자가 검증 (Linux baseline 12 PNG 정합 상태에서 `pnpm build` + `pnpm start -p 3001` + `r1-ui-regression-guard.mjs` 실행 결과로 확정)
- [ ] **detect-and-test job 시간 측정** — ADR §위험 #1 의 8분 잠정 임계 도입 (초과 시 후보 B 별도 job 분리 ADR)

> **자가 검증 한계 박제**: 본 PR check 가 PASS 해도 "고의적 false positive 변경이 r1-guard 를 fail 시키는지" 의 메타 가드 실증은 별도 후속 PR (메인 오케스트레이터 처리) 에서 수행. 본 PR PASS 는 **negative control** (정상 PR 이 r1-guard 통과) 만 확보.

## 비-범위 (CRITICAL #6)

- 메타 가드 실증 PR 직접 생성 (별도 draft PR — 메인 오케스트레이터 처리)
- pixel diff 임계값 (0.5%) 변경 (별도 amendment)
- 다른 R-Phase (R2~R10) baseline 캡처
- macOS 개발 환경 폐기
- `r1-ui-regression-guard.mjs` / `r1-ui-regions.mjs` / `package.json` / `pnpm-lock.yaml` / baseline 12 PNG — 0 변경 (ADR Concrete Prediction 검증 대상)
- 후보 B (별도 job 분리) — ADR §위험 #1 재검토 트리거 충족 시 분리 ADR

## Behavior Changes

- R1 UI 회귀 가드가 모든 PR `detect-and-test` job 에서 자동 실행됨 — Linux baseline 12 PNG 대비 mismatch ratio ≤ 0.5% 검증, fail 시 diff 이미지 7일 보존 (artifact `r1-pixel-diff-<run_id>`)
- detect-and-test job 시간 ~5~8분 예상 (wasm-pack ~30s cold/~5s warm + Playwright ~60s + `pnpm build` ~30s + 웹 서버 + r1-guard ~30s 누적). ADR §위험 #1 임계 8분 모니터링 시작
- 로컬 macOS 검증 시 폰트 차이 false positive 회피 — `SKIP_LOCAL=1 node apps/web/scripts/r1-ui-regression-guard.mjs` (PR #347 머지로 도입)

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)