### PR TITLE
fix(scene): [#507] camera-controller follow observer — venus/mercury/sun focus 추적 일관화

### DIFF
--- a/packages/core/src/scene/camera-controller.ts
+++ b/packages/core/src/scene/camera-controller.ts
@@ -5,6 +5,7 @@ import {
   Vector3,
   type ArcRotateCamera,
   type Mesh,
+  type Observer,
   type Scene,
 } from '@babylonjs/core';
 
@@ -52,12 +53,47 @@ export class CameraController {
   #scene: Scene;
   #easing: EasingFunction;
 
+  /**
+   * R-Phase #507 — focus body 추적 observer.
+   *
+   * 회귀: mercury focus 는 정상 추적 (activeTier='body' → primary follow 활성),
+   * venus focus 는 mesh 가 공전해도 카메라 target 고정 (activeTier='inner' → primary follow skip).
+   *
+   * 본 observer 는 scene 측 tier 정책 (T1/T2 origin reset) 과 직교하게 카메라 책임으로 추적:
+   * focus 진입 시 매 프레임 `camera.target.copyFrom(mesh.absolutePosition)`. tier 무관.
+   *
+   * 라이프사이클:
+   *  - focusOn() Animation 종료 (onAnimationEnd) 후 attach — Animation 도중 target 덮어쓰기 race 회피
+   *  - 새 focusOn() / reset() / dispose() 호출 시 detach
+   *  - 변화 없는 frame 은 copyFrom 자체가 cheap (3 float 복사) — perf 영향 무시 가능
+   */
+  #followObserver: Observer<Scene> | null = null;
+
   constructor(camera: ArcRotateCamera, scene: Scene) {
     this.camera = camera;
     this.#scene = scene;
     const easing = new ExponentialEase();
     easing.setEasingMode(EasingFunction.EASINGMODE_EASEOUT);
     this.#easing = easing;
+  }
+
+  #detachFollow(): void {
+    if (this.#followObserver) {
+      this.#scene.onBeforeRenderObservable.remove(this.#followObserver);
+      this.#followObserver = null;
+    }
+  }
+
+  #attachFollow(mesh: Mesh): void {
+    this.#detachFollow();
+    this.#followObserver = this.#scene.onBeforeRenderObservable.add(() => {
+      // mesh 가 dispose 됐거나 scene 에서 제거됐으면 detach (스크럽 안전)
+      if (mesh.isDisposed()) {
+        this.#detachFollow();
+        return;
+      }
+      this.camera.target.copyFrom(mesh.absolutePosition);
+    });
   }
 
   /**
@@ -97,6 +133,10 @@ export class CameraController {
 
     const targetPos = mesh.absolutePosition.clone();
 
+    // R-Phase #507 — 새 focus 진입 시 기존 follow observer detach. Animation 도중 race 방지 +
+    // 이전 mesh 가 dispose 되지 않은 채 attach 잔존하는 경로 차단.
+    this.#detachFollow();
+
     // 현재 target → 새 target으로 애니메이션 (camera.target)
     Animation.CreateAndStartAnimation(
       'cam-target',
@@ -108,6 +148,12 @@ export class CameraController {
       targetPos,
       Animation.ANIMATIONLOOPMODE_CONSTANT,
       this.#easing,
+      () => {
+        // R-Phase #507 — onAnimationEnd: Animation 종료 후 follow observer attach.
+        // Animation 도중 attach 하면 매 프레임 target.copyFrom 이 Animation 보간값을 덮어써
+        // 부드러운 진입 효과 손실. 종료 후 attach 로 race 0.
+        this.#attachFollow(mesh);
+      },
     );
 
     // 반지름 애니메이션
@@ -122,13 +168,14 @@ export class CameraController {
       Animation.ANIMATIONLOOPMODE_CONSTANT,
       this.#easing,
     );
-
-    // 대상이 움직이는 천체라면 매 프레임 target 추적 — 단순화: 한 번만 애니메이션
-    // C6 다음 단계(D6/D7 UI)에서 실시간 추적 필요 시 observer 등록 예정.
   }
 
   /** 카메라 reset — 기본 위치로 복귀 */
   reset(targetRadius = 35, target: Vector3 = Vector3.Zero()): void {
+    // R-Phase #507 — focus 해제 시 follow observer detach. observer 잔존 시 Animation 의
+    // target=(0,0,0) 을 매 프레임 mesh 위치로 덮어써 reset 자체가 무효화됨.
+    this.#detachFollow();
+
     Animation.CreateAndStartAnimation(
       'cam-reset-target',
       this.camera,
@@ -154,6 +201,7 @@ export class CameraController {
   }
 
   dispose(): void {
+    this.#detachFollow();
     this.#scene.stopAllAnimations();
   }
 }


### PR DESCRIPTION
## Summary

- `CameraController` 에 `#followObserver` 도입 — focus 진입 시 매 프레임 `camera.target.copyFrom(mesh.absolutePosition)` 으로 mesh 공전 자동 추적
- mercury (작은 body, tier='body') 만 우연히 정상 동작했던 패턴을 venus/sun 까지 일관화
- 추적 정확도 diff: venus 24 → **0.039** (3 orders of magnitude 개선)

Closes: #507

## 원인 (forensic, 2026-05-19)

| 항목 | mercury focus | venus focus |
|---|---|---|
| activeTier | 'body' (T3) | 'inner' (T2) |
| primary follow (\`solar-system-scene.ts:885\`) | 발화 ✓ | **skip** ✗ |
| floatingOrigin | mercury world 추적 | (0,0,0) AU 고정 |
| 결과 | mesh local ≈ [0,0,0] → camTarget [0,0,0] 자동 | mesh world 변화 / camTarget 고정 |

mercury 는 작은 mesh → 'body' tier 진입 → origin shift + camera.target=(0,0,0) 으로 우연히 추적. venus 는 큰 mesh → 'inner' tier 진입 → primary follow skip → focus 시점 absolutePosition 으로 고정.

## 해결 — 옵션 A (camera-controller observer)

scene 의 tier 정책 (T1/T2 origin reset) 과 **직교**하게 카메라 측 책임으로 follow:

\`\`\`ts
class CameraController {
  #followObserver: Observer<Scene> | null = null;

  #attachFollow(mesh: Mesh): void {
    this.#detachFollow();
    this.#followObserver = this.#scene.onBeforeRenderObservable.add(() => {
      if (mesh.isDisposed()) { this.#detachFollow(); return; }
      this.camera.target.copyFrom(mesh.absolutePosition);
    });
  }

  focusOn(target): void {
    this.#detachFollow();
    Animation.CreateAndStartAnimation(
      'cam-target', /* ... */,
      () => this.#attachFollow(target.mesh)  // onAnimationEnd
    );
  }

  reset(...): void { this.#detachFollow(); /* ... */ }
  dispose(): void { this.#detachFollow(); /* ... */ }
}
\`\`\`

- Animation \`onAnimationEnd\` 후 attach — 300ms 진입 Animation 도중 target 덮어쓰기 race 회피
- reset / 새 focusOn / dispose 시 detach — 잔존 observer 가 reset 의 (0,0,0) Animation 매 프레임 덮어쓰는 회귀 방지
- mesh.isDisposed() 가드 — 스크럽 안전

## 옵션 B 와 비교

| | A: observer | B: T1/T2 primary follow 확장 |
|---|---|---|
| 변경 위치 | camera-controller 1곳 | solar-system-scene 1곳 |
| scene origin 정책 | 보존 | 변경 (T1/T2 도 setOriginToBody) |
| listener overhead | 추가 0 (camera 자체만) | T1/T2 마다 setOriginToBody → trail listener 호출 누적 |
| 부수 효과 | reset detach 책임 추가 | 주석 명시 "T1/T2 origin [0,0,0] 유지" 계약 위배 |

옵션 A 가 책임 경계 더 명확.

## Test plan

- [x] core 패키지 빌드 통과 (\`pnpm build\`)
- [x] U+FFFD 한글 인코딩 검증
- [x] dev 서버 재기동 (monorepo dist stale 가드)
- [x] **venus focus** 시계열 검증 — t=1.5s diff 0.039 / t=4.5s diff 0.039 (3초 후도 추적 지속)
- [x] **mercury focus** 회귀 가드 — t=1.5s diff 0.067 (이전 동작 보존)
- [x] **sun focus** 시계열 — t=1.5s diff 0.000 / t=4.5s diff 0.000 (정확)
- [x] 시각 검증 — venus / mercury / sun 모두 \"focus 후 카메라가 body 따라감\"
- [ ] D3 회귀 가드 (\`browser-verify-venus-focus-tracking.mjs\`) — 후속 이슈 분리 검토

## 비-범위

- #510 reset 회귀 (별도 PR #511 — base 가 develop 이므로 본 PR 시점엔 #511 미머지 → fix/507 단독으로는 mercury → reset 시 #510 회귀 잔존 가능. **#511 머지 후 정상화**)
- #509 자유시점 (free-fly) UX
- D3 회귀 가드 자동화 — 본 PR 에선 D-T2 수동 검증으로 PASS

## 관련 ADR / 이슈

- 발견: PR #506 D-T2 (2026-05-19)
- 분리 이슈: PR #511 (#510 reset 회귀)
- Related: #378 (focus frustum), #408 (focus tier oscillate), \`solar-system-scene.ts:885\` primary follow

## 1차 D-T2 이력

본 옵션 A 는 #507 코멘트 1차 D-T2 (2026-05-18) 에서 효과 이미 확인된 패턴. 당시 동반 발견된 reset 회귀는 본 PR 무관 (develop tip 잠재 회귀) 으로 확정되어 #510 / PR #511 분리. 본 PR 은 reset 회귀 해소 후 안전하게 도입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 체크리스트

- [x] 커밋 컨벤션 준수 (fix(scene): [#507] ...)
- [x] 불필요한 변경 없음 (camera-controller.ts 51 라인 + 주석)
- [x] 보안 취약점 없음 (scene observer + camera target 동기화만, 외부 입력 없음)
- [x] SSoT (sub-agent JSON 스키마) 영향 없음 — 본 PR 은 sub-agent 호출/계약 변경 없음
- [x] cross-validate 루틴 — 정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 없음 (코드 fix only) → 해당 없음
- [x] ADR 호환성 체크: `20260503-378-focus-frustum-fix.md` 의 4 가드 (in-flight / onAfterRender / lowerRadiusLimit / detachControl) 와 직교 (observer 는 camera target 추적만). 기존 ADR 결정과 충돌 없음
