### PR TITLE
[#348] r1-guard positive control — 메타 가드 실증 (DRAFT, close 예정)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,58 @@ jobs:
         if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('scripts/verify-no-scientific-grep.mjs') != ''
         run: pnpm run --if-present verify:no-scientific-grep
 
+      # ============================================================
+      # R1 UI 회귀 가드 — wasm-pack + Playwright + pixel diff
+      # ============================================================
+      # ADR: docs/decisions/20260425-r1-ui-pixel-diff-guard.md §Amendment v3 2026-04-26
+      # 의존성:
+      #   - physics-wasm 워크스페이스 → wasm-pack (root recursive `pnpm build` 트리거)
+      #   - apps/web → next start (Playwright BASE_URL 타깃)
+      #   - apps/web/scripts/__baselines__/r1/ Linux 캡처본 12장 (PR #351 머지 후 정합)
+
+      - name: Rust 툴체인 설정 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != '' && hashFiles('rust-toolchain.toml') != ''
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치 (R1 r1-guard 의존)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('packages/physics-wasm/Cargo.toml') != ''
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: R1 UI 회귀 가드 (r1-guard)
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/r1-ui-regression-guard.mjs') != ''
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          pnpm build
+          pnpm --filter @astro-simulator/web start -p 3001 &
+          WEB_PID=$!
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ko > /dev/null; then break; fi
+            sleep 2
+          done
+          BASE_URL=http://localhost:3001 node apps/web/scripts/r1-ui-regression-guard.mjs
+          GUARD_EXIT=$?
+          kill $WEB_PID || true
+          exit $GUARD_EXIT
+
+      - name: R1 diff 이미지 업로드 (실패 시)
+        if: failure() && hashFiles('apps/web/scripts/__diff__/r1/**/*.png') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: r1-pixel-diff-${{ github.run_id }}
+          path: apps/web/scripts/__diff__/r1/
+          retention-days: 7
+
       # --- yarn 경로 (pnpm-lock 없을 때만) ---
       # yarn berry (v2+) vs classic (v1) 감지:
       # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)

--- a/apps/web/src/components/layout/focus-quick-buttons.tsx
+++ b/apps/web/src/components/layout/focus-quick-buttons.tsx
@@ -4,7 +4,7 @@ import { useSimStore } from '@/store/sim-store';
 import { useSimCommand } from '@/core/sim-context';
 
 const FOCUS_BUTTONS = [
-  { id: 'sun', label: '태양' },
+  { id: 'sun', label: '태앙' },
   { id: 'earth', label: '지구' },
   { id: 'jupiter', label: '목성' },
   { id: 'neptune', label: '해왕성' },


### PR DESCRIPTION
## 목적 — 메타 가드 실증 (positive control)

**머지 의도 없음** — r1-guard fail 확인 후 close (revert 아님, close 만).

ADR [`docs/decisions/20260425-r1-ui-pixel-diff-guard.md`](https://github.com/coseo12/astro-simulator/blob/feature/348-r1-guard-ci-step-integration/docs/decisions/20260425-r1-ui-pixel-diff-guard.md) §메타 가드 실증 절차 박제 — 권고 (a) shortcut 라벨 1글자 변경.

## 변경 요약

- `apps/web/src/components/layout/focus-quick-buttons.tsx`: `{ id: 'sun', label: '태양' }` → `{ id: 'sun', label: '태앙' }` (1글자)
- DOM 구조 보존, 순수 텍스트 회귀 시그널

## 검증 항목 (r1-guard 가 fail 해야 PASS)

PR #355 (`feature/348-r1-guard-ci-step-integration`) 의 ci.yml `R1 UI 회귀 가드 (r1-guard)` step 이:

1. **`shortcut-bar.png` 영역에서 mismatch ≥ 0.5%** 검출
2. step exit 1 (fail) 종료
3. `R1 diff 이미지 업로드 (실패 시)` step trigger → artifact `r1-pixel-diff-<run_id>` 업로드

## 비-목표

- 머지 (반드시 close)
- baseline 재생성
- 임계값 변경

## 후속

- r1-guard fail 확인 → 본 draft PR close → ADR §결과·재검토 조건 메타 가드 항목 + Amendment 1 §Developer 인계 (e) 충족 박제 (PR #355 코멘트로 박제)
- r1-guard 가 PASS 시 (false negative) → ADR 위험 #5 + 재검토 트리거 #4 발동 → 임계값 / 영역 정의 amendment 후속 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)