### PR TITLE
feat(scene): [#439] orbit-lines R-Phase 가드 통합 — defense-in-depth #5 (zero-touch SSoT)

### DIFF
--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -37,6 +37,7 @@ import {
   type Tier,
 } from './tier.js';
 import { runTierTransition } from './tier-transition.js';
+import { R_PHASE_BODY_ALLOWLIST } from './r-phase-allowlist.js';
 import {
   lodFromScreenCoverage,
   screenCoverageRadius,
@@ -438,6 +439,9 @@ export function createSolarSystemScene(
     const batches: Vector3[][] = [];
     for (const body of system.bodies) {
       if (!body.orbit) continue;
+      // defense-in-depth #5 (이슈 #439): R-Phase 미진입 body 는 본체가 점 수준이라
+      // 궤도선만 그리면 시각 혼란. R_PHASE_BODY_ALLOWLIST SSoT 직접 참조 (BODY_SCALE 의존 역전 회피).
+      if (!(R_PHASE_BODY_ALLOWLIST as readonly string[]).includes(body.id)) continue;
       const pts = sampleOrbitPoints(body, activeTier);
       if (pts) batches.push(pts);
     }


### PR DESCRIPTION
## 배경

PR [#437](https://github.com/coseo12/astro-simulator/pull/437) (#419 mount race fix) D-T2 검증 중 사용자 발견 (2026-05-10):
> \"구현안된 행성들의 불필요 궤도들도 제거하자\"

`packages/core/src/scene/solar-system-scene.ts:432 rebuildOrbitLines()` 가 `system.bodies` 의 **모든 body** 에 대해 궤도선 생성 → R4~R10 미진입 body (earth/mars/jupiter/saturn/uranus/neptune 등) 의 본체는 `DEFAULT_BODY_SCALE=1.0` 점 수준이라 사실상 안 보이지만 궤도선만 보여 시각 혼란.

## 변경 사항

```diff
+ import { R_PHASE_BODY_ALLOWLIST } from './r-phase-allowlist.js';

  const batches: Vector3[][] = [];
  for (const body of system.bodies) {
    if (!body.orbit) continue;
+   // defense-in-depth #5 (이슈 #439): R-Phase 미진입 body 는 본체가 점 수준이라
+   // 궤도선만 그리면 시각 혼란. R_PHASE_BODY_ALLOWLIST SSoT 직접 참조 (BODY_SCALE 의존 역전 회피).
+   if (!(R_PHASE_BODY_ALLOWLIST as readonly string[]).includes(body.id)) continue;
    const pts = sampleOrbitPoints(body, activeTier);
    if (pts) batches.push(pts);
  }
```

**+4 라인** (import 1 + 주석 2 + 조건 1).

## 설계 결정 — 후보 A → R_PHASE_BODY_ALLOWLIST SSoT 직접 참조

이슈 본문 후보 A (`BODY_SCALE` 화이트리스트 필터링) 는 **의존 역전 위반**:
- `packages/core/src/scene/solar-system-scene.ts:298` 코멘트: \"레이어 의존 역전 방지 — `BODY_SCALE` 룩업은 `apps/web` 에 박제 (시각 과장 데이터 ≠ physics)\"
- packages/core 는 apps/web 의 `BODY_SCALE` 을 알 수 없음

**정답**: `R_PHASE_BODY_ALLOWLIST` (이미 packages/core 의 SSoT, ADR `20260504-r-phase-allowlist-guard.md` §결정 1) 직접 참조 → 의존 역전 회피 + SSoT 통합 (zero-touch — R-Phase 진입 시 ADR §결정 4 의 5곳 동시 박제 절차로 자동 활성화).

`isRPhaseFocusable()` helper 대신 직접 includes 사용 — helper 는 `null/undefined` 시 true 반환 (resetCamera 경로 보호) 으로 orbit-lines 가드에 부적합 (명시적 멤버십 검사 필요).

## defense-in-depth 시리즈 5번째

| # | 이슈 | 가드 | PR | Status |
|---|------|------|----|--------|
| 1 | #402 | FocusQuickButtons R-Phase 가드 | #410 | merged |
| 2 | #403 | CelestialTree + InfoPanel R-Phase 가드 | #430 | merged |
| 3 | #404 | ScenarioPresets R-Phase 가드 | #432 | merged |
| 4 | #415 | url-sync R-Phase 가드 | #421 | merged |
| **5** | **#439** | **orbit-lines R-Phase 가드** | **본 PR** | **review** |

## 테스트 ROI 5문 체크 (CLAUDE.md)

- 보호하는 줄: 1 (조건문)
- 회귀 시 결과: 조용히 퇴행 (R4~R10 미진입 body orbit 재출현, 시각 혼란)
- 인접 테스트: `R_PHASE_BODY_ALLOWLIST` 단위 테스트 (`r-phase-allowlist.test.ts`) 가 SSoT 박제값 검증
- closure 우회: `rebuildOrbitLines` 는 `createSolarSystem` 내부 closure — 직접 단위 테스트 비용 > 보호 가치
- **판단**: **주석 계약 + 인접 속성 테스트 패턴 채택** (CLAUDE.md \"1~2줄짜리 스킵 조건은 주석 계약 + 인접 속성 테스트 충분\" 권고)
- 후속: visual 회귀 가드 (`browser-verify-r-phase-allowlist.mjs` 시나리오 통합) 필요 시 별도 이슈 분리

## 검증

- ✅ core build PASS (`pnpm build`)
- ✅ core tests 367/367 PASS (회귀 0)
- ✅ web tests 237/237 PASS (회귀 0)
- ✅ U+FFFD 한글 인코딩: clean

## 체크리스트 (PR 템플릿 7 base 가드)

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=feature/439-orbit-lines-r-phase-guard`

### 체크리스트
- [x] **[1] 커밋 컨벤션**: `feat(scene): [#439] ...` (Conventional Commits)
- [x] **[2] 불필요한 변경 없음**: solar-system-scene.ts +4 라인만
- [x] **[3] 보안 취약점 없음**: 조건 1줄 추가, 외부 입력 0, 시크릿 0
- [x] **[5] cross-validate (정책·규약·ADR 박제 시)**: 본 PR 은 정책/ADR 박제 비대상 (코드 가드 추가 only). cross-validate skip 정당화 — defense-in-depth #5 시리즈의 자명 패턴 (#402/#403/#404/#415 직전 4건 모두 cross-validate 미호출)
- [x] **[6] ADR 호환성**: ADR `20260504-r-phase-allowlist-guard.md` §결정 1 SSoT 재사용으로 ADR 본문 자연 정합. Amendment 비대상
- [x] **[7] Test plan (단위 테스트)**: 주석 계약 + 인접 속성 테스트 패턴 (테스트 ROI 5문 체크 위 참조). 회귀 가드는 core 367 + web 237 = 604 tests PASS

### 테스트
- [x] 단위 테스트 추가/수정: 주석 계약 + 인접 (CLAUDE.md ROI 권고)
- [x] 기존 테스트 통과 확인: 604/604 PASS
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인: N/A (변경 0)

### 브라우저 3단계 검증
defense-in-depth 가드 시각 효과 검증 — visual 회귀는 후속 이슈 분리 가능. **CRITICAL #3 적용 대상 — 머지 전 사용자 D-T2 권장**:
- [ ] **[1/3] 정적**: dev 서버 진입 시 R4+ body (earth/mars/jupiter/saturn/uranus/neptune) 의 궤도선 부재 확인
- [ ] **[2/3] 인터랙션**: 시간 바 + 줌인/아웃 시 R-Phase 진입 body (sun/mercury/venus) 의 궤도선만 일관 표시
- [ ] **[3/3] 흐름**: URL `?focus=sun/mercury/venus` 진입 시 가드 영향 0

## Cross-link

- 발견: PR [#437](https://github.com/coseo12/astro-simulator/pull/437) D-T2 사용자 발견
- Builds on: ADR [`20260504-r-phase-allowlist-guard.md`](docs/decisions/20260504-r-phase-allowlist-guard.md) §결정 1, defense-in-depth 시리즈 (#402/#403/#404/#415)
- Closes: #439

## auto-close 함정 (base=develop)

본 PR 은 `base=develop` 이므로 `closingIssuesReferences=[]` 발화 (CLAUDE.md 박제 25/25=100%). 머지 직후 메인 수동 close 의무.

🤖 Generated with [Claude Code](https://claude.com/claude-code)