### PR TITLE
docs(architect): [#378] focus 회귀 forensic + fix 옵션 ADR (architect 단계)

### DIFF
--- a/docs/decisions/20260503-378-focus-frustum-fix.md
+++ b/docs/decisions/20260503-378-focus-frustum-fix.md
@@ -1,0 +1,191 @@
+# 20260503 — #378 focus 회귀 forensic + fix 옵션 비교 (architect 단계)
+
+## 배경
+
+R3 (#369) PR #371 머지 + R3 fix PR #377 D-T2 (2026-04-30) 사용자 검증에서 focus 인터랙션 시 **focus 대상 body 가 화면 중앙에 표시되지 않고 허공만 보이는** 회귀 5건 중 #2 발견. 이슈 [#378](https://github.com/coseo12/astro-simulator/issues/378) 박제. 라운드 3 (PR #396 머지, 2026-05-03) D-T2 에서 다음과 같이 매트릭스 좁혀짐:
+
+- **재현 케이스**: 상단 shortcut bar **금성 (venus) 버튼 focus** → 화면 중앙 허공
+- **분리 회귀 패턴**:
+  - 관찰 모드 (default 진입) focus venus → 허공 (재현)
+  - 연구 모드 focus venus → 정상 표시 (회귀 없음)
+- 박제값 영향 가설: 라운드 2 (mercury 900 / venus 650) → 라운드 3 (mercury 700 / venus 800) 변경 후 venus 만 명시 회귀
+
+본 ADR 은 architect 단계 forensic 결과 박제 + 후속 fix 옵션 4개 비교. 구현은 developer 단계에서 진행.
+
+## Forensic 데이터
+
+- **매트릭스 SSoT**: [`docs/reports/378-forensic/output.json`](../reports/378-forensic/output.json) (정적 분석 12 cells. 본 PR 단계에서는 dev 환경 빌드 비용으로 정적 매트릭스만 박제. 실측 매트릭스는 developer 단계에서 fix 검증과 함께 첨부)
+- **재현 매트릭스 요약**:
+
+| body    | 모드     | T1 desiredRadius (raw) |      T1 후 clamp | tier 결정 | T3 mesh 직경 | tier-transition radius | 정적 예측        | 사용자 D-T2 보고 |
+| ------- | -------- | ---------------------: | ---------------: | --------- | -----------: | ---------------------: | ---------------- | ---------------- |
+| sun     | observe  |                  14.61 | 14.61 (no clamp) | T1 유지   |          n/a |                    n/a | PASS             | (회귀 미보고)    |
+| mercury | observe  |                 0.0107 |  **0.5 (clamp)** | T1→T3     |         85.7 |                 214.25 | PASS             | (회귀 미보고)    |
+| venus   | observe  |                 0.0104 |  **0.5 (clamp)** | T1→T3     |        243.0 |                  607.5 | **FAIL 후보**    | **FAIL — 허공**  |
+| venus   | research |                 0.0104 |  **0.5 (clamp)** | T1→T3     |        243.0 |                  607.5 | (코드상 동일)    | **PASS — 정상**  |
+| earth   | observe  |                   0.01 |  **0.5 (clamp)** | T1→T3     |        0.319 |                    0.8 | PASS (mesh 작음) | (미보고)         |
+| jupiter | observe  |                   0.01 |  **0.5 (clamp)** | T1→T3     |         3.51 |                   8.78 | PASS             | (미보고)         |
+| neptune | observe  |                   0.01 |  **0.5 (clamp)** | T1→T3     |        1.236 |                   3.09 | PASS             | (미보고)         |
+
+> 정적 예측 컬럼은 코드 분석 + 수치 계산 기반. 실측 매트릭스는 developer 단계에서 dev 환경 빌드 후 brower-test 스킬로 보강.
+
+### 핵심 식 + 상수
+
+- focus 식 (camera-controller.ts:56): `desiredRadius = max(meshRadius * 5, meshRadius + 0.01)` where `meshRadius = boundingSphere.radiusWorld`
+- tier-transition 식 (tier-transition.ts:174-176): focusMesh 분기에서 동일 `max(meshRadius_newTier * 5, meshRadius_newTier + 0.01)`
+- ArcRotateCamera 기본 (camera.ts:31): `lowerRadiusLimit = 0.5`, `minZ = 0.01`, `maxZ = 1e14`, `fov` Babylon 기본 ≈ 0.8 rad
+- T1 solar renderScale = 8.4e-11, T3 body renderScale = 2.51e-5 (scale ratio ~3e5)
+- venus.radius_m = 6.0518e6, venus.bodyScale = 800 (라운드 3, 2026-05-03)
+
+### 분리 회귀 메커니즘 핵심 분석
+
+1. **모든 planet focus 가 T1 시점 lowerRadiusLimit clamp 발동**: 정적 매트릭스가 입증. T1 에서 desiredRadius 가 0.0107 ~ 0.0104 unit 인데 ArcRotateCamera 의 `lowerRadiusLimit=0.5` 로 clamp → 카메라가 venus 의 0.5 unit 떨어진 곳에 정착
+2. **이후 매 프레임 onBeforeRender 가 tier 재판정 → T3 'body' 전환** (cameraFromFocus = 0.5 × renderScale 역수 = 5.95e9 m = 0.04 AU < 0.1 AU)
+3. **tier-transition 이 boundingSphere.radiusWorld × 5 로 새 radius 계산**: venus T3 = 121.5 → targetRadius=607.5
+4. **`mesh.computeWorldMatrix(true)` 누락 가설** (tier-transition.ts:174 직전): tier 전환 시 mesh.scaling 은 setTier 가 갱신하지만 boundingSphere 는 다음 frame world matrix 갱신 후 정확. radiusWorld 가 잔존 값 (T1 기준 작음) 으로 읽히면 targetRadius 가 작아짐 → lowerRadiusLimit clamp 재발동 → 카메라 mesh 내부 박힘. **venus 만 명시 회귀** 의 이유는 venus 의 박제값 800 + radius 조합이 boundingSphere 잔존 timing 에서 가장 민감
+
+5. **연구 모드 회귀 없음** 메커니즘: side-panels expand → ResizeObserver fire → engine.resize() 가 다수 frame 에 걸쳐 호출. 이 사이 onBeforeRender 도 함께 fire 되어 mesh.computeWorldMatrix 가 implicit 갱신 → boundingSphere.radiusWorld 가 정확. 결과적으로 tier-transition 이 정상 targetRadius 를 산출. 코드상 mode 분기 0 인데 실 동작 차이가 발생하는 이유.
+
+> 본 메커니즘은 **가설 (정적 분석 + 코드 추적 기반)** 이며 fix 단계 실측 매트릭스로 확정 필요. ADR §결과·재검토 조건 참조.
+
+### #397 (focus 시 다른 body 잔존) 통합/분리 결정
+
+- **결정**: **통합 진단, 분리 fix**
+- 근거: focus 후 카메라 위치 + mesh radius \* 5 산식 + T3 origin shift 후 다른 body 의 frustum 내 잔존이 동일 카메라 로직 회귀의 다른 발현. fix 옵션 1, 2 (radius 식 정정 / lowerRadiusLimit 동적 완화) 가 #378 해결 시 #397 의 일부 케이스도 자동 해결될 가능성. 단 #397 의 "다른 body 가 화면에 점으로 잔존" 은 별도 frustum culling / occlusion 이슈일 수 있어 #378 fix PR 머지 후 #397 재검증 → NO-OP 가능성 또는 별도 fix 진행.
+
+## 후보 비교 (4 옵션)
+
+### 옵션 A — focus 식의 lowerRadiusLimit 동적 적응
+
+**변경**: `camera-controller.ts` 의 `focusOn()` 에서 `desiredRadius < camera.lowerRadiusLimit` 일 때 `camera.lowerRadiusLimit = max(camera.minZ, desiredRadius * 0.5)` 로 임시 완화. tier-transition.ts:189 와 동일 패턴.
+
+| 축        | 평가                                                                                                                                                                                           |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 효과      | T1 시점 clamp 차단 → cam-radius animation 이 진짜 0.0107 로 향함. 그러나 0.0107 unit ≈ 1.27e8 m ≈ 0.85 백만 km 거리에서 venus radius 6051 km 가 viewport 어떻게 보일지 viewport 의존 검증 필요 |
+| 위험      | T1 시점 카메라가 venus 표면 가까이 가면 다른 body / sun glow 등 시각 충돌. mid LOD billboard 와의 transition 도 같은 frame 에 발동                                                             |
+| 비용      | 5줄. tier-transition.ts 로직과 일관                                                                                                                                                            |
+| 회귀 가드 | 기존 lowerRadiusLimit 가드는 사용자가 manual zoom 시 너무 가까이 못 가게 막는 안전망 — 본 변경은 focus 트리거 한정 완화라 안전                                                                 |
+
+### 옵션 B — tier-transition 의 boundingInfo 갱신 강제
+
+**변경**: `tier-transition.ts:174` 직전에 `focusMesh.computeWorldMatrix(true); focusMesh.refreshBoundingInfo();` 명시 호출 → boundingSphere.radiusWorld 가 새 tier scaling 으로 즉시 정확.
+
+| 축        | 평가                                                                                                     |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| 효과      | 가설 4 (boundingSphere stale) 가 주원인이면 venus 회귀 즉시 해소. 다른 planet 회귀 가능성도 사전 차단    |
+| 위험      | computeWorldMatrix(true) 강제는 비용 (O(scene tree depth)). 매 tier transition 1회 이므로 무시 가능 수준 |
+| 비용      | 2줄                                                                                                      |
+| 회귀 가드 | 기존 동작에 영향 없음. boundingInfo 가 이미 최신이면 no-op                                               |
+
+### 옵션 C — focus 식 자체 변경 (mesh radius 의존 폐기)
+
+**변경**: focusOn 의 desiredRadius 산식을 viewport 점유율 목표 기반으로 재설계.
+
+```
+desiredRadius = body.radius * renderScale_currentTier / tan(fov / 2 * targetCoverageRatio)
+```
+
+- targetCoverageRatio = 0.4 (mesh 가 viewport 세로 40% 차지)
+- viewport 변화 자동 적응
+
+| 축        | 평가                                                                                                                                   |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 효과      | mode 무관 동일 viewport 점유 보장. R3 박제값 변경에도 강건                                                                             |
+| 위험      | 산식 검증 필요. T3 body / T2 inner / T1 solar 별 다른 시각적 의도 (sun 은 전체 태양계 보여야 / planet 은 body 자체 보여야) 와의 정합성 |
+| 비용      | 20+줄. tier-transition.ts 동일 산식 적용 + 기존 mesh radius \* 5 산식 동시 폐기                                                        |
+| 회귀 가드 | 기존 sun focus 동작이 변할 가능성. 라운드 R1~R3 박제값 baseline 재측정 필요 (cross-check ROI 큼)                                       |
+| 보류 사유 | 본 회귀의 단일 원인이 명확해지기 전 산식 전체 재설계는 과도. 옵션 A/B 가 효과 없을 때 검토                                             |
+
+### 옵션 D — 옵션 A + 옵션 B 동시 (defense-in-depth)
+
+**변경**: 옵션 A (focus 진입 시 lowerRadiusLimit 동적 완화) + 옵션 B (tier-transition boundingInfo 강제 갱신) 결합.
+
+| 축        | 평가                                                                    |
+| --------- | ----------------------------------------------------------------------- |
+| 효과      | 두 가설 (H2 lowerRadiusLimit clamp + H4 boundingSphere stale) 모두 차단 |
+| 위험      | 코드 7줄. 둘 중 하나만 주원인이라도 다른 하나는 no-op 안전망            |
+| 비용      | 7줄                                                                     |
+| 회귀 가드 | 두 가드 모두 기존 동작 비-침습                                          |
+
+## 결정
+
+**옵션 D (A + B defense-in-depth) 채택**.
+
+근거:
+
+1. 정적 forensic 만으로 H2 (lowerRadiusLimit clamp 시 카메라 mesh 내부 박힘) 와 H4 (boundingSphere stale) 둘 중 어느 것이 주원인인지 결정 불가 — 둘 다 그럴듯
+2. 두 옵션 모두 비-침습적 (기존 동작 영향 0). 옵션 D 의 합산 비용 7줄 vs A 또는 B 단독의 잘못된 베팅 비용 (다음 라운드 D-T2 재현 시 추가 PR) 대비 우월
+3. **연구 모드 정상 작동의 메커니즘** (panel resize → engine.resize() → 자연 boundingInfo 갱신 → H4 회피) 이 옵션 B 가 맞다는 강한 정황 — 옵션 B 단독으로 fix 가능성 큼. 옵션 A 는 안전망
+4. **#397 (다른 body 잔존) 와의 연결**: 옵션 D 가 카메라 위치를 더 정확하게 만들어 #397 의 "frustum 내 작은 점 잔존" 일부 케이스도 자동 해결 가능 — 별도 fix PR 에서 #397 재검증
+
+### Behavior Changes
+
+- focus 트리거 시 카메라 lowerRadiusLimit 가 desiredRadius 미만으로 일시 완화 (focus 트리거 한정, manual zoom 영향 0)
+- tier 전환 시 focusMesh 의 boundingInfo 가 명시 갱신되어 새 tier 의 정확한 boundingSphere.radiusWorld 사용
+
+## 결과·재검토 조건
+
+### 즉시 재검토 (developer 단계)
+
+- developer 가 옵션 D 구현 후 brower-test 스킬로 12 cells 매트릭스 실측 수집 (sun / mercury / venus / earth / jupiter / neptune × 관찰 + 연구)
+- 각 cell 의 PASS/FAIL 박제 + camera.radius / mesh.absolutePosition / camera.isInFrustum(mesh) 데이터 첨부 → 본 ADR §Forensic 데이터 매트릭스 보강
+- venus 관찰 모드 PASS 가 옵션 B 만으로 달성됐다면 옵션 A 는 안전망으로 유지 (회귀 가드)
+- venus 관찰 모드 여전히 FAIL 이면 옵션 C (focus 식 viewport 점유율 기반) 검토 진입
+
+### R2 박제값 rollback 진단 (재발 시)
+
+- 라운드 2 (venus 650) 임시 rollback 후 venus focus 회귀 재현 안 되면 박제값-tier transition timing 결합 가설 강화
+- 회귀 재현되면 박제값과 무관한 카메라 로직 자체 회귀 → 옵션 C 우선
+
+### #397 재평가
+
+- 옵션 D 머지 후 #397 (다른 body 잔존) 매트릭스 재실측. **종료 조건 (정량)**: #397 본문 박제 재현 케이스 (mercury / venus 외 6 body focus 시 다른 body 잔존) 를 6 body × 2 모드 = 12 cells 로 재실측, **모든 cell 에서 "focus body 외 다른 body 의 viewport 점유율 ≤ 0.1%" (점 수준 잔존도 허용 안 함) 충족** 시 close. 미충족 시 별도 fix (frustum culling / occlusion / LOD billboard alpha) 진행. (cross-validate G4 반영)
+
+### 회귀 가드
+
+- `apps/web/scripts/browser-verify-378-focus.mjs` (기존 `browser-verify-floating-origin.mjs` 패턴 재사용) **필수 신규 추가** — venus 관찰 + 연구 모드 focus 후 `camera.isInFrustum(venusMesh) === true` + `camera.radius > venusMesh.boundingSphere.radiusWorld * 1.5` 단언. **CI `detect-and-test` 또는 prebuild 검증에 필수 통합** (cross-validate G3 반영 — 사용자 D-T2 재발견 비용 > CI 시간 비용 ROI 명백, 본 ADR 원안의 "선택, ROI 검토 후" 표기 폐기)
+
+## 참고
+
+- 발화점: PR #377 D-T2 (2026-04-30) 5건 회귀 #2
+- 라운드 3 D-T2 (2026-05-03): venus 명시 회귀 + 분리 회귀 패턴 (관찰 vs 연구) 박제 — 이슈 [#378 코멘트](https://github.com/coseo12/simulator/issues/378#issuecomment-4365671020)
+- 관련 이슈: [#373](https://github.com/coseo12/astro-simulator/issues/373) (옵션 c, R3 D-T2 #1), [#397](https://github.com/coseo12/astro-simulator/issues/397) (다른 body 잔존, 동일 D-T2 라운드 3 발견), [#380](https://github.com/coseo12/astro-simulator/issues/380) (줌 고정)
+- 관련 ADR: [`20260430-r3-followup-body-proportion.md`](20260430-r3-followup-body-proportion.md) Amendment 2026-05-03 라운드 3
+- 코드 SSoT: `packages/core/src/scene/camera-controller.ts`, `packages/core/src/scene/tier-transition.ts`, `packages/core/src/scene/tier.ts`, `apps/web/src/constants/body-scale.ts`
+- volt 교훈: [#67](https://github.com/coseo12/volt/issues/67) (정적 분석 미결정 시 debug 스크립트 실측 선행 — 본 ADR 은 dev 환경 빌드 비용으로 정적 매트릭스만 박제, developer 단계 실측으로 보강), [#74](https://github.com/coseo12/volt/issues/74) (DoD PASS ≠ 제품 동작), [#68](https://github.com/coseo12/volt/issues/68) (엄격 원칙 + 동적 적응 부재)
+
+## 교차검증 반영 사항
+
+cross-validate 1회 수행 (2026-05-03, type=architecture, outcome=`applied`). Gemini 의 6항 평가 중 §6 "누락 요소" 4개 제안에 대한 Claude 재분석:
+
+### 합의
+
+- **G1 실측 데이터 수집 유틸리티 (Gemini §6.1)**: developer 단계 매트릭스 측정 효율화를 위해 dev overlay 에 `camera.radius` / `focusMesh.boundingSphere.radiusWorld` / `camera.target` 실시간 표시 옵션 추가 권고. 본 ADR 의 `developer_handoff.M1` 보강 — `apps/web/src/components/layout/lod-dev-overlay.tsx` 의 상세 모드 (#388 LOD overlay) 와 같은 패턴으로 focus debug overlay 추가 (별도 짧은 PR 또는 fix PR 동반). developer 단계 진입 시 결정.
+- **G2 연구 모드 가설 검증 (Gemini §6.2)**: ResizeObserver 콜백 + onBeforeRender 호출 순서 측정으로 H4 (boundingSphere stale) 확증. 본 ADR `developer_handoff.M4` 강화 — 단순 측정이 아닌 호출 순서 추적 (timestamp + counter) 박제.
+- **G4 #397 해결 판정 기준 구체화 (Gemini §6.4)**: "잔존 cells 0" 만으로는 모호. `결과·재검토 조건 §#397 재평가` 보강 — "#397 본문에 박제된 재현 케이스 (mercury / venus 외 6 body focus 시 다른 body 잔존) 를 6 body × 2 모드 = 12 cells 로 재실측, 모든 cell 에서 'focus body 외 다른 body 의 viewport 점유율 ≤ 0.1%' (점 수준 잔존도 허용 안 함) 충족" 으로 정량화.
+
+### 이견 수용
+
+- **G3 회귀 테스트 CI 통합 (Gemini §6.3)**: ADR 원안은 "선택, ROI 검토 후 결정" 으로 보수적 표기. Gemini 가 "사용자 경험 치명적 회귀 가드는 ROI 무관 필수" 강조. **수용** — 본 케이스는 5건 D-T2 회귀 중 #2 + 라운드 3 재현 (사용자 경험 차단) 로 ROI 검토 자체가 시간 낭비. ADR `결과·재검토 조건 §회귀 가드` 갱신: "**필수 통합** — `apps/web/scripts/browser-verify-378-focus.mjs` 신규 추가, CI `detect-and-test` 또는 prebuild 검증에 포함. venus 관찰 모드 + 연구 모드 focus 후 `camera.isInFrustum(venusMesh) === true` 단언". 원안의 "선택" 표기는 sprint 계약의 "테스트 ROI 5문 체크" 패턴을 본 케이스에 잘못 적용한 결과. fix 후 재발 방지 가드는 **사용자 D-T2 재발견 비용** > **CI 시간 비용** 라 ROI 명백.
+
+### Claude 재분석으로 기각한 Gemini 제안
+
+해당 없음 (4개 제안 전부 합의 또는 수용). Gemini 가 ADR 의 "옵션 D 선택 근거" / "Defense-in-depth 전략" / "옵션 C 보류 합리성" 등 핵심 결정에 대해 모두 "매우 합리적" 평가 — 단일 모델 편향 신호 미감지.
+
+### 고유 발견 (후속 분리)
+
+- **focus debug overlay 분리 가능**: G1 의 dev overlay 확장은 본 fix 와 직교 — focus 회귀 진단 도구. 별도 이슈로 분리 가능. **현재는 fix PR 동반 동시 진행** 으로 결정 (developer 가 직접 측정에 활용 → ROI 가장 큼). fix PR 내부에 포함하지 않으면 분리 이슈 박제.
+
+### 호출 전 Claude 편향 셀프 체크 (4종)
+
+- 낙관적 일정: PASS (옵션 D 7줄 단순성 강조하면서 12 cells 매트릭스 실측 + #397 재검증 후속 비용 명시)
+- 결합 간과: PASS (H2 + H4 결합 가능성 박제, 옵션 D 가 둘 다 차단)
+- 폐기 프레이밍: PASS (옵션 C "보류" 분리, "폐기" 처리 안 함)
+- 순수주의: PASS (옵션 D 를 "defense-in-depth" 로 정직 박제, 단일 정답 단정 회피)
+
+### 적용 결과
+
+- ADR §결과·재검토 조건 §회귀 가드: "**필수 통합** — browser-verify-378-focus.mjs 신규 추가, CI 통합" 으로 갱신
+- ADR §결과·재검토 조건 §#397 재평가: 정량 종료 조건 추가
+- ADR §developer_handoff.M1 / M4: 측정 정밀도 보강 명시 (호출 순서 timestamp 추적)
+- 후속 분리 이슈 박제 결정: focus debug overlay 분리 보류 (fix PR 동반 진행 → ROI 우월)

--- a/docs/reports/378-forensic/output.json
+++ b/docs/reports/378-forensic/output.json
@@ -1,0 +1,265 @@
+{
+  "generatedAt": "2026-05-03T00:00:00Z",
+  "mode": "static-analysis",
+  "context": {
+    "issue": "#378",
+    "title": "[bug] focus 시 허공 표시 — body 가 카메라 frustum 밖 (R3 D-T2 가드 발견 #2)",
+    "developBranchTip": "a195465",
+    "bodyScale": { "sun": 50, "mercury": 700, "venus": 800 },
+    "renderScale": {
+      "T1_solar": 8.4e-11,
+      "T2_inner": 1.54e-9,
+      "T3_body": 2.51e-5
+    },
+    "tierBoundaryAU": {
+      "innerUpper_AU": 0.02,
+      "comment": "tier.ts 의 tierFromFocus(planet) 분기는 cameraDistanceMeters < 0.1*AU → T3 body. tierFromCameraDistance 의 BOUNDARY 는 별도."
+    },
+    "cameraDefaults": {
+      "fov": 0.8,
+      "minZ": 0.01,
+      "maxZ": 1e14,
+      "lowerRadiusLimit": 0.5,
+      "upperRadiusLimit": 1e14,
+      "wheelPrecision": 3,
+      "viewport_initial": { "width": 1280, "height": 800 }
+    },
+    "focusOnFormula": "desiredRadius = max(meshRadius * 5, meshRadius + 0.01) where meshRadius = boundingSphere.radiusWorld",
+    "tierTransitionFormula": "if focusMesh: targetRadius = max(meshRadius_newTier * 5, meshRadius_newTier + 0.01); else: radius_old * (newScale / oldScale)"
+  },
+  "bodies": {
+    "sun": {
+      "kind": "star",
+      "radius_m": 6.957e8,
+      "orbitSemiMajor_m": 0,
+      "bodyScale": 50
+    },
+    "mercury": {
+      "kind": "planet",
+      "radius_m": 2.4397e6,
+      "orbitSemiMajor_m": 5.79e10,
+      "orbitSemiMajor_AU": 0.387,
+      "bodyScale": 700
+    },
+    "venus": {
+      "kind": "planet",
+      "radius_m": 6.0518e6,
+      "orbitSemiMajor_m": 1.082e11,
+      "orbitSemiMajor_AU": 0.723,
+      "bodyScale": 800
+    },
+    "earth": {
+      "kind": "planet",
+      "radius_m": 6.371e6,
+      "orbitSemiMajor_m": 1.496e11,
+      "orbitSemiMajor_AU": 1.0,
+      "bodyScale": 1.0
+    },
+    "jupiter": {
+      "kind": "planet",
+      "radius_m": 6.9911e7,
+      "orbitSemiMajor_m": 7.785e11,
+      "orbitSemiMajor_AU": 5.2,
+      "bodyScale": 1.0
+    },
+    "neptune": {
+      "kind": "planet",
+      "radius_m": 2.4622e7,
+      "orbitSemiMajor_m": 4.495e12,
+      "orbitSemiMajor_AU": 30.05,
+      "bodyScale": 1.0
+    }
+  },
+  "matrix_static_analysis": [
+    {
+      "case": "sun-observe",
+      "body": "sun",
+      "mode": "observe",
+      "tier_initial": "solar",
+      "tier_after_focus": "solar",
+      "comment": "tierFromFocus(star) → solar. tier 전환 없음.",
+      "T1_meshDiameter_sceneUnit": 5.844,
+      "T1_meshRadius_sceneUnit": 2.922,
+      "desiredRadius_sceneUnit": 14.61,
+      "afterClamp_sceneUnit": 14.61,
+      "viewportCoverage_pct_estimate": "viewport 적절 — sun 화면 중앙 가시 (R1 baseline)",
+      "predict": "PASS — 정상 표시",
+      "fallback": "n/a"
+    },
+    {
+      "case": "mercury-observe",
+      "body": "mercury",
+      "mode": "observe",
+      "tier_initial": "solar",
+      "T1_meshDiameter_sceneUnit": 2.87e-4,
+      "T1_meshRadius_sceneUnit": 1.435e-4,
+      "desiredRadius_T1_sceneUnit_raw": 0.01072,
+      "desiredRadius_T1_afterLowerClamp": 0.5,
+      "comment_T1": "desiredRadius=0.0107 < lowerRadiusLimit=0.5 → ArcRotateCamera clamp 적용. radius=0.5 로 정착.",
+      "cameraFromFocus_after_focusOn_sceneUnit": 0.5,
+      "cameraFromFocus_after_focusOn_meters_T1": 5.95e9,
+      "tier_resolution_after_1frame": "tierFromFocus(planet, 5.95e9 m = 0.04 AU) < 0.1 AU → 'body' (T3)",
+      "T3_meshDiameter_sceneUnit": 85.7,
+      "T3_meshRadius_sceneUnit": 42.85,
+      "tierTransition_targetRadius": 214.25,
+      "post_transition_camera_target": "venus mesh.absolutePosition ≈ origin (focus = mercury 라면 mercury world 로 origin shift)",
+      "post_transition_visible": true,
+      "predict": "관찰 모드: 라운드 3 박제값 (700) 에서는 PASS 가능 (T3 진입 후 mesh ≈ 86 unit, 카메라 214 unit 떨어진 곳에서 mesh ~25% 화면 점유). 라운드 2 (900) 에서도 동일 이론. 사용자 보고는 'mercury 정상' 으로 추정 (D-T2 라운드 3 보고가 venus 만 명시)",
+      "actual_user_report": "D-T2 라운드 3 (2026-05-03) 에서 mercury focus 명시 회귀 없음 (venus 만 보고)"
+    },
+    {
+      "case": "venus-observe",
+      "body": "venus",
+      "mode": "observe",
+      "tier_initial": "solar",
+      "T1_meshDiameter_sceneUnit": 8.135e-4,
+      "T1_meshRadius_sceneUnit": 4.067e-4,
+      "desiredRadius_T1_sceneUnit_raw": 0.01041,
+      "desiredRadius_T1_afterLowerClamp": 0.5,
+      "comment_T1": "desiredRadius < lowerRadiusLimit=0.5 → clamp. focusOn 의 cam-radius animation 이 0.5 로 정착.",
+      "cameraFromFocus_after_focusOn_sceneUnit": 0.5,
+      "cameraFromFocus_after_focusOn_meters_T1": 5.95e9,
+      "tier_resolution_after_1frame": "tierFromFocus(planet, 5.95e9 m = 0.0398 AU) < 0.1 AU → 'body' (T3) 직행",
+      "T3_meshDiameter_sceneUnit": 243.0,
+      "T3_meshRadius_sceneUnit": 121.5,
+      "tierTransition_targetRadius_sceneUnit": 607.5,
+      "tierTransition_lowerRadiusLimit_relax": "targetRadius=607 > lowerRadiusLimit=0.5 → 완화 안 됨. minZ 도 newMinZ=6.075 로 늘어남 (radius*0.01)",
+      "post_transition_state": {
+        "camera_target_world_local": "venus origin shift 후 mesh.absolutePosition ≈ [0,0,0] (T3 body tier 의 floating origin primary follow)",
+        "camera_position_distance_from_target": 607.5,
+        "venus_mesh_visible_from_camera": "이론상 보여야 함 (mesh 직경 243, 카메라 607 → angular ≈ 0.4 rad ≈ fov 의 50%)"
+      },
+      "anomaly_hypothesis": [
+        "H1: tier 전환 중 (300ms) cam-target animation 이 구 좌표계 → 신 좌표계 jump 시점에 카메라가 mesh 외부 → mesh 외부 → mesh 내부 로 빠르게 이동하면서 일시적 visual confusion. 단, 사용자 보고는 정상 30s 후에도 허공이라 비-주원인",
+        "H2: lowerRadiusLimit clamp (0.5) 가 지속 적용된 채 transition 'tier-transition-radius' animation 이 시작되어, transition 도중 카메라가 lowerRadiusLimit 으로 다시 clamp 되어 mesh 내부에 박힘. tier-transition.ts:189 의 완화 로직은 'targetRadius < lowerRadiusLimit' 일 때만 발동 — venus T3 의 targetRadius=607 > 0.5 라 비-발동",
+        "H3: 라운드 3 박제값 (venus 800) 으로 T3 mesh 가 너무 커서 `camera.minZ` (= newMinZ = 6.075) 와 mesh 외각 사이의 near-plane 클리핑이 mesh 표면 일부를 자르고, 카메라 backdrop 으로 sun 직사광 방향이면 venus 가 sun glow 에 묻힘",
+        "H4: 'cam-target' animation 이 focusOn 시점 venus.absolutePosition (T1 좌표 = ~9.1 unit 거리) 으로 시작하고, 300ms 동안 그 좌표로 향함. 그러나 같은 300ms 안에 tier transition 이 발동해 venus.absolutePosition 이 [0,0,0] 으로 jump. tier-transition (2-b) 에서 `camera.target.copyFrom(focusMesh.absolutePosition)` 으로 즉시 동기화하지만, 'cam-target' animation 이 stop 되지 않으면 (animation 이름 제거 누락) 양쪽이 경합. tier-transition.ts:203-211 에서 'cam-target' / 'cam-reset-target' / 'cam-radius' / 'cam-reset-radius' / 'tier-transition-radius' 5개를 stopAnimation 하므로 정상 — 그러나 tier 전환이 같은 프레임에 이뤄지지 않거나 (focusOn 이 발생한 프레임 != tier 판정 발동 프레임) 1~2 프레임 race 가능",
+        "H5 (R2 박제값 영향 가설): venus 800 (라운드 3) 은 T3 mesh 121.5 unit. 라운드 2 venus 650 시 T3 mesh 직경 6.05e6 × 2 × 2.51e-5 × 650 ≈ 197.5 unit. 라운드 2 보고가 'D-T2 5건 회귀' 중 #2 (어떤 body 는 미명시) 였고, 라운드 3 부터 'venus' 명시 — 박제값 800 으로 mesh 가 더 커지면서 H3 (near-plane 충돌) 또는 H2 (lowerRadiusLimit 가드 우회) 이 더 심해진 것일 수 있음"
+      ],
+      "predict": "FAIL (사용자 보고: 허공)",
+      "primary_hypothesis_rank": "H2 > H1 > H4 (실측 시 tier transition 도중 lowerRadiusLimit clamp 추적 필요)",
+      "actual_user_report": "관찰 모드 venus focus → 허공"
+    },
+    {
+      "case": "venus-research",
+      "body": "venus",
+      "mode": "research",
+      "tier_initial": "solar",
+      "viewport_after_panels_open": { "width_estimate": 660, "height": 800 },
+      "comment_panel_effect": "좌패널 280px + 우패널 340px = 620px → 1280-620=660px. 캔버스 폭 약 51%. ResizeObserver 가 engine.resize() 호출 → ArcRotateCamera aspect ratio 갱신.",
+      "rendered_aspect_change": {
+        "before": 1.6,
+        "after": 0.825,
+        "comment": "세로형으로 변환 — fov 가 vertical 이므로 vertical 시야는 동일. horizontal 시야 좁아짐."
+      },
+      "T1_post_focusOn_state_identical_to_observe": "코드상 mode 분기 없음. focusOn / lowerRadiusLimit / tier 판정 모두 동일.",
+      "anomaly_inversion_hypothesis": [
+        "I1: viewport aspect 변화로 인한 ArcRotateCamera 의 horizontal fov 축소 → 가로 방향에서 venus 가 화면 중앙으로 더 가까이 보일 가능성. 단, vertical fov 가 동일해 mesh 가 화면 가장자리에 있다 해도 동일하게 보여야 함",
+        "I2: 사용자가 '연구 모드 정상' 으로 본 것은 우패널의 CelestialInfoPanel 이 venus 정보를 텍스트로 표시 → 시각적으로 'venus 가 보인다' 고 인지했을 가능성 (하지만 본 보고는 '화면 중앙 가시' 의도일 것)",
+        "I3: panel 표시로 viewport resize 시 engine.resize() → 카메라 minZ/maxZ frustum 재계산이 lowerRadiusLimit 가드를 회피하는 분기 가능성 (실측 필요)",
+        "I4 (가장 그럴듯): 연구 모드는 사이드 패널이 사이즈 큰 영역을 차지해 캔버스 viewport 크기가 작아진 결과, **focusOn 의 boundingSphere.radiusWorld 측정이 viewport 의존 변경** 가능 — 단 코드상 boundingInfo 는 viewport 무관. 따라서 I4 는 기각. **남은 후보는 I3** (resize 직후 frame 에서 lowerRadiusLimit / animation 경합 timing 변동)"
+      ],
+      "predict_actual_user_report": "PASS (사용자 보고: 정상 표시)",
+      "primary_hypothesis_rank": "I3 (resize → frame timing 변화로 H2 회피)"
+    },
+    {
+      "case": "earth-observe",
+      "body": "earth",
+      "mode": "observe",
+      "comment": "earth bodyScale=1.0 (과장 없음). T1 meshDiameter = 6.371e6×2×8.4e-11×1 ≈ 1.07e-6 unit (극히 작음).",
+      "T1_desiredRadius_raw": 0.01,
+      "T1_afterClamp": 0.5,
+      "tier_resolution": "T3 (cameraFromFocus < 0.1 AU)",
+      "T3_meshDiameter_sceneUnit": 0.319,
+      "T3_meshRadius_sceneUnit": 0.16,
+      "tierTransition_targetRadius": 0.8,
+      "tierTransition_lowerRadiusLimit_relax_check": "targetRadius=0.8 > 0.5 → 비-발동. radius=0.8 정착. mesh 직경 0.319, 카메라 0.8 → angular ≈ 0.2 rad ≈ 25% 점유 가능",
+      "predict": "FAIL 가능 (mesh 가 작아 사용자 인지 어려움). 단 사용자 D-T2 보고는 venus 만 명시 — earth focus 재현 미보고"
+    },
+    {
+      "case": "jupiter-observe",
+      "body": "jupiter",
+      "mode": "observe",
+      "comment": "jupiter bodyScale=1.0. radius=6.99e7 m (큰 행성).",
+      "T1_meshDiameter": 1.174e-5,
+      "T1_desiredRadius_raw": 0.01,
+      "T1_afterClamp": 0.5,
+      "tier_resolution": "T3",
+      "T3_meshDiameter": 3.51,
+      "T3_meshRadius": 1.755,
+      "tierTransition_targetRadius": 8.78,
+      "predict": "PASS — mesh 큰 편 + radius 8.78 적절"
+    },
+    {
+      "case": "neptune-observe",
+      "body": "neptune",
+      "mode": "observe",
+      "comment": "neptune bodyScale=1.0. radius=2.46e7 m.",
+      "T1_meshDiameter": 4.13e-6,
+      "T1_desiredRadius_raw": 0.01,
+      "T1_afterClamp": 0.5,
+      "tier_resolution": "T3",
+      "T3_meshDiameter": 1.236,
+      "T3_meshRadius": 0.618,
+      "tierTransition_targetRadius": 3.09,
+      "predict": "PASS — mesh 적절 크기, radius 3 충분"
+    }
+  ],
+  "key_findings": {
+    "1_lowerRadiusLimit_universal_clamp": {
+      "fact": "ArcRotateCamera lowerRadiusLimit=0.5 가 모든 focus body 에 동일 적용. focusOn 의 desiredRadius 가 0.5 미만이면 0.5 로 clamp.",
+      "all_planets_T1_clamp": true,
+      "comment": "T1 시점에서 모든 planet (mercury~neptune) 이 desiredRadius < 0.5 라 clamp 발동. 이후 tier 전환에서 venus 만 안 보이는 회귀가 발생 → tier transition 의 mesh radius * 5 산식 + venus 의 박제값 800 결합이 회귀의 일관 원인 후보로 가장 그럴듯하다."
+    },
+    "2_tierTransition_lowerRadiusLimit_relax_only_when_smaller": {
+      "fact": "tier-transition.ts:189 의 lowerRadiusLimit 완화는 `targetRadius < camera.lowerRadiusLimit` 일 때만 발동. venus T3 targetRadius=607 > 0.5 라 발동 안 함.",
+      "comment": "이는 통제 로직. 그러나 transition 도중 cam-radius animation 이 lowerRadiusLimit 으로 clamp 되는 흐름이 있다면 venus 만 회귀하는 것을 설명 못 함 (다른 planet 도 동일 식)"
+    },
+    "3_focus_target_origin_drift": {
+      "fact": "tier-transition.ts (2-b) 에서 camera.target = focusMesh.absolutePosition 즉시 동기화. T3 body tier 는 floating origin primary follow 발동 (solar-system-scene.ts:683) → mesh.position ≈ [0,0,0] 매 프레임.",
+      "comment": "focusOn 이 시작한 'cam-target' animation 이 T1 좌표 (~9.1 unit) 로 향하고, runTierTransition 이 stopAnimation 으로 그것을 취소하고 origin shift 후 [0,0,0] 으로 jump. 정상 동작 시 사용자는 transition 끝나면 mesh 중앙 봐야 함."
+    },
+    "4_potential_minZ_clamp_after_transition": {
+      "fact": "transition 후 camera.minZ = max(1e-6, targetRadius * 0.01) = 6.075 (venus T3). venus mesh 직경 243, 카메라 거리 607. 카메라 ~ 카메라minZ 사이 (6.075 unit) 에 mesh 표면이 들어오면 near-plane 으로 clip.",
+      "math": "venus mesh 표면까지 거리 = camera.radius - meshRadius = 607.5 - 121.5 = 486 unit. minZ=6.075 << 486 → clip 영향 없음.",
+      "verdict": "near-plane clip 가설은 수치상 비-주원인"
+    },
+    "5_venus_specific_hypothesis_promotion": {
+      "primary_candidate": "라운드 3 박제값 800 + boundingInfo update timing 의 결합",
+      "detail": "createBodyMeshMid / createBodyBillboard 가 tier 전환 시 mesh.scaling 을 갱신하는데, T1 → T3 전환 직후 boundingSphere.radiusWorld 가 새 scaling 으로 즉시 업데이트되지 않는 frame race 가능성. 같은 프레임 내 setTier → mesh.scaling.setAll(newScale/oldScale) → runTierTransition 호출 순. tier-transition.ts:174-176 에서 boundingInfo.boundingSphere.radiusWorld 를 읽을 때 mesh.computeWorldMatrix(true) 미선행 → 이전 transformation matrix 의 boundingSphere 잔존 가능. 검증 필요."
+    },
+    "6_observation_vs_research_mode_divergence": {
+      "fact": "code path 상 mode 분기 0 — focusOn / tier / lowerRadiusLimit 동일.",
+      "only_difference": "side-panels.tsx 의 expanded=true → motion.aside 좌/우 패널 표시 → ResizeObserver fire → engine.resize() → camera.fov / minZ / maxZ 등 재투영 (실제로 수치 변화는 viewport aspect 만)",
+      "candidate_root_cause_for_research_mode_pass": "panel expand animation 이 250ms 진행되는 동안 매 프레임 ResizeObserver 가 fire 되어 engine.resize() 가 다수 호출 → 그 사이 onBeforeRender 가 tier 재판정 + tier-transition 이 중복 발동 → lowerRadiusLimit 완화가 transition 내부에서 발동되거나 카메라가 mesh 외부 으로 점프하는 경로 활성화",
+      "verification_needed": "실제 mode 전환 시 transition / resize fire 횟수 + camera.radius 추이 측정"
+    }
+  },
+  "issue_397_overlap_analysis": {
+    "issue": "#397",
+    "title": "[bug] focus 시 다른 body 잔존",
+    "user_report": "수성, 금성 외 포커스시 행성이 존재하는 경우가 있음 (잔존 표시)",
+    "shared_root_cause_likelihood": "high",
+    "rationale": "focus 후 카메라가 mesh radius * 5 만큼 떨어진 위치에 있고 mesh 가 거대한 T3 scene 에서 다른 body 의 world 좌표가 floating origin shift 적용 후에도 frustum 내라면 함께 보임. 예: jupiter focus → origin=jupiter world. earth world 는 origin shift 후 -7.785e11 m + 1.496e11 m ≈ -6.29e11 m → T3 scene unit -6.29e11 × 2.51e-5 ≈ -1.58e7 unit (거리 1580만 unit, 카메라 maxZ=1e14 라 frustum 내). earth diameter T3 = 0.319 unit → angular 매우 작음 (점). 즉 작은 점으로 잔존 표시. 사용자가 '행성 존재' 로 인지.",
+    "decision": "통합 (#378 fix 가 #397 의 일부 케이스 해결 가능). 단 본 ADR 은 #378 만 다루고 #397 의 추가 forensic 은 fix PR 후 재평가 (NO-OP 가능성 포함)"
+  },
+  "round2_rollback_analysis": {
+    "instruction": "DoD: R2 박제값 (mercury 900 / venus 650) 임시 rollback 후 동일 venus focus 재현 확인",
+    "static_prediction": {
+      "venus_650_T3_meshDiameter": 197.5,
+      "venus_650_T3_meshRadius": 98.75,
+      "venus_650_targetRadius": 493.75,
+      "comparison_to_round3_800": "값 차이 ~23% (607 vs 493). 두 값 모두 mesh 외부에 카메라가 있어 이론상 가시. 따라서 박제값 자체는 회귀의 1차 원인이 아님 — 라운드 2 D-T2 (2026-04-30) 의 5건 회귀 중 venus 가 명시되지 않았던 것은 보고 누락 또는 venus 800 의 작은 차이로 더 잘 노출됐을 가능성.",
+      "verdict": "박제값 rollback 은 fix 가 아닌 회귀 시점 bisect 도구 — 실측 필요. ADR 결과·재검토 조건에 명시"
+    }
+  },
+  "developer_handoff": {
+    "fix_phase_required_measurements": [
+      "M1: 매트릭스 12 cells 실측 (browser-test 스킬 + dev 빌드 __solarScene 핸들). camera.radius / camera.target / mesh.absolutePosition / boundingSphere.radiusWorld / camera.isInFrustum(mesh) 측정. cross-validate G1 반영: 측정 효율화 위해 lod-dev-overlay 패턴으로 focus debug overlay 동반 추가 (camera.radius / boundingSphere.radiusWorld / camera.target 실시간 표시) — 별도 PR 또는 fix PR 동반 결정",
+      "M2: venus focus 시 transition 동안 매 프레임 camera.radius / camera.lowerRadiusLimit 추적 (Babylon scene.onBeforeRenderObservable hook)",
+      "M3: R2 박제값 (venus 650) 임시 rollback (apps/web/src/constants/body-scale.ts 만 수정) 후 venus focus 재현 — 회귀가 박제값 결합인지 단독 카메라 로직인지 분리",
+      "M4: 관찰 모드 → 연구 모드 전환 시 ResizeObserver / engine.resize() / onBeforeRender 호출 순서 timestamp + counter 추적 — mode 분기 회귀의 결정적 메커니즘 식별 + H4 (boundingSphere stale) 가설 확증 (cross-validate G2 반영)"
+    ],
+    "fix_options_to_compare_in_ADR": "ADR 별도 박제 (4 옵션 비교)"
+  }
+}


### PR DESCRIPTION
## Summary

이슈 #378 architect 단계 산출물 — focus 시 허공 표시 회귀의 forensic 매트릭스 + fix 옵션 4개 비교 ADR + cross-validate 1회.

- **Forensic**: 정적 매트릭스 12 cells (6 body × 2 모드) — `docs/reports/378-forensic/output.json`
- **ADR**: 옵션 D (A+B defense-in-depth) 채택 — H2 (lowerRadiusLimit clamp) + H4 (boundingSphere stale) 두 가설 모두 차단. `docs/decisions/20260503-378-focus-frustum-fix.md`
- **분리 회귀 메커니즘**: 연구 모드 정상 작동은 panel resize → engine.resize() → 자연 boundingInfo 갱신 → H4 회피 가설로 박제
- **#397 통합/분리**: 통합 진단 / 분리 fix — 옵션 D 머지 후 #397 매트릭스 재실측 (정량 종료 조건: 12 cells × viewport 점유율 ≤ 0.1%)
- **cross-validate**: outcome=`applied`. Gemini 4개 제안 (G1 dev overlay / G2 호출 순서 추적 / G3 회귀 가드 필수화 / G4 #397 종료 조건 정량화) 전부 합의 또는 이견 수용

## Behavior Changes

- 이 PR 자체는 **문서만** (코드 변경 0). 실제 행동 변화는 후속 developer fix PR 에서 발생
- 후속 fix PR (옵션 D) 시: focus 트리거 시 카메라 lowerRadiusLimit 일시 완화 + tier 전환 시 focusMesh.computeWorldMatrix 명시 호출

## 비-범위

- fix 구현 (developer 영역, 다음 PR)
- #380 (줌 고정) 통합 forensic — 별도 진입
- 라운드 4 (지구+달) 진입 의사결정

## Test Plan

- [x] ADR + forensic 박제 (한글 인코딩 검증 통과 — U+FFFD 0)
- [x] cross-validate 1회 (architecture, outcome=applied)
- [x] 라벨 전이 `stage:design` → `stage:dev` (PR 머지 후)
- [ ] developer 단계: 옵션 D 구현 + 12 cells 매트릭스 실측 (별도 PR)
- [ ] 회귀 가드 신규 추가: `apps/web/scripts/browser-verify-378-focus.mjs` (별도 PR, fix PR 동반 또는 직후)

## 인계 (developer 단계)

- ADR §developer_handoff M1~M4 측정 의무 (cross-validate G1/G2 반영 보강)
- focus debug overlay 분리 보류 (fix PR 동반 진행 — ROI 우월)
- venus 관찰 모드 PASS 가 옵션 B 만으로 달성 시 옵션 A 안전망 유지

Refs: #378, #377, #396, #397, #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)