### PR TITLE
docs(adr-meta): [#449][#370][#382] batch 1 — Glossary + ADR Status workflow + 시각 자료 embed 표준

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,22 @@ sub-agent 에 multi-turn 세션 위임 시 세부 매트릭스가 다음 라운�
 - 코어 기술 스택 선택(언어/런타임/프레임워크/주요 라이브러리)을 도입·교체할 때는 `docs/decisions/<YYYYMMDD>-<topic>.md` 로 ADR을 남긴다
 - 섹션: **배경 / 후보 비교(축별) / 결정 / 결과·재검토 조건**
 - 프로젝트별 고유 패턴(상태 관리, 씬 동기화 등)도 추후 에이전트가 참조 가능하도록 `docs/architecture/` 또는 해당 프로젝트 CLAUDE.md에 명시 기록한다
+- 프로젝트 고유 용어 (D-T2 / R-Phase / Tier / Floating Origin / EIH 등) 는 [`docs/glossary.md`](docs/glossary.md) 에 일괄 정의 (#449) — ADR 본문 첫 등장 시 glossary 링크 권장
+
+#### ADR Status 워크플로 (Provisional → Accepted, 부분 도입 — #370 옵션 C)
+
+- 기본: 단순 결정 ADR (NO-OP / Phase 진입 / 라이브러리 채택 등) 은 **Accepted 직접 박제**
+- 예외 (Provisional 의무): **cross-validate 발동 ADR** (`## 교차검증` 의 박제 직후 1회 루틴 대상 — CRITICAL DIRECTIVE 개정 / ADR 신규·개정/폐기 / MINOR 이상 릴리스 Behavior Changes / 프로젝트 원칙·철학 선언) 은 cross-validate 결과 본문 통합 전까지 **Provisional** 박제. 통합 후 Accepted 전이
+- 전이 절차: ADR 메타데이터 `상태: Provisional` → `상태: Accepted (cross-validate <YYYY-MM-DD>)` 명시. §교차검증 반영 사항 4축 분류 (합의 / 이견 / 고유 발견 / Claude 편향 셀프 체크) 박제 후 전이
+- 근거: #370 (R3 cross-validate Gemini 고유 발견 — ADR 머지 시점 cross-validate 결과 미통합 잠재 위험)
+
+#### ADR 본문 시각 자료 embed 표준 (#382)
+
+forensic ADR 의 측정 데이터 (스크린샷 / 차트 / diagram) 는 별도 파일 박제 + ADR 본문 markdown image embed (`![desc](../reports/<이슈>-debug-<resolution>.png)`) 형식. ADR 단독 가독성 보장 — GitHub 렌더링에서 측정 시각 자료가 본문에 보임.
+
+- 적용 대상: 모든 forensic ADR (§Forensic 측정 결과 섹션) + 시각 자료가 있는 일반 ADR
+- 위치: 측정 데이터 표 직전 또는 직후
+- 표준 alt text: `<이슈번호> <측정 이름> <viewport 또는 시나리오>` (예: `373 forensic 측정 1280×720`)
 
 #### Forensic ADR 변형 (복잡 회귀 전용)
 

--- a/docs/decisions/20260430-r3-followup-body-proportion.md
+++ b/docs/decisions/20260430-r3-followup-body-proportion.md
@@ -25,6 +25,12 @@ R3 (#369) PR #371 의 D-T2 사용자 검증 2회차에서 ambient fix (#372) 와
 
 `scripts/_debug-373-proportion-tmp.mjs` (volt #67 패턴 일회성 debug) 로 실측. 데이터: [`docs/reports/373-debug-output.json`](../reports/373-debug-output.json), 스크린샷: [`docs/reports/373-debug-{1280x720,1920x1080,375x667}.png`](../reports/).
 
+#### 측정 시각 자료 (#382 embed 표준)
+
+![373 forensic 측정 1280×720](../reports/373-debug-1280x720.png)
+![373 forensic 측정 1920×1080](../reports/373-debug-1920x1080.png)
+![373 forensic 측정 375×667 (모바일)](../reports/373-debug-375x667.png)
+
 #### 측정 1 — 다중 metric 비교 (1280×720 default 진입 `?gpu=a`)
 
 | metric                       | 정의                                                                                  | 값         | 비고                                                                          |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,141 @@
+# 용어사전 (Glossary)
+
+> astro-simulator 의 ADR / lessons / phases / retrospectives 문서가 공유하는 프로젝트 고유 용어를 정의한다. 신규 참여자/에이전트의 onboarding 비용 절감 목적. 각 항목은 5줄 이내 정의 + 첫 도입 ADR 또는 PR 링크.
+
+---
+
+## D-T2 (D Trigger 2 — 사용자 D-Trigger 2 검증)
+
+사용자가 실 브라우저에서 시나리오를 손수 실행해 보고하는 검증 라운드. 자동 CI (`bench`, `r1-guard`, `verify:378-focus` 등) 가 통과해도 D-T2 에서 회귀가 발견되는 경우가 많음 — "DoD PASS ≠ 제품 동작" (volt #74) 원칙의 실측 게이트. 라운드 N=2가 기본 (라운드 1은 architect/dev 의 자체 검증, 라운드 2부터 사용자).
+
+- 발화: [`docs/decisions/20260425-r1-sun-visualization.md`](decisions/20260425-r1-sun-visualization.md) 이후 매 R-Phase ADR 의 §결과·재검토 조건 표준 박제
+
+## R-Phase (Roadmap v3 phase)
+
+Roadmap v3 의 incremental body-by-body build 단계. **R1**=태양 가시성 / **R2**=수성 / **R3**=금성 / **R4**=지구 (예정) / **R5+**=화성·목성·외행성. 각 phase 진입 시 `R_PHASE_BODY_ALLOWLIST` (focus 활성) + `BODY_SCALE` (시각 활성) 5곳 동시 박제 의무 (`20260506-body-scale-r-phase-policy.md` §체크리스트).
+
+- 발화: [`docs/phases/roadmap-v3-incremental.md`](phases/roadmap-v3-incremental.md), [`docs/decisions/20260425-r1-sun-visualization.md`](decisions/20260425-r1-sun-visualization.md)
+
+## Tier (T1 / T2 / T3)
+
+씬 단위 renderScale 차등 단계. **T1 solar** (renderScale ≈ 8.4e-11, 전체 태양계 뷰) / **T2 inner** (≈ 1.5e-9, 내행성권) / **T3 body** (≈ 5e-5, 표면 근접). `tier-transition.ts:runTierTransition` 이 ExponentialEase 300ms 로 camera dolly + apparent size 보존 수식 (`radius_new = radius_old × newScale / oldScale`) 으로 전환.
+
+- 발화: [`docs/decisions/20260423-display-relative-scale-unification.md`](decisions/20260423-display-relative-scale-unification.md) §3 후보 D (Q8=8D 배선 원리)
+- 정밀: [`docs/decisions/20260509-380-zoom-camera-freeze-forensic.md`](decisions/20260509-380-zoom-camera-freeze-forensic.md) (가드 A G1 fix)
+
+## Floating Origin (primary follow / safety net)
+
+큰 좌표 (Heliocentric 절대 m) 가 float32 precision 한계를 초과하지 않도록, 카메라 근처를 origin 으로 이동하는 시스템. **primary** = focus body 추적 (`activeTier === 'body' && focusBodyId` 시), **safety net** = free-fly 시 카메라가 1 AU 이상 이동 시 강제 shift. 변화 없으면 listener no-op.
+
+- 발화: [`docs/decisions/20260422-floating-origin.md`](decisions/20260422-floating-origin.md) (#288 P11-A primary), `solar-system-scene.ts:873-933`
+
+## scene unit
+
+Babylon 의 internal 좌표 단위. 현재 tier 의 `renderScale = 1 / metersPerSceneUnit` 으로 결정. T1 에서 1 unit ≈ 8.4e10 m (≈ 0.56 AU), T3 에서 1 unit ≈ 2e4 m (≈ 20 km). `camera.radius`, `mesh.position` 등 모든 Babylon 객체의 좌표가 scene unit.
+
+## focus / focusOn / detachFocus / clearFocus
+
+카메라 target 을 특정 body 로 잠그는 모드. **focusOn(body)** = mesh.absolutePosition 추적 + tier 사전 결정 (`applyFocusTier`). **detachFocus** = focus 만 해제 + tier/origin 보존 (#509 free-fly). **clearFocus** = focus + tier 완전 default 복원 (#510 reset). `controller.#followObserver` (#507) 가 `onBeforeRenderObservable` 으로 매 프레임 추적.
+
+- 발화: `camera-controller.ts:focusOn`, [`20260425-r1-store-scene-sync-unification.md`](decisions/20260425-r1-store-scene-sync-unification.md)
+
+## dolly
+
+카메라 radius (피사체와의 거리) 를 부드럽게 변경하는 ExponentialEase Animation. tier 전환의 핵심 — `runTierTransition` 의 `tier-transition-radius` Animation 이 300ms dolly 로 apparent size 보존.
+
+## detachControl / attachControl (G8a 가드)
+
+`Scene.detachControl()` 은 ArcRotateCamera 의 모든 입력 (wheel/pinch/drag) 을 일시 차단. tier 전환 직후 race window 0 ms 보장 목적 (#380 G8a). `attachControl()` 은 idempotent — 정상 종료 / fallback timer / visibilitychange 어느 경로로도 1회만 발동 (released 플래그).
+
+- 발화: [`docs/decisions/20260509-380-zoom-camera-freeze-forensic.md`](decisions/20260509-380-zoom-camera-freeze-forensic.md) §결정 §G8a SSoT
+
+## ArcRotateCamera (Babylon)
+
+target 주위를 alpha (수평) / beta (수직) / radius (거리) 구좌표로 회전하는 카메라. 본 프로젝트는 `setupArcRotateCamera` 가 default `alpha=-π/2`, `beta=π/2.5`, `radius=30`, `lowerRadiusLimit=0.5`, `upperRadiusLimit=1e14`, `wheelPrecision=3`, `pinchPrecision=50`, `panningSensibility=0` 으로 설정.
+
+- 발화: `camera.ts:setupArcRotateCamera`
+
+## runTierTransition
+
+tier 전환 시 입력 잠금 + camera dolly + onComplete 콜백 lifecycle 을 관리하는 함수. 300ms Animation + 500ms fallback timer + visibilitychange listener 3중 방어로 영구 잠금 방지. F2/F7/G8a 가드 통합.
+
+- 발화: `tier-transition.ts:runTierTransition`, [`20260509-380-zoom-camera-freeze-forensic.md`](decisions/20260509-380-zoom-camera-freeze-forensic.md)
+
+## EIH (Einstein-Infeld-Hoffmann 1PN)
+
+일반상대성 1차 후 뉴턴 보정 (1 Post-Newtonian) 식. 수성 근일점 세차 (43''/century) 등 GR 효과를 Newton 적분에 추가. `grMode === 'eih'` 활성 시 적용. `single-1pn` 은 sun-only 단순 항.
+
+- 발화: [`docs/decisions/20260321-p5-general-relativity.md`](decisions/20260321-p5-general-relativity.md) (#178/#191)
+
+## Yoshida (4th-order symplectic integrator)
+
+해밀턴 시스템 적분기 — velocity-verlet (2차) 대비 에너지 보존성 우수. 모바일에서 perf 비용 ~30% 추가. `integrator: 'yoshida4'` 옵션. 장기 적분 정확성 우선 시.
+
+- 발화: [`docs/decisions/20260411-p7-yoshida4-default-decision.md`](decisions/20260411-p7-yoshida4-default-decision.md) (#207)
+
+## Barnes-Hut (octree-based N-body)
+
+O(N²) → O(N log N) 가속 알고리즘. 소행성대 N=5000+ 같은 큰 N 에서 활성. `physicsEngine: 'barnes-hut'`. θ=0.5 가 정확도/성능 균형 기본값.
+
+- 발화: [`docs/decisions/20260227-p3-barnes-hut.md`](decisions/20260227-p3-barnes-hut.md) (#124/#138)
+
+## NO-OP ADR
+
+인계 항목 (이전 마일스톤 회고에서 인계된 작업) 이 착수 시점에 이미 해소되어 있을 때 작성하는 ADR. `docs/decisions/<YYYYMMDD>-<topic>-no-op.md`. 회귀 가드 (verify 스크립트 또는 테스트) 동반 박제 의무 — 미래 재발굴 시 빠르게 기각 근거.
+
+- 발화: CLAUDE.md §"인계 항목 실측 재검증 — NO-OP ADR 패턴"
+
+## Forensic ADR
+
+복잡 회귀 (가설 N≥2 + runtime 측정 + 사용자 인지 단위 mismatch 등) 전용 8섹션 ADR 변형. 일반 ADR 4섹션이 부족할 때 사용. 5조건 중 3개 이상 충족 시 발동.
+
+- 템플릿: [`docs/templates/forensic-adr-template.md`](templates/forensic-adr-template.md) (#381)
+- 모범: [`20260430-r3-followup-body-proportion.md`](decisions/20260430-r3-followup-body-proportion.md), [`20260509-380-zoom-camera-freeze-forensic.md`](decisions/20260509-380-zoom-camera-freeze-forensic.md), [`20260504-411-r1-guard-shortcut-bar-forensic.md`](decisions/20260504-411-r1-guard-shortcut-bar-forensic.md)
+
+## ADR Status (Provisional / Accepted / Superseded)
+
+ADR 라이프사이클 상태. **Provisional** = cross-validate 또는 사용자 결정 미완료 (잠정). **Accepted** = cross-validate 통과 + 사용자 승인 (최종). **Superseded** = 후속 ADR 이 본 결정을 대체 (`Superseded by: <new ADR>` 박제). cross-validate 발동 ADR 만 Provisional 사용 (#370 옵션 C — 부분 도입).
+
+- 발화: [`docs/decisions/20260429-r3-venus-visualization.md`](decisions/20260429-r3-venus-visualization.md) §교차검증 §고유 발견 §발견 1 → #370
+
+## cross-validate (Gemini 1회 교차검증)
+
+ADR / 정책 / CRITICAL DIRECTIVE 박제 직후 Gemini 2.5 Pro 로 1회 교차검증하는 루틴. 결과는 **합의 / 이견 / 고유 발견** 3축 분류 후 ADR §교차검증 반영 사항에 박제. 고유 발견은 (a) 현재 PR 반영 / (b) 후속 이슈 분리 둘 중 결정.
+
+- 발화: CLAUDE.md §"교차검증 (cross-validate)", [`docs/lessons/cross-validate-followup-pattern.md`](lessons/cross-validate-followup-pattern.md)
+
+## R-Phase Allowlist 가드 (defense-in-depth)
+
+R-Phase 미진입 body 의 focus / mass mutation 진입을 차단하는 4중 방어선. **#402 UI 1차** (focus-quick-buttons disabled), **#414 scene 2차** (simulation-core handler 가드), **#415 url-sync 3차** (`?focus=`), **#403 #404 UI 4차** (CelestialTree / InfoPanel / ScenarioPresets).
+
+- 발화: [`docs/decisions/20260504-r-phase-allowlist-guard.md`](decisions/20260504-r-phase-allowlist-guard.md)
+
+## BODY_SCALE / R-Phase 정책 매트릭스
+
+body 의 시각 활성 (BODY_SCALE 박제) vs focus 활성 (R-Phase allowlist) 2축 직교 정책. R-Phase 진입 의무 5곳 동시 박제: (1) `BODY_SCALE` (2) `R_PHASE_BODY_ALLOWLIST` (3) `FOCUS_BODIES` (verify 매트릭스) (4) R-Phase ADR (5) CHANGELOG. 누락 시 시각/focus 불일치 발생.
+
+- 발화: [`docs/decisions/20260506-body-scale-r-phase-policy.md`](decisions/20260506-body-scale-r-phase-policy.md) (#412)
+
+## viewport / 모바일 (375×667)
+
+R1/R2/R3 가드의 시각 회귀 검증 viewport 매트릭스. **1280×720** (desktop 기본), **1920×1080** (FHD), **375×667** (iPhone SE 기준 모바일). R1 가드 mismatch 임계 — desktop 0.5%, mobile 1.5% (ADR Amendment 2 #508).
+
+- 발화: [`docs/decisions/20260425-r1-ui-pixel-diff-guard.md`](decisions/20260425-r1-ui-pixel-diff-guard.md), [`apps/web/scripts/r1-ui-regression-guard.mjs`](../apps/web/scripts/r1-ui-regression-guard.mjs)
+
+## focus tracking observer (#507)
+
+`CameraController.#followObserver` — `focusOn` Animation `onAnimationEnd` 후 attach, `reset` / 새 `focusOn` / `dispose` 시 detach. 매 프레임 `camera.target.copyFrom(mesh.absolutePosition)` 으로 venus 등 큰 mesh (tier 'inner' 진입) 의 공전 추적. tier-conditional primary follow (T1/T2 skip) 과 직교한 카메라 측 책임.
+
+- 발화: [`#507`](https://github.com/coseo12/astro-simulator/issues/507) / PR [#512](https://github.com/coseo12/astro-simulator/pull/512)
+
+## free-fly mode (#509)
+
+focus 해제 시 camera 시점 (alpha/beta/radius/target/tier) 을 그대로 유지하면서 focus tracking 만 해제하는 UX 모드. `solar.detachFocus()` + `controller.clearFollow()`. shortcut bar "탐색" 버튼 + Esc 단축키. clearFocus (sun 중심 reset, #510) 와 구분.
+
+- 발화: [`#509`](https://github.com/coseo12/astro-simulator/issues/509) / PR [#513](https://github.com/coseo12/astro-simulator/pull/513)
+
+## tier transition input drops (#444)
+
+tier 전환 윈도우 (`detachControl ~ cleanup`) 에서 도달한 사용자 wheel/touchstart 카운트. G8a (input lock) 의 UX 비용 정량화 — 일정 운영 후 분포 관찰 → G8b (큐잉) 격상 결정 데이터. DevTools: `window.__simCore.metrics.tierTransitionInputDrops`.
+
+- 발화: [`#444`](https://github.com/coseo12/astro-simulator/issues/444) / PR [#516](https://github.com/coseo12/astro-simulator/pull/516)

--- a/docs/templates/forensic-adr-template.md
+++ b/docs/templates/forensic-adr-template.md
@@ -41,6 +41,20 @@
 
 > ⚠️ `_debug-*-tmp.mjs` 는 실측 직후 `rm` (영구 박제 금지). 결과 JSON/PNG 만 `docs/reports/` 에 박제. 영속화 가치가 있는 측정 스크립트는 `scripts/verify-<topic>.mjs` 로 승격.
 
+#### 측정 시각 자료 (PNG embed 표준 — #382)
+
+ADR 단독 가독성 보장 — GitHub 렌더링에서 본문에 측정 시각 자료가 보이도록 markdown image embed:
+
+```markdown
+![<이슈번호> forensic 측정 1280×720](../reports/<이슈번호>-debug-1280x720.png)
+![<이슈번호> forensic 측정 1920×1080](../reports/<이슈번호>-debug-1920x1080.png)
+![<이슈번호> forensic 측정 375×667](../reports/<이슈번호>-debug-375x667.png)
+```
+
+- 위치: 측정 데이터 표 직전 또는 직후 (가독성 우선 선택)
+- alt text: `<이슈번호> <측정 이름> <viewport 또는 시나리오>` (예: `373 forensic 측정 1280×720`)
+- 모범 사례: [`20260430-r3-followup-body-proportion.md`](../decisions/20260430-r3-followup-body-proportion.md) §Forensic 측정 결과
+
 #### 측정 1 — <측정 이름> (<viewport / 시나리오>)
 
 | metric | 정의 | 값 | 비고 |


### PR DESCRIPTION
## Summary

low priority 일괄 처리 batch 1 (G6 ADR 메타 그룹 3 이슈):

- **#449** — `docs/glossary.md` 신규 (20+ 프로젝트 용어 정의)
- **#370** — ADR Status workflow (Provisional → Accepted, 옵션 C 부분 도입)
- **#382** — ADR 본문 시각 자료 embed 표준 + 기존 #373 forensic ADR 에 시범 적용

Closes #449
Closes #370
Closes #382

## 변경 (4 파일 / +177 라인)

| 파일 | 변경 |
|---|---|
| `docs/glossary.md` | 신규 (+141) — 20+ 용어 정의 |
| `CLAUDE.md` | +16 — ADR 섹션에 Status workflow + 시각 자료 embed 표준 + glossary 링크 |
| `docs/templates/forensic-adr-template.md` | +14 — PNG embed 표준 박제 |
| `docs/decisions/20260430-r3-followup-body-proportion.md` | +6 — 3 viewport PNG embed 시범 |

## DoD 매핑

### #449 ADR Glossary
- [x] `docs/glossary.md` 신규 박제 (20+ 용어, 각 5줄 이내 + ADR/PR 링크)
- [x] CLAUDE.md ADR 섹션에서 glossary 링크

### #370 ADR Status workflow
- [x] CLAUDE.md `### 아키텍처 결정 기록 (ADR)` 에 Provisional → Accepted workflow 박제 (옵션 C 부분 도입)
- [x] glossary.md `ADR Status` 항목 SSoT 박제

### #382 시각 자료 embed
- [x] CLAUDE.md `#### ADR 본문 시각 자료 embed 표준` 신설
- [x] forensic ADR 템플릿에 PNG embed 표준 박제
- [x] 기존 #373 forensic ADR 에 3 viewport PNG embed 적용 (시범 사례)

## Test plan

- [x] 한글 인코딩 검증 (4 파일 U+FFFD 없음)
- [x] glossary.md 의 ADR/PR 링크 유효성 (관계 확인)
- [x] CLAUDE.md ADR 섹션 추가가 기존 4섹션 정책과 충돌 없음 (forensic 변형 + Status workflow + 시각 자료 표준 모두 추가 박제)
- [x] forensic 템플릿 갱신이 #381 (PR #517) 머지 후 상태와 정합

## 비-범위

- record-adr 스킬 자동화 (Provisional 자동 박제) — 별도 후속 (수동 박제로 충분)
- 모든 기존 ADR 의 PNG embed 일괄 적용 — #373 시범 박제 후 자연 적용

## 체크리스트

- [x] 커밋 컨벤션 준수 (docs(adr-meta): [#449][#370][#382] batch 1)
- [x] 불필요한 변경 없음 (4 파일 — glossary 신규 + ADR 메타 가이드 + 시범 적용)
- [x] 보안 취약점 없음 (문서 only)
- [x] SSoT (sub-agent JSON 스키마) 영향 없음
- [x] cross-validate 루틴 — ADR Status workflow + embed 표준은 정책 박제. 본 PR 후 cross-validate 발동 시 #370 의 Provisional→Accepted 전이 자체가 첫 시험대. 단독 cross-validate 호출 비목표 (본 PR 은 메타 정책 박제만, 첫 적용은 다음 ADR 작성 시)
- [x] ADR 호환성 체크: 기존 ADR 의 4섹션 정책과 직교 (Status workflow + 시각 자료 표준 = 추가 박제, 기존 결정 변경 없음). forensic 템플릿 (#381) 과도 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)