### PR TITLE
chore(web): 파비콘 추가 — astro-simulator 식별용 SVG

### DIFF
--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0a0e1a" rx="6"/>
+  <ellipse cx="16" cy="16" rx="11" ry="3.5" fill="none" stroke="#3a4a6a" stroke-width="0.8" opacity="0.6"/>
+  <circle cx="16" cy="16" r="4" fill="#ffb84a"/>
+  <circle cx="26.5" cy="14.8" r="1.6" fill="#6cb4ff"/>
+</svg>


### PR DESCRIPTION
## Summary

- `apps/web/app/icon.svg` 신설 (335 bytes). Next.js App Router 자동 인식 — metadata 변경 0
- 천체 시뮬레이터 테마 + R1~R3 박제 정합: 다크 배경 + 태양 + 궤도 + 행성 1개

## 디자인

| 요소 | 값 |
|---|---|
| 배경 | `#0a0e1a` (우주 다크) + rx=6 둥근 모서리 |
| 태양 | `#ffb84a` (sunScale 50 의도 보존) r=4 |
| 궤도 라인 | stroke `#3a4a6a` 0.8 opacity 0.6 |
| 행성 | `#6cb4ff` r=1.6 |
| viewBox | 32×32 |

## 사유

- 현재 `apps/web/app/`, `public/` 모두 favicon 없음
- 브라우저 탭 식별성 부재 → astro-simulator 식별 위한 최소 파비콘 박제
- SVG 우선 (모던 브라우저 호환 + 가벼움 + retina 자동 대응)

## Test plan

- [x] `file apps/web/app/icon.svg` → SVG Scalable Vector Graphics image
- [x] 파일 크기 335 bytes (적정)
- [x] Next.js 자동 인식 (metadata `icons` field 변경 0)
- [ ] 사용자 D-T2 (실 Chrome): 브라우저 탭 favicon 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)