### PR TITLE
chore: [#386][#434][#435] batch 2 — lint 부채 + sim-context useMemo/fallback 가시화

### DIFF
--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -51,7 +51,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
       const wantsGpu = requested === 'webgpu' || requested === 'auto';
       if (!cap.webgpu) {
         // 항상 경고: 향후 P3-A/B 활성화 시 진단에 도움.
-        // eslint-disable-next-line no-console
+         
         console.warn('[gpu] WebGPU 미지원:', cap.reason);
         if (wantsGpu) {
           useSimStore.getState().setEngineNotice({

--- a/apps/web/src/core/detect-gpu-tier.ts
+++ b/apps/web/src/core/detect-gpu-tier.ts
@@ -100,7 +100,7 @@ export function classifyAdapterIsDiscrete(
 ): boolean {
   if (adapter === null || adapter.vendor === '') {
     // Privacy fingerprinting 완화로 빈 adapter info — 보수적 integrated 취급 (ADR §위험 1)
-    // eslint-disable-next-line no-console
+     
     console.warn('[detect-gpu-tier] adapter info unavailable (privacy) — integrated 폴백');
     return false;
   }
@@ -118,7 +118,7 @@ export function classifyAdapterIsDiscrete(
   }
 
   // 미지 vendor — 보수적 integrated 취급 + drift 탐지 경고 (ADR §축 1 암묵 전제)
-  // eslint-disable-next-line no-console
+   
   console.warn(
     `[detect-gpu-tier] 미지 vendor='${adapter.vendor}' architecture='${adapter.architecture}' — integrated 폴백`,
   );

--- a/apps/web/src/core/parse-gpu-tier.ts
+++ b/apps/web/src/core/parse-gpu-tier.ts
@@ -28,7 +28,7 @@ export function parseGpuTier(urlParam: string | null | undefined): GpuTier | 'au
     return normalized as GpuTier;
   }
   // 알 수 없는 값 — 기존 parse-* 패턴과 동일한 폴백 + warn.
-  // eslint-disable-next-line no-console
+   
   console.warn(`[parse-gpu-tier] 알 수 없는 ?gpu=${urlParam} — 'auto' 로 폴백`);
   return 'auto';
 }

--- a/apps/web/src/core/parse-gr-mode.ts
+++ b/apps/web/src/core/parse-gr-mode.ts
@@ -30,7 +30,7 @@ export function parseGrMode(urlParam: string | null | undefined): GrMode {
   }
   if (normalized === 'eih') return 'eih';
   // 알 수 없는 값 — parseIntegratorKind 와 동일한 폴백 + warn.
-  // eslint-disable-next-line no-console
+   
   console.warn(`[parse-gr-mode] 알 수 없는 ?gr=${urlParam} — 'off'로 폴백`);
   return 'off';
 }

--- a/apps/web/src/core/parse-integrator.ts
+++ b/apps/web/src/core/parse-integrator.ts
@@ -29,7 +29,7 @@ export function parseIntegratorKind(urlParam: string | null | undefined): Integr
     return 'yoshida4';
   }
   // 알 수 없는 값 — GrMode 패턴과 동일한 폴백 + warn.
-  // eslint-disable-next-line no-console
+   
   console.warn(`[parse-integrator] 알 수 없는 ?integrator=${urlParam} — 'velocity-verlet'로 폴백`);
   return 'velocity-verlet';
 }

--- a/apps/web/src/core/parse-lod-level.ts
+++ b/apps/web/src/core/parse-lod-level.ts
@@ -32,7 +32,7 @@ export function parseLodLevel(urlParam: string | null | undefined): LodOverride 
     return normalized as LodOverride;
   }
   // 알 수 없는 값 — parse-integrator 패턴과 동일한 폴백 + warn.
-  // eslint-disable-next-line no-console
+   
   console.warn(`[parse-lod-level] 알 수 없는 ?lod=${urlParam} — 'auto' 로 폴백`);
   return 'auto';
 }

--- a/apps/web/src/core/sim-context.tsx
+++ b/apps/web/src/core/sim-context.tsx
@@ -3,7 +3,7 @@
 import type { SimulationCore } from '@astro-simulator/core';
 import type { Tier } from '@astro-simulator/core/scene';
 import type { CoreCommand } from '@astro-simulator/shared';
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 /**
  * #400 — ScaleControl 양방향 sync 에 필요한 camera 의 최소 surface.
@@ -60,21 +60,48 @@ export function SimCommandProvider({
   // ADR: docs/decisions/20260510-419-sim-canvas-mount-race.md §결정 1 (A1-E early return).
   // sim-canvas.tsx 의 비동기 core 생성 (useEffect → setCore) 이 완료된 후에만 children 의 useEffect 가
   // 발화 → sendCommand 가 항상 non-null core 호출 보장 → useSimCommand race condition 구조적 차단.
-  // 부모 ADR 20260504-415-url-sync-guard.md §재검토 조건 1 충족 (line 104 race fallback 의 존재 이유 소멸).
-  if (core === null) return null;
+  // 부모 ADR 20260504-415-url-sync-guard.md §재검토 조건 1 충족.
+  //
+  // #435 — Context value referential equality 안정화. 매 렌더 새 api object 생성 시 모든
+  // useContext 소비자 재렌더 + useEffect deps 충돌 위험. useMemo 는 Rule of Hooks 준수 위해
+  // early return *이전* 에 호출 — core === null 분기를 useMemo 안에 통합 후 api === null 일 때 보류.
+  const api: SimCommandApi | null = useMemo(() => {
+    if (core === null) return null;
+    return {
+      command: (cmd) => core.command(cmd),
+      camera: camera ?? null,
+      getActiveTier: getActiveTier ?? null,
+    };
+  }, [core, camera, getActiveTier]);
 
-  const api: SimCommandApi = {
-    command: (cmd) => core.command(cmd),
-    camera: camera ?? null,
-    getActiveTier: getActiveTier ?? null,
-  };
+  if (api === null) return null;
+
   return <SimCommandContext.Provider value={api}>{children}</SimCommandContext.Provider>;
 }
 
-/** core에 명령을 보내는 훅. core가 아직 초기화되지 않았으면 no-op. */
+// #434 — Provider 외부 또는 mount 보류 우회 진입 시 dev 가시화. silent no-op 패턴은 미래
+// 새 진입자 (portal / 별도 root / programmatic API 등) 가 race 를 만들어도 흡수되어 발견 불가
+// → dev 환경에서 console.warn 으로 가시화. production 은 silent no-op 유지 (UX 안정성).
+//
+// throw 안 함 — error boundary 설계 영향 회피. warn 으로 충분 (dev 단계 가시화 목적).
+const noopCommand = (): void => undefined;
+const warnAndNoop = (): void => {
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'development') {
+    console.warn(
+      '[useSimCommand] SimCommandProvider 외부 또는 core 미준비 상태에서 호출됨 — silent no-op 반환. ' +
+        'mount 순서 확인 필요 (ADR 20260510-419-sim-canvas-mount-race).',
+    );
+  }
+  return undefined;
+};
+
+/** core에 명령을 보내는 훅. core가 아직 초기화되지 않았으면 dev warn + no-op. */
 export function useSimCommand(): (cmd: CoreCommand) => void {
   const ctx = useContext(SimCommandContext);
-  return ctx?.command ?? (() => undefined);
+  // #435 — ctx.command 가 안정 reference (useMemo) 이거나 fallback 도 module-level 상수
+  // (noopCommand / warnAndNoop) → 매 호출 새 closure 미생성 → 호출자 useEffect deps 안정.
+  // #434 — dev 가시화: ctx === null (Provider 외부 호출) 일 때 warnAndNoop, ctx?.command 미존재시 noopCommand.
+  return ctx?.command ?? (ctx === null ? warnAndNoop : noopCommand);
 }
 
 /**

--- a/apps/web/src/hooks/use-osculating-sync.ts
+++ b/apps/web/src/hooks/use-osculating-sync.ts
@@ -1,11 +1,13 @@
 'use client';
 
 import { ephemeris as ephemerisApi } from '@astro-simulator/core';
+// #386 — TypeScript 5 권고 `import type` 분리 (consistent-type-imports). type-only import 는
+// SSR prerender 시 runtime wasm 로드 시도를 차단 (기존 `typeof import(...)` 패턴과 동일 의도).
+import type { physics as physicsApi } from '@astro-simulator/core';
 import { GRAVITATIONAL_CONSTANT } from '@astro-simulator/shared';
 import { useEffect, useRef, useState } from 'react';
 
-// 동적 import 결과 타입 참조용 — top-level import 하면 SSR prerender 시 wasm 로드 시도하므로 type-only.
-type ExtractFn = typeof import('@astro-simulator/core').physics.extractOsculatingElements;
+type ExtractFn = typeof physicsApi.extractOsculatingElements;
 
 /**
  * P9 #254 D7 — Galilean 위성 Osculating 원소 1Hz polling 훅.
@@ -298,7 +300,7 @@ export function useOsculatingSync(opts?: OscSyncOptions): OscSyncResult {
       if (timerId !== null) clearTimeout(timerId);
     };
     // observedFps 는 ref 로 참조 → 의존성 배열 제외 (매 frame 재실행 방지).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [enabled, baseInterval]);
 
   return { elements, currentIntervalMs, observedFps };


### PR DESCRIPTION
## Summary

low priority 일괄 처리 batch 2 (G5 React/store/lint 그룹 3 이슈):

- **#386** — lint 부채 fix (use-osculating-sync `import()` type annotation + unused eslint-disable 8건). lod-dev-overlay setState in effect 는 **이미 해소**됨 (NO-OP)
- **#435** — `SimCommandProvider` 의 `api` object useMemo 안정화 (Context value referential equality)
- **#434** — `useSimCommand` fallback dev 가시화 (silent no-op → warnAndNoop)

Closes #386
Closes #435
Closes #434

## 변경 (8 파일 / +49/-20 라인)

### #386 lint 부채

- `apps/web/src/hooks/use-osculating-sync.ts:8` — `typeof import('@astro-simulator/core').physics.extractOsculatingElements` → `import type { physics as physicsApi } ... typeof physicsApi.extractOsculatingElements`
- 6 파일 (sim-canvas.tsx + detect-gpu-tier.ts + parse-{gpu-tier,gr-mode,integrator,lod-level}.ts) — unused eslint-disable directive 8건 `--fix` 자동 제거
- **NO-OP 확정**: `lod-dev-overlay.tsx:44` setState in effect — develop tip 시점 이미 해소 (`useState` mount 시 1회 결정, useEffect 내부 setState 0)

### #435 useMemo 안정화

- `apps/web/src/core/sim-context.tsx` `SimCommandProvider` 의 `api` object → `useMemo([core, camera, getActiveTier])`
- **Rule of Hooks 준수**: useMemo 안에서 `core === null` 분기 통합 후 `api === null` 일 때 early return. #419 mount 보류 가드와 정합

### #434 dev 가시화

- `apps/web/src/core/sim-context.tsx` 의 fallback `() => undefined` → module-level `noopCommand` / `warnAndNoop` 분리
- Provider 외부 호출 (ctx === null) 시 dev 환경 `console.warn` — production silent no-op 유지
- throw 안 함 (error boundary 설계 영향 회피)

## Test plan

- [x] `pnpm lint` 0 error 0 warning PASS
- [x] `pnpm typecheck` PASS
- [x] `pnpm -F web test` 237 passed (회귀 0)
- [x] `pnpm -F core build` PASS
- [x] U+FFFD 한글 인코딩 검증 (2 파일)
- [x] sim-context.test.tsx mount 보류 단언 회귀 검증

## 체크리스트

- [x] 커밋 컨벤션 준수 (chore: [#386][#434][#435] batch 2)
- [x] 불필요한 변경 없음 (8 파일, lint --fix + 2 React 패턴 fix)
- [x] 보안 취약점 없음
- [x] SSoT (sub-agent JSON 스키마) 영향 없음
- [x] cross-validate 루틴 — lint 부채 + React 패턴 fix 는 정책·규약·ADR 박제 변경 없음
- [x] ADR 호환성 체크: `20260510-419-sim-canvas-mount-race.md` §결정 1 (A1-E early return) 보존 — useMemo 안에 core null 분기 통합 후 동일 effect (mount 보류) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)