### PR TITLE
feat(scene): [#509] 자유시점 (free-fly) 진입 메커니즘 — 시점 보존 detachFocus 경로

### DIFF
--- a/apps/web/src/components/layout/focus-quick-buttons.tsx
+++ b/apps/web/src/components/layout/focus-quick-buttons.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useSimStore } from '@/store/sim-store';
 import { useSimCommand } from '@/core/sim-context';
 // #402 — R-Phase allowlist SSoT (named import — scene namespace 경유 금지).
@@ -36,6 +37,24 @@ export function FocusQuickButtons() {
   const selected = useSimStore((s) => s.selectedBodyId);
   const sendCommand = useSimCommand();
 
+  // #509 — focus 중 Esc 키로 자유시점 진입. focus 없을 때는 no-op (reset 과 구분).
+  // input/textarea/contenteditable 포커스 중에는 발화 차단 (사용자 입력 보호).
+  useEffect(() => {
+    if (selected === null) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      const el = document.activeElement;
+      const isEditable =
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        (el instanceof HTMLElement && el.isContentEditable);
+      if (isEditable) return;
+      sendCommand({ type: 'enterFreeFly' });
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [selected, sendCommand]);
+
   return (
     <div className="flex items-center gap-1" data-r1-region="shortcut-bar">
       {FOCUS_BUTTONS.map((b) => {
@@ -71,6 +90,23 @@ export function FocusQuickButtons() {
         style={{ transitionDuration: 'var(--duration-fast)' }}
       >
         reset
+      </button>
+      {/* #509 — 자유시점 진입. focus 있을 때만 활성 (focus 없으면 의미 없음). */}
+      <button
+        type="button"
+        data-testid="focus-free-fly"
+        disabled={selected === null}
+        aria-disabled={selected === null}
+        title={selected === null ? '포커스 상태에서만 사용 가능' : '자유시점 (Esc)'}
+        onClick={() => sendCommand({ type: 'enterFreeFly' })}
+        className={`num text-caption px-2 py-1 rounded-sm border transition-colors ${
+          selected === null
+            ? 'bg-bg-surface/40 text-fg-muted border-border-subtle opacity-50 cursor-not-allowed'
+            : 'bg-bg-surface/80 text-fg-secondary border-border-subtle hover:bg-bg-elevated'
+        }`}
+        style={{ transitionDuration: 'var(--duration-fast)' }}
+      >
+        탐색
       </button>
     </div>
   );

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -408,6 +408,14 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           }
         };
 
+        // #509 — 자유시점 (free-fly) 진입 분기. clearFocus + reset 과 달리 tier/origin/camera 보존.
+        // syncFocusToScene 과 별도 helper — selectedBodyId 변화 (null 전이) 와 freeFlyMode 변화를
+        // 분리 처리하기 위함 (resetCamera vs enterFreeFly 경로 구분).
+        const detachToFreeFly = () => {
+          solar.detachFocus();
+          controller.clearFollow();
+        };
+
         // 엔진 스토어 변경 → 씬 setPhysicsEngine (#89 심리스 전환)
         // + 질량 배수 변경 → setBodyMassMultiplier (#107)
         // + selectedBodyId 변경 → syncFocusToScene (R1 #334+#335 — scene focus / camera 단일 책임)
@@ -438,7 +446,14 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           // 이전 (Phase 1 fix `acfcb74`): subscribe 분기 + setCameraHandlers focus/reset 콜백 이중 경로.
           // 이중 호출로 `controller.focusOn` 의 `Animation.CreateAndStartAnimation × 2` 가 2회 폐기 + 재시작.
           if (state.selectedBodyId !== prev.selectedBodyId) {
-            syncFocusToScene(state.selectedBodyId);
+            // #509 — selectedBodyId=null 전이 시 freeFlyMode 확인. true 면 detachToFreeFly (시점 유지),
+            // false 면 syncFocusToScene (sun 중심 reset). enterFreeFly action 이 selectedBodyId=null +
+            // freeFlyMode=true 를 같은 set 으로 commit 하므로 두 상태가 동시 관찰됨.
+            if (state.selectedBodyId === null && state.freeFlyMode) {
+              detachToFreeFly();
+            } else {
+              syncFocusToScene(state.selectedBodyId);
+            }
           }
         });
         // R1 #334+#335 — `setCameraRadiusHandler` 단일 인자 (focus/reset 콜백 폐기 — ADR §결정 2).

--- a/apps/web/src/core/core-adapter.ts
+++ b/apps/web/src/core/core-adapter.ts
@@ -27,6 +27,13 @@ export function attachCoreToStore(core: SimulationCore): () => void {
     store.setSelectedBody(id);
   };
 
+  // #509 — 자유시점 진입. 'bodySelected:null' 이 emit 직전에 발화하므로 freeFlyMode=true 가
+  // setSelectedBody(null) 의 freeFlyMode=false 에 덮여쓰지 않도록 enterFreeFly() 호출이 후행.
+  // simulation-core 가 emit 순서를 freeFlyEntered → bodySelected:null 로 보장.
+  const onFreeFlyEntered = () => {
+    store.enterFreeFly();
+  };
+
   const onTimeScaleChanged = ({ scale }: { scale: number }) => {
     store.setTimeScale(scale);
   };
@@ -39,6 +46,7 @@ export function attachCoreToStore(core: SimulationCore): () => void {
   core.on('error', onError);
   core.on('timeChanged', onTimeChanged);
   core.on('bodySelected', onBodySelected);
+  core.on('freeFlyEntered', onFreeFlyEntered);
   core.on('timeScaleChanged', onTimeScaleChanged);
   core.on('performance', onFps);
 
@@ -47,6 +55,7 @@ export function attachCoreToStore(core: SimulationCore): () => void {
     core.off('error', onError);
     core.off('timeChanged', onTimeChanged);
     core.off('bodySelected', onBodySelected);
+    core.off('freeFlyEntered', onFreeFlyEntered);
     core.off('timeScaleChanged', onTimeScaleChanged);
     core.off('performance', onFps);
   };

--- a/apps/web/src/store/sim-store.ts
+++ b/apps/web/src/store/sim-store.ts
@@ -72,6 +72,16 @@ export interface SimStoreState {
   mode: SimMode;
   julianDate: number | null;
   selectedBodyId: string | null;
+  /**
+   * #509 — 자유시점 (free-fly) 모드. focus 해제 시 'reset' (sun 중심 복귀) vs 'free-fly' (시점 유지) 구분.
+   *
+   * 전이:
+   *  - focus 진입 (selectedBodyId !== null) → 자동 false
+   *  - resetCamera 경로 → false (sun 중심)
+   *  - enterFreeFly 경로 → true (시점 유지)
+   * subscribe 측은 `selectedBodyId === null && freeFlyMode === true` 분기에서 detachFocus + clearFollow.
+   */
+  freeFlyMode: boolean;
   timeScale: number;
   fps: number | null;
   unitSystem: UnitSystem;
@@ -111,6 +121,8 @@ export interface SimStoreState {
   setMode: (mode: SimMode) => void;
   setTime: (julianDate: number) => void;
   setSelectedBody: (id: string | null) => void;
+  /** #509 — 자유시점 진입 시 호출. selectedBodyId=null + freeFlyMode=true 동시 set. */
+  enterFreeFly: () => void;
   setTimeScale: (scale: number) => void;
   setFps: (fps: number) => void;
   setUnitSystem: (unit: UnitSystem) => void;
@@ -160,6 +172,7 @@ export const useSimStore = create<SimStoreState>((set) => ({
   mode: 'observe',
   julianDate: null,
   selectedBodyId: null,
+  freeFlyMode: false,
   timeScale: 86_400,
   fps: null,
   unitSystem: 'astro',
@@ -189,7 +202,11 @@ export const useSimStore = create<SimStoreState>((set) => ({
     }),
   setMode: (mode) => set({ mode }),
   setTime: (julianDate) => set({ julianDate }),
-  setSelectedBody: (id) => set({ selectedBodyId: id }),
+  setSelectedBody: (id) =>
+    // #509 — focus 진입 시 freeFlyMode 자동 해제. resetCamera 경로 (id=null) 도 freeFlyMode=false.
+    // enterFreeFly 경로는 별도 action 으로 freeFlyMode=true 명시.
+    set({ selectedBodyId: id, freeFlyMode: false }),
+  enterFreeFly: () => set({ selectedBodyId: null, freeFlyMode: true }),
   setTimeScale: (scale) => set({ timeScale: scale }),
   setFps: (fps) => set({ fps }),
   setUnitSystem: (unit) => set({ unitSystem: unit }),

--- a/packages/core/src/engine/simulation-core.ts
+++ b/packages/core/src/engine/simulation-core.ts
@@ -223,6 +223,13 @@ export class SimulationCore {
         // R1 #334+#335 — resetCamera 콜백 폐기. event emit 으로 selectedBodyId=null sync 트리거.
         this.#emitter.emit('bodySelected', { id: null });
         break;
+      case 'enterFreeFly':
+        // #509 — 자유시점 진입. bodySelected:null (resetCamera) 과 구분 — focus tracking 만
+        // 해제 + 카메라 시점 (alpha/beta/radius/target/tier) 보존.
+        // 어댑터가 freeFlyEntered + bodySelected:null 동시 처리 → store freeFlyMode=true.
+        this.#emitter.emit('freeFlyEntered', {});
+        this.#emitter.emit('bodySelected', { id: null });
+        break;
       case 'setCameraRadius':
         this.#setRadiusHandler?.(cmd.radius);
         break;

--- a/packages/core/src/scene/camera-controller.ts
+++ b/packages/core/src/scene/camera-controller.ts
@@ -84,6 +84,16 @@ export class CameraController {
     }
   }
 
+  /**
+   * #509 — follow observer 외부 해제 (free-fly 진입 경로 전용).
+   *
+   * `reset()` 은 follow detach + Animation 동반이지만 free-fly 는 시점 유지 필수 →
+   * Animation 없이 follow 만 해제하는 public 진입점. 호출자 책임으로 한 번만 호출.
+   */
+  clearFollow(): void {
+    this.#detachFollow();
+  }
+
   #attachFollow(mesh: Mesh): void {
     this.#detachFollow();
     this.#followObserver = this.#scene.onBeforeRenderObservable.add(() => {

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -203,6 +203,17 @@ export interface SolarSystemSceneHandles {
    */
   clearFocus: () => void;
   /**
+   * #509 — 자유시점 (free-fly) 진입. `clearFocus` 와 달리 **tier/origin 을 유지**한다.
+   *
+   * 동작:
+   *  - focusBodyIdForAssert = null (focus tracking 해제)
+   *  - **setTier 미호출** — activeTier / floatingOrigin / mesh.scaling 등 모두 보존
+   *  - 카메라 alpha/beta/radius/target 도 호출자가 별도 변경하지 않으면 그대로 유지
+   *
+   * 사용: sim-canvas 의 freeFlyMode 진입 분기에서 호출 + camera-controller.clearFollow() 동반.
+   */
+  detachFocus: () => void;
+  /**
    * P11-B #289 — LOD override 설정. URL `?lod=high|mid|low` 는 전 body 강제, `'auto'` 는 거리 자동 판정 (기본).
    *
    * 런타임 1회 변경 전제 — 반복 호출도 허용되지만 매 updateAt 에서 즉시 반영.
@@ -761,6 +772,13 @@ export function createSolarSystemScene(
   const clearFocus = () => {
     focusBodyIdForAssert = null;
     setTier(defaultInitialTier());
+  };
+
+  // #509 — 자유시점 진입. focus tracking 만 해제 (tier/origin 보존).
+  // clearFocus 와 분리된 이유는 free-fly UX 가 "현재 시점 그대로 자유 탐색" 의도이므로
+  // tier/origin 까지 default 복원하면 사용자 시점이 깨짐 (예: venus 가까이 → 갑자기 solar 뷰).
+  const detachFocus = () => {
+    focusBodyIdForAssert = null;
   };
 
   // P10-D #263 — Newton 엔진 state 에서 body pos/vel 직접 추출 (timeScale 내성).
@@ -1384,6 +1402,7 @@ export function createSolarSystemScene(
     setFocusOrigin,
     applyFocusTier,
     clearFocus,
+    detachFocus,
     setLodOverride,
     getLodStats,
     getLodInfo,

--- a/packages/shared/src/events/core-events.ts
+++ b/packages/shared/src/events/core-events.ts
@@ -12,6 +12,17 @@ export type CoreEvents = {
   /** 천체가 선택됨 */
   bodySelected: { id: string | null };
 
+  /**
+   * #509 — 자유시점 (free-fly) 진입.
+   *
+   * `bodySelected: null` (resetCamera 경로) 과 구분된 별도 event.
+   * focus tracking 만 해제 + 카메라 alpha/beta/radius/target/tier 모두 보존 의도.
+   *
+   * UI 진입: shortcut bar "탐색" 버튼 or Esc 단축키 → sendCommand({type:'enterFreeFly'}).
+   * 어댑터 측에서 store.setFreeFlyMode(true) + selectedBodyId=null 동반 처리.
+   */
+  freeFlyEntered: Record<string, never>;
+
   /** 시뮬레이터 모드가 변경됨 */
   modeChanged: { mode: SimMode };
 
@@ -46,6 +57,7 @@ export type CoreCommand =
   | { type: 'jumpToJulianDate'; julianDate: number }
   | { type: 'focusOn'; bodyId: string }
   | { type: 'resetCamera' }
+  | { type: 'enterFreeFly' }
   | { type: 'setCameraRadius'; radius: number }
   | { type: 'setMode'; mode: SimMode }
   | { type: 'setLodOverride'; level: 'high' | 'mid' | 'low' | 'auto' };


### PR DESCRIPTION
## Summary

- focus 상태에서 카메라 시점 (alpha/beta/radius/target/tier) 을 **그대로 유지하면서** focus tracking 만 해제하는 자유시점 UX 신설
- shortcut bar "탐색" 버튼 + Esc 단축키 진입
- D-T2 시나리오 모두 통과 — 시점 보존 0.0000 dDelta, wheel zoom 정상, focus 재진입 추적 0.038 diff

Closes #509

## 동기 (PR #508 D-T2)

사용자 요구:
> 리셋 시 화면이 정상적이지 않음. 기존 포커스에서 자유시점으로 벗어나는 방법이 필요함.

기존 \`resetCamera\` (sun 중심 복귀) 와 다른 **시점 유지 detach** 경로 필요. UI 옵션 결정: 명시적 버튼 + Esc 단축키 (옵션 A).

## 변경 범위 (8 파일 / +127 라인)

### Core 신규 API

| 파일 | 변경 |
|---|---|
| \`shared/events/core-events.ts\` | \`CoreCommand\` \`'enterFreeFly'\` + \`CoreEvents.freeFlyEntered\` |
| \`core/engine/simulation-core.ts\` | \`case 'enterFreeFly'\`: emit \`freeFlyEntered\` + \`bodySelected:null\` 순서 보장 |
| \`core/scene/solar-system-scene.ts\` | \`detachFocus()\` (focusBodyIdForAssert=null 만, setTier 미호출 — tier/origin 보존) |
| \`core/scene/camera-controller.ts\` | \`clearFollow()\` public (#detachFollow 외부 노출) |

### Web 통합

| 파일 | 변경 |
|---|---|
| \`store/sim-store.ts\` | \`freeFlyMode: boolean\` + \`enterFreeFly()\` action. setSelectedBody 자동 false / enterFreeFly 만 true |
| \`core/core-adapter.ts\` | freeFlyEntered → store.enterFreeFly() |
| \`components/sim-canvas.tsx\` | subscribe 분기 — selectedBodyId=null + freeFlyMode=true 시 detachToFreeFly() (reset 대신) |
| \`components/layout/focus-quick-buttons.tsx\` | "탐색" 버튼 (focus 없을 때 disabled) + Esc 단축키 (focus 중 only, input/contenteditable 보호) |

## 실측

### D2 — 시점 보존 (Esc/"탐색" 후 3초 freeze)

| 항목 | dΔ | 판정 |
|---|---|---|
| alpha | 0.000000 | ✅ |
| beta | 0.000000 | ✅ |
| radius | 0.0000 | ✅ |
| target | 0.0000 | ✅ |

### D3 — free-fly → venus 재진입

venus 클릭 후 추적 정확도: **diffMag 0.0384** (4cm). PR #512 의 follow observer 효과 보존.

### D4 — free-fly wheel 동작

pre-wheel radius 47.92 → wheel -400 → **radius 14.61** (delta -33.31). 줌 제약 없음.

### D5 — 사용자 D-T2 시나리오

venus focus → Esc → 자유 탐색 (wheel zoom) → venus 재진입. 스크린샷: venus 중앙 크게 표시 + "focus · venus" 라벨.

## Test plan

- [x] shared / core 빌드 (\`pnpm -F ... build\`)
- [x] web typecheck (\`pnpm -F @astro-simulator/web typecheck\`)
- [x] U+FFFD 한글 인코딩 검증 (8 파일)
- [x] dev 서버 재기동 (monorepo dist stale 가드)
- [x] D1 UI — "탐색" 버튼 + Esc 단축키 동작
- [x] D2 시점 보존 — alpha/beta/radius/target 모두 dΔ=0
- [x] D3 재진입 — 추적 diff 0.038
- [x] D4 wheel — radius 47.92 → 14.61 (정상 줌인)
- [x] D5 시각 D-T2 — venus 중앙 표시 + "focus · venus" 라벨
- [ ] 회귀 가드 \`browser-verify-free-fly.mjs\` — 후속 이슈 분리 검토

## 비-범위

- 모바일 터치 제스처 (별도 이슈)
- reset 회귀 fix — 이미 PR #511 (#510) 머지 완료
- 회귀 가드 자동화 — 수동 D-T2 PASS, 별도 PR 분리

## 관련

- 발견: PR #508 후속 D-T2 (2026-05-19)
- 의존: PR #512 (#507 follow observer fix) — 재진입 추적 효과
- ADR: \`20260425-r1-store-scene-sync-unification.md\` (event 단일 진실원 유지)

## 체크리스트

- [x] 커밋 컨벤션 준수 (feat(scene): [#509] ...)
- [x] 불필요한 변경 없음 (8 파일, focus 해제 경로 분기만)
- [x] 보안 취약점 없음 (외부 입력 없음, Esc 이벤트만 추가)
- [x] SSoT (sub-agent JSON 스키마) 영향 없음
- [x] cross-validate 루틴 — 정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 없음 (코드 신규 기능 only) → 해당 없음
- [x] ADR 호환성 체크: \`20260425-r1-store-scene-sync-unification.md\` 의 event 단일 진실원 계약 유지 (freeFlyEntered 도 동일 흐름 — emit → adapter → store → subscribe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)