### PR TITLE
chore(release): v0.15.0 prep — CHANGELOG 헤더 변환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
-> **R2 사이클 (2026-04-28~)** — Roadmap v3 "Incremental Body-by-Body Build" 두 번째 스프린트. 태양 단독 visible (R1) 위에 **수성** 점진 추가. R1 박제 인프라 (BODY_SCALE 룩업 / FOCUS_BUTTONS / focus sync / rebuildOrbitLines / r1-guard 매트릭스) 100% 재사용. `mercury: 8500` BODY_SCALE 1줄 + `FOCUS_BUTTONS` 1줄 = R1 §결과 Concrete Prediction "R2 코드 변경 ≤ 3 라인" 자연 검증.
+## [0.15.0] — 2026-04-28
+
+> **R2 사이클 (2026-04-28)** — Roadmap v3 "Incremental Body-by-Body Build" 두 번째 스프린트. 태양 단독 visible (R1, v0.14.0) 위에 **수성** 점진 추가. R1 박제 인프라 (BODY_SCALE 룩업 / FOCUS_BUTTONS / focus sync / rebuildOrbitLines / r1-guard 매트릭스) 100% 재사용. `mercury: 8500` BODY_SCALE 1줄 + `FOCUS_BUTTONS` 1줄 = R1 §결과 Concrete Prediction "R2 코드 변경 ≤ 3 라인" 자연 검증. PR [#363](https://github.com/coseo12/astro-simulator/pull/363) (R2 anchor) + [#365](https://github.com/coseo12/astro-simulator/pull/365) (baseline 갱신 + Amendment v4 정정) + [#366](https://github.com/coseo12/astro-simulator/pull/366) (agent-browser 가드 — volt #79).
 
 ### Behavior Changes
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/physics-wasm/package.json
+++ b/packages/physics-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/physics-wasm",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Newton N-body WASM 코어 (Rust + wasm-pack)",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/shared",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Shared types, constants, and event definitions for astro-simulator",
   "type": "module",


### PR DESCRIPTION
## 요약

v0.15.0 release prep. CHANGELOG.md 의 \`## [Unreleased]\` (R2 사이클 + R2 후속 누적) → \`## [0.15.0] — 2026-04-28\` 헤더 변환 + 빈 \`## [Unreleased]\` 추가 (다음 사이클용).

본 PR 머지 후 develop → main release PR 으로 이어진다.

## 분류

- **SemVer MINOR** (0.14.0 → 0.15.0)
- 행동 변화: 수성 body 추가 (mercuryScale=8500) + shortcut bar 5 항목 + R2 focus race 가드 + agent-browser 가드 (volt #79)

## 누적 PR (R2 사이클 + R2 후속)

- [#363](https://github.com/coseo12/astro-simulator/pull/363) — R2 anchor (mercuryScale + shortcut + r2-focus-race-guard)
- [#365](https://github.com/coseo12/astro-simulator/pull/365) — R2 후속 baseline 갱신 + Amendment v4 정정
- [#366](https://github.com/coseo12/astro-simulator/pull/366) — agent-browser cleanup 가드 (volt #79)

## 변경

- \`CHANGELOG.md\`: \`## [Unreleased]\` 빈 블록 유지 + \`## [0.15.0] — 2026-04-28\` 신규 헤더 박제 (변경 라인 +3 / -1)

## 검증

- [x] U+FFFD 0건
- [x] 헤더 순서 정합 ([Unreleased] / [0.15.0] / [0.14.0] / ...)
- [ ] CI green (build / test / lint)
- [ ] reviewer (small docs only — qa 생략 옵션 3)
- [ ] 머지 후 release PR (develop → main) 생성

## 다음 단계

1. 본 PR 머지 → develop 갱신
2. develop → main release PR 생성 (base=main, head=develop, 본문에 v0.15.0 + tag 계획)
3. release PR \`--merge\` 머지 (\`--squash\` 금지)
4. \`git push origin main:develop\` fast-forward
5. \`git tag v0.15.0\` + \`gh release create\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)