### PR TITLE
feat(dev-overlay): [#388] LOD dev overlay 상세 모드 + getLodInfo API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+### Behavior Changes
+
+- **LOD dev overlay 상세 모드 (`?lodOverlay=1`)** ([#388](https://github.com/coseo12/astro-simulator/issues/388)) — body 별 LOD level + screenCoverage(px) + pxDiameter(px) + cameraDistance(km) 4 column 표 박제. 색상 코딩 (high=emerald / mid=amber / low=rose) + `data-lod-level` 속성. 기존 `?debug=draw-calls` 집계 모드는 backwards-compat 으로 유지 (단일 행 H/M/L 분포 박제). **prod bundle DCE 검증**: `LodDevOverlay` 함수 진입 즉시 `if (production) return null` 으로 본체 (`useState`/`useEffect`/JSX) 전체 제거 — `LodDevOverlayImpl` 분리로 hooks 의존 그래프와 prod 분기 격리. `grep -rln "lod-row-\|waiting for first frame" .next/static/` 0 매치 실측. 발화점: PR [#387](https://github.com/coseo12/astro-simulator/pull/387) ([#379] architect 단계) Gemini cross-validate 고유 발견 분리 — `docs/decisions/20260502-379-fix-decision.md` Phase 1 (screenCoverage 식 정정) 디버깅 도구
+- **`SolarSystemSceneHandles.getLodInfo()` API 추가** ([#388](https://github.com/coseo12/astro-simulator/issues/388)) — `runLodPass` 매 프레임 갱신. 반환 시그니처 `readonly LodBodyInfo[]` (`id` / `level` / `screenCoverage` / `pxDiameter` / `cameraDistanceMeters`). 내부 버퍼 in-place mutate (재할당 회피, 매 프레임 24+ body × 5 필드 = 120+ assignment). 호출자는 read-only 계약 — mutate 금지. PR #387 reviewer non-blocking #1 (forensic `actualCameraRadius` 일률 35 cell 별 변별) + #2 (`bodyInfo.pixelDiameter` null) 직접 해소 가능 — overlay 가 raw 박제하면 forensic 측정 시 cell 별 차이가 드러남
+
+### Notes
+
+- **LOD overlay tree-shaking 검증 절차** — prod build 후 `grep -rln "lod-row-\|waiting for first frame\|isDetailedOverlayEnabled" apps/web/.next/static/chunks/` 가 0 매치여야 한다. `LodDevOverlay` 의 prod early-return 패턴은 컴포넌트 본체 분리 (`LodDevOverlayImpl`) 가 필수 — 단일 함수 내 hooks 와 prod 분기 공존 시 minifier 가 보수적 회피하여 hooks 의존 그래프 보존, dead branch JSX 가 잔존 (실측 1차 시도에서 발견)
+- **`getLodInfo` core API 는 prod bundle 에 포함됨** — `LodBodyInfo` 인터페이스 + `runLodPass` 의 buffer in-place mutation (~30 라인) 은 packages/core scene 정상 API 의 일부로 prod 에서도 호출 가능. dev overlay 만 prod 에서 호출하지 않을 뿐. bundle size 영향 약 +1KB minified (버퍼 mutation 코드만, JSX 0)
+- **`__solarScene.getLodInfo` 후방 호환** — 구버전 scene (P11-B v0.13.0~v0.15.0) 에는 `getLodInfo` 부재. dev overlay 가 optional chaining 으로 가드 — `getLodInfo` 미존재 시 `waiting for first frame` 메시지 유지 (#388 vitest 회귀 가드)
+
 > **R3 D-T2 후속 — body 비율 자연화 (2026-05-01, #373 라운드 2 적극 재조정)** — 어제 (2026-04-30) D-T2 사용자 검증 5건 회귀 발견 중 **#1 (sun ↔ mercury / venus 비율 미해소)** 만 본 PR 범위. #378/#379/#380 (회귀 #2~#4) 은 별도 이슈 분리. 선행 PR [#377](https://github.com/coseo12/astro-simulator/pull/377) (옵션 c 보수값 mercury=2000 / venus=1500) D-T2 미통과 → CLOSED → 라운드 2 적극값 (임계 비례 역산 mercury=900 / venus=650) 채택. forensic ADR [`docs/decisions/20260430-r3-followup-body-proportion.md`](docs/decisions/20260430-r3-followup-body-proportion.md) Amendment 2026-05-01 (라운드 2) SSoT.
 
 ### Behavior Changes

--- a/apps/web/src/components/layout/lod-dev-overlay.test.tsx
+++ b/apps/web/src/components/layout/lod-dev-overlay.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * LOD dev overlay 회귀 가드 (#388)
+ *
+ * 검증 대상:
+ *  - URL 파라미터 부재 시 컴포넌트 미노출 (DCE 외 런타임 가드)
+ *  - `?debug=draw-calls` (집계 모드) 정상 표시 — 기존 P11-B 워크플로 회귀 0 보장
+ *  - `?lodOverlay=1` (상세 모드) — body 별 LOD/coverage/pxDiameter 표시 + 색상 코딩
+ *  - prod 빌드 가드는 `process.env.NODE_ENV` 리터럴 치환에 의존 — vitest 환경에선 dev 경로 검증
+ *
+ * `__solarScene` 글로벌은 sim-canvas 가 dev 빌드에서 노출. 본 테스트는 그 mock 을 직접 주입.
+ */
+import { render, screen, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LodDevOverlay } from './lod-dev-overlay';
+
+// `vi.useFakeTimers` 로 `setInterval` 1초 tick 을 즉시 실행 가능하게 함.
+// 컴포넌트는 mount 후 첫 tick 에서 stats/info 수집.
+
+interface MockBodyInfo {
+  id: string;
+  level: 'high' | 'mid' | 'low';
+  screenCoverage: number;
+  pxDiameter: number;
+  cameraDistanceMeters: number;
+}
+
+function setSearch(params: string) {
+  // jsdom URL 변경 — `URLSearchParams(window.location.search)` 가 정확히 읽도록.
+  window.history.replaceState({}, '', `/?${params}`);
+}
+
+function installScene(opts: {
+  stats?: { high: number; mid: number; low: number; override: 'auto' | 'high' | 'mid' | 'low' };
+  info?: MockBodyInfo[];
+}) {
+  Object.defineProperty(window, '__solarScene', {
+    configurable: true,
+    writable: true,
+    value: {
+      getLodStats: () => opts.stats ?? { high: 1, mid: 0, low: 23, override: 'auto' as const },
+      getLodInfo: () => opts.info ?? [],
+    },
+  });
+}
+
+function clearScene() {
+  // jsdom 에서 configurable 객체 제거.
+  delete (window as unknown as { __solarScene?: unknown }).__solarScene;
+}
+
+describe('LodDevOverlay (#388)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setSearch('');
+    clearScene();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearScene();
+  });
+
+  it('URL 파라미터 부재 시 렌더링 안 함', () => {
+    installScene({});
+    const { container } = render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('`?debug=draw-calls` (집계 모드) — H/M/L 분포 박제', () => {
+    setSearch('debug=draw-calls');
+    installScene({
+      stats: { high: 5, mid: 3, low: 16, override: 'auto' },
+    });
+    render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    const overlay = screen.getByTestId('lod-dev-overlay');
+    expect(overlay).toHaveTextContent('total 24');
+    expect(overlay).toHaveTextContent('H:5');
+    expect(overlay).toHaveTextContent('M:3');
+    expect(overlay).toHaveTextContent('L:16');
+    expect(overlay).toHaveTextContent('(auto)');
+    // 집계 모드는 detailed 마커 없음.
+    expect(overlay).not.toHaveAttribute('data-overlay-mode', 'detailed');
+  });
+
+  it('`?lodOverlay=1` (상세 모드) — body 별 LOD/coverage/pxDiameter 행 박제', () => {
+    setSearch('lodOverlay=1');
+    installScene({
+      stats: { high: 1, mid: 1, low: 1, override: 'auto' },
+      info: [
+        {
+          id: 'sun',
+          level: 'high',
+          screenCoverage: 71.5,
+          pxDiameter: 143.0,
+          cameraDistanceMeters: 1.5e11,
+        },
+        {
+          id: 'mercury',
+          level: 'mid',
+          screenCoverage: 12.3,
+          pxDiameter: 24.6,
+          cameraDistanceMeters: 5.79e10,
+        },
+        {
+          id: 'venus',
+          level: 'low',
+          screenCoverage: 4.0,
+          pxDiameter: 8.0,
+          cameraDistanceMeters: 1.08e11,
+        },
+      ],
+    });
+    render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    const overlay = screen.getByTestId('lod-dev-overlay');
+    expect(overlay).toHaveAttribute('data-overlay-mode', 'detailed');
+
+    // 헤더 행 (집계).
+    expect(overlay).toHaveTextContent('total 3');
+
+    // body 별 행 검증 — DoD-3.
+    const sunRow = screen.getByTestId('lod-row-sun');
+    expect(sunRow).toHaveAttribute('data-lod-level', 'high');
+    expect(sunRow).toHaveTextContent('sun');
+    expect(sunRow).toHaveTextContent('71.50');
+    expect(sunRow).toHaveTextContent('143.00');
+
+    const mercuryRow = screen.getByTestId('lod-row-mercury');
+    expect(mercuryRow).toHaveAttribute('data-lod-level', 'mid');
+
+    const venusRow = screen.getByTestId('lod-row-venus');
+    expect(venusRow).toHaveAttribute('data-lod-level', 'low');
+  });
+
+  it('상세 모드 — `getLodInfo` 빈 배열 시 waiting 메시지', () => {
+    setSearch('lodOverlay=1');
+    installScene({
+      stats: { high: 0, mid: 0, low: 0, override: 'auto' },
+      info: [],
+    });
+    render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(screen.getByTestId('lod-dev-overlay-empty')).toBeInTheDocument();
+  });
+
+  it('상세 모드 — LOD level 별 색상 클래스 부여 (DoD-4)', () => {
+    setSearch('lodOverlay=1');
+    installScene({
+      stats: { high: 1, mid: 1, low: 1, override: 'auto' },
+      info: [
+        {
+          id: 'sun',
+          level: 'high',
+          screenCoverage: 71.5,
+          pxDiameter: 143.0,
+          cameraDistanceMeters: 1.5e11,
+        },
+        {
+          id: 'mercury',
+          level: 'mid',
+          screenCoverage: 12.3,
+          pxDiameter: 24.6,
+          cameraDistanceMeters: 5.79e10,
+        },
+        {
+          id: 'venus',
+          level: 'low',
+          screenCoverage: 4.0,
+          pxDiameter: 8.0,
+          cameraDistanceMeters: 1.08e11,
+        },
+      ],
+    });
+    render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    // tailwind 클래스로 색상 박제 — high=emerald / mid=amber / low=rose.
+    expect(screen.getByTestId('lod-row-sun').querySelector('.text-emerald-400')).not.toBeNull();
+    expect(screen.getByTestId('lod-row-mercury').querySelector('.text-amber-400')).not.toBeNull();
+    expect(screen.getByTestId('lod-row-venus').querySelector('.text-rose-400')).not.toBeNull();
+  });
+
+  it('상세 모드 — `getLodInfo` 미존재 (구버전 scene) 시 waiting 메시지 유지', () => {
+    setSearch('lodOverlay=1');
+    // getLodInfo 부재 — 구버전 scene 시뮬레이션.
+    Object.defineProperty(window, '__solarScene', {
+      configurable: true,
+      writable: true,
+      value: {
+        getLodStats: () => ({ high: 1, mid: 0, low: 0, override: 'auto' as const }),
+        // getLodInfo 의도적 부재.
+      },
+    });
+    render(<LodDevOverlay />);
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    expect(screen.getByTestId('lod-dev-overlay-empty')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/lod-dev-overlay.tsx
+++ b/apps/web/src/components/layout/lod-dev-overlay.tsx
@@ -1,24 +1,32 @@
 'use client';
 
 /**
- * P11-B #289 — LOD dev overlay
+ * LOD dev overlay — 두 모드 지원
  *
- * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §결정 §6
+ * 1. **집계 모드** (P11-B #289 — `?debug=draw-calls`)
+ *    LOD H/M/L 분포 1줄 박제. backwards-compat 으로 유지 (이전 사용자/QA 워크플로 보존).
  *
- * draw call 분포를 시각화해 LOD 동작을 런타임 관찰 가능하게 한다.
+ * 2. **상세 모드** (#388 — `?lodOverlay=1`)
+ *    body 별 LOD level / screenCoverage / pxDiameter / cameraDistance 표 박제.
+ *    PR #387 cross-validate Gemini 고유 발견 분리 — #379 Phase 1 (screenCoverage 식 정정) 디버깅 도구.
  *
- * 활성 조건:
- *  - `process.env.NODE_ENV !== 'production'` (prod 빌드에서 DCE)
- *  - URL `?debug=draw-calls` 옵트인 (dev 에서도 기본 숨김, 필요할 때만 활성)
+ *    reviewer 권고 직접 해소:
+ *      - non-blocking #1: forensic `actualCameraRadius` 일률 35 → cell 별 변별 가능
+ *      - non-blocking #2: `bodyInfo.pixelDiameter` null → raw 박제 + 일관성 검증 가능
  *
- * 표시 형식: `LOD H:12 M:8 L:72 (auto)` — LOD 별 body 수 + override 상태
+ * ADR: `docs/decisions/20260424-p11-b-lod-design.md` §결정 §6 (집계 모드)
+ *      `docs/decisions/20260502-379-fix-decision.md` §Phase 1 (상세 모드 발화점)
  *
- * 갱신: 1초 throttle. 매 프레임 갱신은 LOD 분기 O(N) 대비 과도한 re-render 비용.
+ * 활성 조건 (양 모드 공통):
+ *  - `process.env.NODE_ENV !== 'production'` — prod 빌드에서 컴포넌트 본체 DCE
+ *  - URL 파라미터 (`?debug=draw-calls` 또는 `?lodOverlay=1`) — dev 에서도 기본 숨김
+ *
+ * 갱신: 1초 throttle. 매 프레임 갱신은 24+ body × 4 column re-render 비용 과도.
  */
 import { useEffect, useState } from 'react';
 
-// `window.__solarScene` 는 dev 빌드에서 sim-canvas 가 노출하는 handles (`Object.defineProperty`).
-// LOD 집계는 `getLodStats()` 반환. handles 구조는 solar-system-scene.ts SolarSystemSceneHandles 참조.
+// `window.__solarScene` 는 sim-canvas 가 dev 빌드에서 노출하는 handles (`Object.defineProperty`).
+// 본 컴포넌트가 prod 에서 early-return 으로 제거되므로 prod bundle 에 `__solarScene` 참조도 없음.
 interface LodStats {
   high: number;
   mid: number;
@@ -26,40 +34,171 @@ interface LodStats {
   override: 'high' | 'mid' | 'low' | 'auto';
 }
 
+// #388 — `getLodInfo()` 반환 타입. core 패키지 LodBodyInfo 와 시그니처 정합 (read-only 계약).
+// 직접 import 하지 않는 이유: 본 컴포넌트는 prod 에서 DCE 되며, 타입 import 만으로도
+// type-only 부수효과는 없으나 의존 명시 최소화 + worktree 경계에서 자체 검증 가능 형태 유지.
+interface LodBodyInfo {
+  id: string;
+  level: 'high' | 'mid' | 'low';
+  screenCoverage: number;
+  pxDiameter: number;
+  cameraDistanceMeters: number;
+}
+
 interface SceneHandlesPartial {
   getLodStats?: () => LodStats;
+  getLodInfo?: () => readonly LodBodyInfo[];
 }
 
 const POLL_INTERVAL_MS = 1000;
 
+// LOD level 색상 코딩 — DoD-4 (#388). high=green / mid=yellow / low=red.
+// tailwind 의미 색상 (text-emerald / text-amber / text-rose) 가 디자인 시스템 fg-* 를 거치지 않으므로
+// 색약 사용자에게도 명도 차이가 충분한 saturated tone 사용.
+const LEVEL_COLOR_CLASS: Record<LodBodyInfo['level'], string> = {
+  high: 'text-emerald-400',
+  mid: 'text-amber-400',
+  low: 'text-rose-400',
+};
+
+/**
+ * `?lodOverlay=1` 활성 여부. URL 파싱 1회만 수행 (window.location 변경은 라우트 단위).
+ *
+ * `process.env.NODE_ENV` 가드는 호출자가 처리 (DCE 보장).
+ */
+function isDetailedOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('lodOverlay') === '1';
+}
+
+/**
+ * `?debug=draw-calls` 활성 여부. 기존 P11-B 워크플로 보존.
+ */
+function isAggregateOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('debug') === 'draw-calls';
+}
+
+/**
+ * 본 컴포넌트는 dev/test 환경 한정 — `process.env.NODE_ENV === 'production'` 일 때 함수 진입 즉시
+ * `null` 반환하여 React tree 에서 제거되며, Next.js Turbopack/SWC 가 빌드 시점 리터럴 치환으로
+ * **컴포넌트 본체 (useState / useEffect / JSX) 전체를 DCE** 한다. dev/test 에서는 URL 파라미터에 따라
+ * 집계 모드 (`?debug=draw-calls`) 또는 상세 모드 (`?lodOverlay=1`) 중 하나로 동작.
+ *
+ * **DoD-5 (#388)**: prod bundle 에서 `lod-row-` / `waiting for first frame` 등 detailed-mode JSX
+ * 문자열이 보이지 않아야 한다. 공식 검증: PR 본문의 grep 결과 (`grep -rln "lod-row-"`).
+ */
 export function LodDevOverlay() {
+  // **빌드 시점 DCE 의존 지점** — 본 분기는 Turbopack/SWC 가 `process.env.NODE_ENV` 를 리터럴
+  // (`'production'`) 로 치환하면서 함수 본체 나머지 전체를 unreachable 로 판단해 제거한다.
+  // dev/test 에서만 아래 hooks 가 실행됨.
+  if (process.env.NODE_ENV === 'production') return null;
+  return <LodDevOverlayImpl />;
+}
+
+/**
+ * 실제 hooks/JSX 보유 본체. 별도 함수로 분리한 이유:
+ *
+ *  - 위 `LodDevOverlay` 의 `if (production) return null` 조기 종료가 **컴포넌트 함수 본체 전체 DCE**
+ *    에 직결되어야 한다. hooks (`useState`, `useEffect`) 가 같은 함수에 있으면 minifier 가 dead branch
+ *    제거를 보수적으로 회피할 수 있다 — Hook 의존 그래프 보존이 명시적으로 요청되지 않으면 안전 경로 선택.
+ *  - 본체를 분리하면 `LodDevOverlayImpl` 자체가 `LodDevOverlay` 안에서만 참조되며, top-level 의 prod
+ *    분기 (`'production' === 'production' → return null`) 가 호출 사이트 자체를 제거 → DCE 가 함수
+ *    그래프를 따라 자연스럽게 전파.
+ */
+/**
+ * 초기 모드 결정 — URL 파싱 1회. lazy initializer 형식으로 mount 시점에만 평가하여
+ * `useEffect` 내부 setState 회피 (`react-hooks/set-state-in-effect`).
+ */
+function resolveInitialMode(): 'off' | 'aggregate' | 'detailed' {
+  if (isDetailedOverlayEnabled()) return 'detailed';
+  if (isAggregateOverlayEnabled()) return 'aggregate';
+  return 'off';
+}
+
+function LodDevOverlayImpl() {
   const [stats, setStats] = useState<LodStats | null>(null);
-  const [enabled, setEnabled] = useState(false);
+  const [bodies, setBodies] = useState<readonly LodBodyInfo[]>([]);
+  // mode 는 mount 시 1회 결정 — URL 변경은 페이지 라우팅 단위라 effect 내부 setState 불필요.
+  const [mode] = useState<'off' | 'aggregate' | 'detailed'>(resolveInitialMode);
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'production') return;
     if (typeof window === 'undefined') return;
-    const debugParam = new URLSearchParams(window.location.search).get('debug');
-    if (debugParam !== 'draw-calls') return;
-    setEnabled(true);
+    if (mode === 'off') return;
+
+    const detailed = mode === 'detailed';
+
     const timer = window.setInterval(() => {
       const scene = (window as unknown as { __solarScene?: SceneHandlesPartial }).__solarScene;
-      if (scene?.getLodStats) {
+      if (!scene) return;
+      if (scene.getLodStats) {
         setStats(scene.getLodStats());
       }
+      if (detailed && scene.getLodInfo) {
+        // getLodInfo 반환은 내부 버퍼 — 매 frame in-place mutate 됨.
+        // React state 비교가 새 참조라 판단하도록 shallow copy (배열 스프레드).
+        // 24+ body × 1초 = 초당 24+ 객체 할당, 무시 가능 비용.
+        setBodies([...scene.getLodInfo()]);
+      }
     }, POLL_INTERVAL_MS);
-    return () => window.clearInterval(timer);
-  }, []);
 
-  if (!enabled || !stats) return null;
+    return () => window.clearInterval(timer);
+  }, [mode]);
+
+  if (mode === 'off' || !stats) return null;
 
   const total = stats.high + stats.mid + stats.low;
+
+  // 집계 모드 — 기존 동작 유지 (단일 행 박제).
+  if (mode === 'aggregate') {
+    return (
+      <div
+        data-testid="lod-dev-overlay"
+        className="absolute bottom-36 left-2 text-caption num text-fg-tertiary bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle pointer-events-none"
+      >
+        LOD · total {total} · H:{stats.high} M:{stats.mid} L:{stats.low} ({stats.override})
+      </div>
+    );
+  }
+
+  // 상세 모드 — body 별 LOD raw 데이터 표 박제.
   return (
     <div
       data-testid="lod-dev-overlay"
-      className="absolute bottom-36 left-2 text-caption num text-fg-tertiary bg-bg-surface/70 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle pointer-events-none"
+      data-overlay-mode="detailed"
+      className="absolute bottom-36 left-2 max-h-[60vh] overflow-y-auto text-caption num text-fg-tertiary bg-bg-surface/80 backdrop-blur px-2 py-1 rounded-sm border border-border-subtle pointer-events-none"
     >
-      LOD · total {total} · H:{stats.high} M:{stats.mid} L:{stats.low} ({stats.override})
+      <div className="font-semibold text-fg-secondary pb-1 border-b border-border-subtle mb-1">
+        LOD · total {total} · H:{stats.high} M:{stats.mid} L:{stats.low} ({stats.override})
+      </div>
+      {bodies.length === 0 ? (
+        <div data-testid="lod-dev-overlay-empty" className="text-fg-tertiary italic">
+          waiting for first frame...
+        </div>
+      ) : (
+        <table className="text-[10px] leading-tight">
+          <thead className="text-fg-secondary">
+            <tr>
+              <th className="text-left pr-2">body</th>
+              <th className="text-left pr-2">lod</th>
+              <th className="text-right pr-2">cov(px)</th>
+              <th className="text-right pr-2">dia(px)</th>
+              <th className="text-right">camR(km)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {bodies.map((b) => (
+              <tr key={b.id} data-testid={`lod-row-${b.id}`} data-lod-level={b.level}>
+                <td className="pr-2">{b.id}</td>
+                <td className={`pr-2 font-semibold ${LEVEL_COLOR_CLASS[b.level]}`}>{b.level}</td>
+                <td className="text-right pr-2">{b.screenCoverage.toFixed(2)}</td>
+                <td className="text-right pr-2">{b.pxDiameter.toFixed(2)}</td>
+                <td className="text-right">{(b.cameraDistanceMeters / 1000).toFixed(0)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -194,7 +194,37 @@ export interface SolarSystemSceneHandles {
    * `{ high, mid, low }` 는 각 LOD 단계로 판정된 body 개수. 합은 전체 body 수 (고리/HUD 제외).
    */
   getLodStats: () => { high: number; mid: number; low: number; override: LodOverride };
+  /**
+   * #388 — 마지막 `runLodPass` 에서 결정된 body 별 LOD 상세. dev overlay 시각화 용도.
+   *
+   * 각 항목:
+   *  - `id`: body 식별자 (예: `'sun'`, `'mercury'`)
+   *  - `level`: 결정된 LOD 단계
+   *  - `screenCoverage`: `screenCoverageRadius` 결과 (pixel) — 화면 점유 반지름
+   *  - `pxDiameter`: 시각 직경 추정 (`screenCoverage × 2`, pixel) — 사용자가 보는 크기 직관용
+   *  - `cameraDistanceMeters`: 카메라-body 실세계 거리 (m) — #387 reviewer 권고 #1 의 actualCameraRadius 변별
+   *
+   * 빈 배열 반환 = `runLodPass` 미실행 (씬 초기화 직후 / dev overlay 가 frame 보다 빠르게 polling).
+   * dev/prod 무관 노출 (overlay 컴포넌트가 prod 빌드에서 DCE 되므로 prod bundle 에 호출 코드 없음).
+   *
+   * **재할당 회피**: 반환 배열은 내부 버퍼 (frozen 아님). 호출자가 mutate 하면 안 됨 (read-only 계약).
+   */
+  getLodInfo: () => readonly LodBodyInfo[];
   dispose: () => void;
+}
+
+/**
+ * #388 — body 별 LOD raw 데이터. dev overlay (`lod-dev-overlay.tsx`) 시각화 + 회귀 진단 용도.
+ *
+ * `runLodPass` 가 매 프레임 갱신. `null` 좌표 (frustum 밖) 가 아닌 raw 결정 입력값을 보존하여
+ * #387 reviewer non-blocking #1 (actualCameraRadius 변별) / #2 (pixelDiameter null 박제) 직접 해소.
+ */
+export interface LodBodyInfo {
+  id: string;
+  level: LodLevel;
+  screenCoverage: number;
+  pxDiameter: number;
+  cameraDistanceMeters: number;
 }
 
 export type PhysicsEngineKind = 'kepler' | 'newton' | 'barnes-hut' | 'webgpu' | 'auto';
@@ -339,6 +369,9 @@ export function createSolarSystemScene(
   const bodyCurrentLod = new Map<string, LodLevel>();
   // LOD 집계 — getLodStats 반환 값 재사용 버퍼 (매 프레임 객체 할당 회피).
   const lodStats = { high: 0, mid: 0, low: 0, override: 'auto' as LodOverride };
+  // #388 — body 별 LOD raw 데이터 버퍼. runLodPass 가 매 프레임 in-place 갱신.
+  // 배열 자체는 매 frame 동일 참조 — body 추가/제거 시에만 길이 조정. 행 객체도 mutable in-place.
+  const lodInfo: LodBodyInfo[] = [];
   let lodOverride: LodOverride = 'auto';
   // LOD cross-fade 상태 (ADR §축 3 — 200ms linear interp).
   // 각 body 의 전환 진행 상태 보관. `nowMs - startMs >= LOD_FADE_DURATION_MS` 이면 정착.
@@ -855,6 +888,8 @@ export function createSolarSystemScene(
     lodStats.mid = 0;
     lodStats.low = 0;
     lodStats.override = lodOverride;
+    // #388 — body 별 raw 데이터 버퍼 인덱스. system.bodies 길이 변동 없음 (정적 SSoT).
+    let lodInfoIndex = 0;
 
     // view × projection 결합 행렬. Babylon `scene.getTransformMatrix()` 는 `viewMatrix × projectionMatrix` 의
     // row-major 16 원소 Float32Array (`.m` 필드). 카메라 타입 관계없이 scene 단위로 호출 가능.
@@ -931,7 +966,29 @@ export function createSolarSystemScene(
       if (nextLevel === 'high') lodStats.high += 1;
       else if (nextLevel === 'mid') lodStats.mid += 1;
       else lodStats.low += 1;
+
+      // #388 — body 별 raw 데이터 박제. lodInfo 버퍼는 매 프레임 in-place 갱신 (객체 재할당 회피).
+      // 시각 직경 추정 (pxDiameter) = coverage × 2 — screenCoverageRadius 가 반지름이므로 직경은 두 배.
+      const existing = lodInfo[lodInfoIndex];
+      if (existing) {
+        existing.id = body.id;
+        existing.level = nextLevel;
+        existing.screenCoverage = coverage;
+        existing.pxDiameter = coverage * 2;
+        existing.cameraDistanceMeters = cameraDistanceMeters;
+      } else {
+        lodInfo.push({
+          id: body.id,
+          level: nextLevel,
+          screenCoverage: coverage,
+          pxDiameter: coverage * 2,
+          cameraDistanceMeters,
+        });
+      }
+      lodInfoIndex += 1;
     }
+    // body 가 줄었을 가능성 — trailing slot 잘라내기 (현재 시스템에선 정적이지만 미래 안전).
+    if (lodInfo.length > lodInfoIndex) lodInfo.length = lodInfoIndex;
   };
 
   /**
@@ -1041,6 +1098,8 @@ export function createSolarSystemScene(
     lodStats.override = level;
   };
   const getLodStats = () => lodStats;
+  // #388 — body 별 LOD raw 데이터 노출. dev overlay 가 frame 간격으로 polling.
+  const getLodInfo = (): readonly LodBodyInfo[] => lodInfo;
 
   const updateAtKepler = (jd: number) => {
     // 1) 각 바디의 부모-로컬 좌표 계산 (부모가 없으면 (0,0,0))
@@ -1148,6 +1207,7 @@ export function createSolarSystemScene(
     clearFocus,
     setLodOverride,
     getLodStats,
+    getLodInfo,
     dispose: () => {
       ambient.dispose();
       sunLight.dispose();


### PR DESCRIPTION
## Summary

PR #387 ([#379] architect 단계) Gemini cross-validate 고유 발견 분리. #379 Phase 1 (screenCoverage 식 정정) 진입을 위한 디버깅 도구 + reviewer non-blocking #1/#2 (forensic `actualCameraRadius` 일률 35 / `pixelDiameter` null) 직접 해소.

- **`?lodOverlay=1` 상세 모드** — body 별 LOD level + screenCoverage(px) + pxDiameter(px) + cameraDistance(km) 4 column 표 박제. 색상 코딩 (high=emerald / mid=amber / low=rose) + `data-lod-level` 속성
- **`SolarSystemSceneHandles.getLodInfo()` API** — `runLodPass` 매 프레임 갱신, `readonly LodBodyInfo[]` 반환 (재할당 회피, in-place mutate)
- **prod bundle DCE** — `LodDevOverlayImpl` 분리로 hooks 의존 그래프와 prod 분기 격리. grep tree-shaking 0 매치 실측

## Sprint Contract — 6 DoD 충족

| ID | 기준 | 검증 |
|----|------|------|
| DoD-1 | dev overlay 컴포넌트 확장 + body 별 raw 데이터 노출 API | `lod-dev-overlay.tsx` 두 모드 + `getLodInfo()` API |
| DoD-2 | URL 플래그 활성 / dev 모드 가드 | `?lodOverlay=1` / `?debug=draw-calls` / 미지정 → 미표시 (실 Chrome 검증) |
| DoD-3 | LOD level + screenCoverage + pxDiameter 표시 | 24 body 표시 (sun=high/69.40/138.79, mercury=low/4.13/8.26 등) |
| DoD-4 | 색상 코딩 + 실시간 갱신 | tailwind text-emerald/amber/rose-400 + 1초 throttle |
| DoD-5 | production 빌드 tree-shaken | `grep "lod-row-\|waiting for first frame\|isDetailedOverlayEnabled" .next/static/` 0 매치 |
| DoD-6 | 회귀 가드 1건 이상 | vitest 6 케이스 (URL / 양 모드 / 빈 / 색상 / 후방 호환 / 무 URL) |

## reviewer #387 권고 직접 해소

### non-blocking #1: forensic `actualCameraRadius` 일률 35 → cell 별 변별 가능
실 브라우저 검증 시 cameraDistance 가 body 마다 다름:
- sun: 416,666,641 km (~2.78 AU)
- mercury: 424,135,179 km
- saturn: 1,324,800,000 km

forensic 매트릭스 재실행 시 본 overlay 의 raw 데이터로 cell 별 차이 박제 가능.

### non-blocking #2: `bodyInfo.pixelDiameter` null → raw 박제
모든 body 의 pxDiameter / screenCoverage 가 null 없이 박제됨. Phase 1 식 정정 후 재측정 시 `pxDiameter ≥ 16` (high 임계) 도달 검증 가능.

## 사전 조사 결과 (volt #21)

기존 함수 검색:
- `Grep: lodLevel|lodStats|pixelDiameter|screenCoverage` — 5 위치 발견
- `getLodStats()` 이미 존재 (`SolarSystemSceneHandles`, P11-B #289)
- `LodDevOverlay` 컴포넌트 이미 존재 (집계 모드 박제)
- `screenCoverageRadius()` 순수 함수 이미 존재 (`packages/core/src/render/lod.ts`)

**판정**: **wrapped — 기존 컴포넌트 확장 + 기존 API 보강**.
- LodDevOverlay 컴포넌트는 집계 모드 (`?debug=draw-calls`) 보존 + 신규 `?lodOverlay=1` 분기 추가
- `getLodStats()` 와 별도로 `getLodInfo()` API 신설 (집계 vs body 별 raw 분리)
- `screenCoverageRadius` 는 이미 `runLodPass` 가 사용 — 재호출 없이 결과만 lodInfo 버퍼에 박제

## 검증 절차

### Unit tests
- `apps/web/src/components/layout/lod-dev-overlay.test.tsx` — 6 케이스
- `pnpm --filter @astro-simulator/core test` → 303 PASS
- `pnpm --filter @astro-simulator/web test` → 153 PASS (146 → 153, 신규 6 + 기존 1 회귀 0)

### Production bundle DCE
```bash
cd apps/web && rm -rf .next && pnpm build
grep -rln "lod-row-\|waiting for first frame\|isDetailedOverlayEnabled\|isAggregateOverlayEnabled\|LodDevOverlayImpl\|resolveInitialMode" .next/static/
# 출력: (없음 — 0 매치)
```

### 실 Chrome 검증 (CRITICAL #3 — UI 3단계)
- **Level 1 (정적)**: 1280×720 viewport, `?lodOverlay=1` 페이지 로드 → overlay element + `data-overlay-mode="detailed"` 박제. 콘솔 에러 0
- **Level 2 (인터랙션)**: detailed/aggregate/off 3 모드 정확 분기. URL 변경 시 모드 전환 정상
- **Level 3 (흐름)**: forensic 매트릭스 (#379 PM) 와 100% 정합 (high=1 / low=23, sun coverage 69.40 ≈ 이론값 71)

## Test plan

- [x] `pnpm --filter @astro-simulator/core test` (303 PASS)
- [x] `pnpm --filter @astro-simulator/web test` (153 PASS)
- [x] `pnpm --filter @astro-simulator/web build` (prod 통과)
- [x] tree-shaking grep 검증 (0 매치)
- [x] 실 Chrome `?lodOverlay=1` 시각 검증 (24 body 박제)
- [x] 실 Chrome `?debug=draw-calls` (집계 모드 회귀 0)
- [x] 실 Chrome 미지정 시 미표시 (DoD-2 가드)
- [x] CHANGELOG `### Behavior Changes` + `### Notes` 박제 (MINOR 릴리스 후보)
- [x] 한글 인코딩 검증 (grep '�' 0 매치)
- [x] lint-staged silent partial commit 가드 (`git diff develop HEAD --stat` 4 파일 일치)

## Builds on / Closes

- Builds on: #387 (architect 단계 머지, a5c5365)
- Related: #379 (모바일 그래픽 사각형 본 이슈, Phase 1 fix 진입 시 본 도구 활용)
- Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)