### PR TITLE
fix(workflow): [#483 hotfix] YAML 'on:' → "on": quote — boolean True 함정 우회 (D2/D3 활성화)

### DIFF
--- a/.github/workflows/adr-z-pattern-health.yml
+++ b/.github/workflows/adr-z-pattern-health.yml
@@ -9,7 +9,8 @@ name: ADR 20260515 Z Pattern Health Metric
 #   - workflow_dispatch 는 default branch (develop) 반영 후에만 discover 됨
 #   - 본 PR 머지 후 D2/D3 검증은 develop 반영 후 1회 수동 실행으로 수행
 
-on:
+# YAML 1.1 'on:' → boolean True 함정 — quote 로 string key 강제 (volt 캡처 후보)
+"on":
   schedule:
     - cron: '0 0 * * 1' # 매주 월요일 UTC 00:00 = KST 09:00
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- PR #490 머지 후 D2 manual dispatch 실행 시도에서 GitHub API HTTP 422 `Workflow does not have 'workflow_dispatch' trigger` 발생
- 원인: **YAML 1.1 'on:' 키 boolean True 함정** — Python yaml.safe_load 는 dict 인식하나 GitHub Actions parser 는 boolean True 키로 트리거 미인식 (PR #490 qa non-blocking 권고 적중)
- 1줄 fix: `on:` → `"on":` quote 처리 (string key 강제)

## 변경 사항

`.github/workflows/adr-z-pattern-health.yml` (+2/-1):
- `on:` → `"on":` (quote 처리)
- YAML 1.1 boolean 함정 회피 주석 추가 (volt 캡처 후보)

## 영향 범위

- **Behavior Changes**: workflow_dispatch trigger 정상 인식. D2/D3 자동 가드 활성화. **PATCH** SemVer (문구 + 1줄 변경, 행동 정합 회복).
- 다운스트림 영향: 없음
- prettier 영향: 없음 (.github/workflows/)

## 검증

- [x] python3 yaml.safe_load: `on keys: ['schedule', 'workflow_dispatch']` + boolean True key 부재
- [x] 한글 인코딩: U+FFFD 0건
- [x] base=develop, head=feature/483-hotfix-yaml-on-quote

## 머지 후 D2/D3 의무

1. `gh workflow run adr-z-pattern-health.yml` (default branch 반영 후)
2. `[ADR Trigger]` 자동 이슈 생성 확인 (Phase 2 = 0/9 = 0% → 즉시 발화 예상)

## Cross-link

- 원본: #483 (자동 탐지) + PR #490 (머지된 fix 후속)
- qa non-blocking 권고: PR #490 qa 코멘트 ("YAML 1.1 on→True boolean 함정 발견")
- ADR: \`docs/decisions/20260515-harness-managed-divergent-pattern.md\` Amendment 3
- volt 캡처 후보 (high): YAML 1.1 'on:' boolean True 함정 패턴

Closes #483