### PR TITLE
fix(scene): [#510] clearFocus 에 tier/origin 복원 동반 — reset 회귀 차단

### DIFF
--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -748,8 +748,19 @@ export function createSolarSystemScene(
     focusBodyIdForAssert = bodyId;
   };
   // P12-A #298 — focus 해제 (reset) 시 tier 는 free-fly 경로로 전환.
+  //
+  // R-Phase #510 H6 fix — focus 해제는 **tier 까지 default 복원**해야 한다.
+  // 이전: focusBodyIdForAssert = null 만 → tier (focus 시 sub-tier) + origin (focus body 위치) 잔존.
+  // 잔존 상태에서 sim-canvas 가 controller.reset(35) Animation 시작하면 매 프레임
+  // updateTierByCamera 가 잘못된 tier 판정 → setTier 트리거 → tier-transition.ts:288-296 의
+  // stopAnimation 이 cam-reset-radius/target 까지 stop + computeTargetRadius(35, oldScale, newScale)
+  // 로 radius 폭증 (forensic 실측: 35 → 688,901 ≈ ×19,683).
+  //
+  // setTier(defaultInitialTier()) 호출은 내부에서 floatingOrigin.reset() (T1/T2 경로) 도 자동
+  // 동반하므로 origin 도 함께 복원. focus 진입 시 applyFocusTier + setFocusOrigin 의 대칭.
   const clearFocus = () => {
     focusBodyIdForAssert = null;
+    setTier(defaultInitialTier());
   };
 
   // P10-D #263 — Newton 엔진 state 에서 body pos/vel 직접 추출 (timeScale 내성).


### PR DESCRIPTION
## Summary

- `solar-system-scene.ts:751 clearFocus()` 에 `setTier(defaultInitialTier())` 한 줄 추가 — focus 해제가 tier/origin 까지 default 복원하도록 대칭화
- forensic 실측으로 H6 신규 가설 확정: reset Animation 중 잔존 tier scale 이 `tier-transition.stopAnimation` 과 `computeTargetRadius` 와 결합해 radius ×19,683 폭증
- D-T2 3 시나리오 (venus / mercury / sun → reset) 모두 시각적으로 정상화

Closes: #510

## 원인 (H6 — forensic 단계 신규 가설)

기존 5 가설 (H1~H5) 정적+실측으로 전부 기각 또는 부분 일치. 신규 H6 확정:

- focus 진입: `applyFocusTier(bodyId, ...)` + `setFocusOrigin(bodyId)` → tier=sub-tier, origin=body 위치
- focus 해제 (기존): `focusBodyIdForAssert = null` 만 → **tier/origin 잔존**
- 잔존 상태에서 `controller.reset(35)` Animation 시작 → 매 프레임 `updateTierByCamera` 가 잘못된 tier 판정 → `setTier` 트리거 → `tier-transition.ts:288-296` 이 `cam-reset-radius/target` stop + `computeTargetRadius(35, oldScale, newScale)` 로 폭증

기각된 가설:
- **H1** detachControl: `inputs.attached: true` 유지 (실측)
- **H2** alpha/beta 미복원: drag 미발생 시 변화 0 (실측). 사용자 보고 "시점 이상" 은 H6 (target/radius 폭증) 효과
- **H3** lowerRadiusLimit 단방향 완화 잔존: 잔존이 아니라 0.5 → 6889 폭증 (H6 원인)
- **H4** floatingOrigin: 이슈 본문에서 이미 기각

## 변경

`packages/core/src/scene/solar-system-scene.ts:751-763` — clearFocus 에 setTier 호출 + 11 라인 주석 (H6 발견 박제):

```ts
const clearFocus = () => {
  focusBodyIdForAssert = null;
  setTier(defaultInitialTier());
};
```

setTier 내부에서 `computeFloatingOriginForTier(tier, focusBodyIdForAssert=null, ...)` 가 originTarget=[0,0,0] 반환 → `floatingOrigin.reset()` 자동 동반 (중복 호출 불필요).

## 실측 결과 (3-state 비교)

### Fix 전

| 단계 | radius | lowerRadiusLimit | target | inputs.attached |
|---|---|---|---|---|
| initial | 35 | 0.5 | (0,0,0) | ✅ |
| post-venus-focus | 64.57 | 0.76 | (-101.82,-132.11,4.07) | ✅ |
| **post-reset** | **688,901** ⚠ | **6889** ⚠ | **(-25.03,-32.47,1.0)** ⚠ | ✅ |

화면: 거의 빈 검은색 + 작은 점 (사용자 보고 일치)

### Fix 후

| 단계 | radius | lowerRadiusLimit | target |
|---|---|---|---|
| initial | 35.00 | 0.5000 | (0,0,0) |
| post-venus-focus | 64.57 | 0.7619 | (-152.52,-65.75,7.91) |
| **post-reset (venus)** | **35.00** ✅ | 0.0352 | **(0,0,0)** ✅ |
| post-reset (mercury) | 35.00 ✅ | 0.0124 | (0,0,0) ✅ |
| post-reset (sun) | 463.92 | 4.6392 | (0,0,0) ✅ |

화면 (venus → reset, sun → reset 모두): 태양 중앙 + 궤도 + 행성 정상 표시

## Test plan

- [x] core 패키지 빌드 통과 (`pnpm build`)
- [x] U+FFFD 한글 인코딩 검증
- [x] dev 서버 재기동 (monorepo dist stale 가드)
- [x] D-T2 시나리오 — venus focus → reset → radius 35 + target (0,0,0)
- [x] D-T2 시나리오 — mercury focus → reset → radius 35 + target (0,0,0)
- [x] D-T2 시나리오 — sun focus → reset → 시각적 정상 (radius 463.92 는 sun mesh 크기 반영)
- [x] post-reset wheel 동작 검증 — radius 463.92 → 438.94 (정상 줌인)
- [ ] D4 회귀 가드 (`browser-verify-reset-camera.mjs`) — 후속 이슈 분리 검토

## 비-범위

- #507 venus focus 추적 회귀 (별도 이슈, 옵션 A/C 재설계)
- #509 자유시점 (free-fly) UX 진입 (별도 이슈)
- D4 회귀 가드 자동화 — 본 PR 에선 D-T2 수동 검증으로 PASS. 회귀 가드는 별도 PR/이슈 분리 검토
- Animation race (sun 케이스 radius 463 잔존) — 시각적 정상이므로 본 PR 범위 외. 별도 잠재 이슈

## 관련 ADR / 이슈

- 발견: #507 venus focus 추적 회귀 옵션 A D-T2
- Related: #378 (focus frustum fix), #380 (zoom camera freeze), #408 (focus transition tier oscillate)
- 검증 매트릭스 위치: `camera-controller.ts:131-154` (reset Animation), `solar-system-scene.ts:591-680` (setTier), `tier-transition.ts:237/288-296` (stopAnimation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 체크리스트

- [x] 커밋 컨벤션 준수 (fix(scene): [#510] ...)
- [x] 불필요한 변경 없음 (clearFocus 11 라인 + 주석만)
- [x] 보안 취약점 없음 (camera state restoration 만, 외부 입력 없음)
- [x] SSoT (sub-agent JSON 스키마) 영향 없음 — 본 PR 은 sub-agent 호출/계약 변경 없음
- [x] cross-validate 루틴 — 정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 없음 (코드 fix only) → 해당 없음
- [x] ADR 호환성 체크: `20260503-378-focus-frustum-fix.md` / `20260509-380-zoom-camera-freeze-forensic.md` / `20260504-focus-tier-oscillate-fix.md` 의 결정과 충돌 없음 — clearFocus 의 origin/tier 복원은 focus 대칭 동작으로 ADR §결정 직교
