### PR TITLE
[#629] free-fly 줌 고정 회귀 fix — wheelDeltaPercentage (scale-invariant zoom)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,29 @@ jobs:
           kill $WEB_PID || true
           exit $GUARD_EXIT
 
+      # ============================================================
+      # #629 free-fly 줌 고정 회귀 가드 — wheelDeltaPercentage (scale-invariant zoom)
+      # ============================================================
+      # ADR: docs/decisions/20260607-629-freefly-camera-zoom-forensic.md §결정 §회귀 가드
+      # 검증 2축: (S1) free-fly 직접 baseline 줌 체감 (#509 시점 보존 + 줌 작동)
+      #          (S2) io(galilean) focus → free-fly 줌 5틱 누적 rel ≥ 1% + 회전 작동
+      # forensic 회귀값: S2 절대 wheelPrecision 시 rel 0.03% (tier=body radius≈158386).
+      # DoD PASS ≠ 제품 동작 (volt #74) — 위성 free-fly 줌 정지 잠복 재발 차단.
+
+      - name: '#629 free-fly 줌 회귀 가드 (verify:629-freefly-zoom)'
+        if: hashFiles('pnpm-lock.yaml') != '' && hashFiles('apps/web/scripts/browser-verify-629-freefly-zoom.mjs') != ''
+        run: |
+          pnpm --filter @astro-simulator/web exec next dev -p 3006 &
+          WEB_PID=$!
+          for i in {1..60}; do
+            if curl -sf http://localhost:3006/ > /dev/null; then break; fi
+            sleep 2
+          done
+          BASE_URL=http://localhost:3006 node apps/web/scripts/browser-verify-629-freefly-zoom.mjs
+          GUARD_EXIT=$?
+          kill $WEB_PID || true
+          exit $GUARD_EXIT
+
       # --- yarn 경로 (pnpm-lock 없을 때만) ---
       # yarn berry (v2+) vs classic (v1) 감지:
       # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "verify:380-zoom": "node scripts/browser-verify-380-zoom.mjs",
     "verify:focus-transition": "node scripts/browser-verify-focus-transition.mjs",
     "verify:r-phase-allowlist": "node scripts/browser-verify-r-phase-allowlist.mjs",
-    "verify:627-satellite-orbit": "node scripts/browser-verify-627-satellite-orbit.mjs"
+    "verify:627-satellite-orbit": "node scripts/browser-verify-627-satellite-orbit.mjs",
+    "verify:629-freefly-zoom": "node scripts/browser-verify-629-freefly-zoom.mjs"
   },
   "dependencies": {
     "@astro-simulator/core": "workspace:*",

--- a/apps/web/scripts/browser-verify-629-freefly-zoom.mjs
+++ b/apps/web/scripts/browser-verify-629-freefly-zoom.mjs
@@ -36,8 +36,8 @@ const flags = { json: args.includes('--json') };
 
 const VIEWPORT = { width: 1280, height: 720 };
 const SETTLE_MS = 2500;
-// 줌 체감 임계 — 5틱 누적 상대변화율. fix(wheelDeltaPercentage=0.01) 후 ~5%, 회귀(절대) 시 ~0.15%.
-// 1% 임계는 두 상태를 안전 마진으로 분리.
+// 줌 체감 임계 — 5틱 누적 상대변화율. 실측: fix(wheelDeltaPercentage=0.01) 후 위성 free-fly
+// ~38.95%/54.66%, 회귀(절대 wheelPrecision) 시 ~0.03%. 1% 임계가 두 상태를 안전 마진으로 분리.
 const ZOOM_PERCEPTIBLE_THRESHOLD = 0.01;
 const WHEEL_TICKS = 5;
 // 위성 focus 가 push 하는 deep tier. fix 전 radius≈158386 에서 줌 정지가 발현된 케이스.

--- a/apps/web/scripts/browser-verify-629-freefly-zoom.mjs
+++ b/apps/web/scripts/browser-verify-629-freefly-zoom.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * #629 fix 회귀 가드 — free-fly 진입 시 줌 "고정" 회귀 차단.
+ *
+ * ADR `docs/decisions/20260607-629-freefly-camera-zoom-forensic.md` §결정 §회귀 가드.
+ *
+ * 사용법:
+ *   pnpm --filter @astro-simulator/web verify:629-freefly-zoom
+ *   pnpm --filter @astro-simulator/web verify:629-freefly-zoom -- --json
+ *
+ * ## 배경 (forensic 확정)
+ *
+ * 위성(galilean) focus → free-fly 진입 시 카메라가 tier=body / radius≈158386 으로 잔존.
+ * 절대 `wheelPrecision=3` 은 틱당 수십 unit (절대) 만 변경 → radius 158386 대비 변화율 0.03%
+ * → 줌이 체감상 완전히 멈춤 ("탐색 시 시점 고정"). fix = `wheelDeltaPercentage` (radius 비례 %).
+ *
+ * ## 검증 시나리오 (2 직교)
+ *
+ * | 시나리오 | DoD | 회귀 시 |
+ * |---|---|---|
+ * | S1. free-fly 직접 (baseline) | 줌 5틱 누적 상대변화 ≥ 1% (#509 시점 보존 + 줌 작동) | baseline 줌 죽음 |
+ * | S2. io(galilean) focus → free-fly | 줌 5틱 누적 상대변화 ≥ 1% + 회전 작동 | 0.03% (절대 wheelPrecision 회귀) |
+ *
+ * dev 빌드 의존:
+ *  - window.__solarScene (getTier / meshes) — solar-system-scene export
+ *  - window.__simStore  — zustand store (setSelectedBody / enterFreeFly)
+ *
+ * 환경변수: BASE_URL (기본 http://localhost:3000)
+ */
+
+import { chromium } from 'playwright';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const args = process.argv.slice(2);
+const flags = { json: args.includes('--json') };
+
+const VIEWPORT = { width: 1280, height: 720 };
+const SETTLE_MS = 2500;
+// 줌 체감 임계 — 5틱 누적 상대변화율. fix(wheelDeltaPercentage=0.01) 후 ~5%, 회귀(절대) 시 ~0.15%.
+// 1% 임계는 두 상태를 안전 마진으로 분리.
+const ZOOM_PERCEPTIBLE_THRESHOLD = 0.01;
+const WHEEL_TICKS = 5;
+// 위성 focus 가 push 하는 deep tier. fix 전 radius≈158386 에서 줌 정지가 발현된 케이스.
+const SATELLITE_ID = 'io';
+
+async function measure(page) {
+  return await page.evaluate(() => {
+    const solar = window.__solarScene;
+    const meshes = solar?.meshes;
+    const firstMesh = meshes?.values().next().value;
+    const scene = firstMesh?.getScene();
+    const cam = scene?.activeCamera;
+    if (!cam) return { error: 'no camera' };
+    const t = cam.target;
+    return {
+      tier: solar.getTier ? solar.getTier() : 'unknown',
+      radius: cam.radius,
+      alpha: cam.alpha,
+      beta: cam.beta,
+      targetDistToOrigin: Math.hypot(t.x, t.y, t.z),
+    };
+  });
+}
+
+async function realWheel(page, deltaY, count) {
+  await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+  for (let i = 0; i < count; i += 1) {
+    await page.mouse.wheel(0, deltaY);
+    await page.waitForTimeout(120);
+  }
+}
+
+async function dragRotate(page) {
+  const cx = VIEWPORT.width / 2;
+  const cy = VIEWPORT.height / 2;
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  await page.mouse.move(cx + 120, cy + 60, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(200);
+}
+
+async function bootstrap(page) {
+  await page.goto(`${BASE_URL}/?gpu=a&lod=auto`, { waitUntil: 'networkidle', timeout: 30_000 });
+  await page.waitForFunction(
+    () => typeof window.__solarScene !== 'undefined' && typeof window.__simStore !== 'undefined',
+    { timeout: 15_000 },
+  );
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+async function enterFreeFly(page) {
+  await page.evaluate(() => window.__simStore?.getState?.().enterFreeFly?.());
+  await page.waitForTimeout(600);
+}
+
+/** 줌 체감 측정 — 줌인/줌아웃 각 WHEEL_TICKS 틱 누적 상대변화율의 큰 쪽 반환. */
+async function measureZoomPerceptibility(page) {
+  const beforeIn = await measure(page);
+  await realWheel(page, -120, WHEEL_TICKS);
+  const afterIn = await measure(page);
+  const relIn = beforeIn.radius ? Math.abs(afterIn.radius - beforeIn.radius) / beforeIn.radius : 0;
+
+  const beforeOut = await measure(page);
+  await realWheel(page, 120, WHEEL_TICKS);
+  const afterOut = await measure(page);
+  const relOut = beforeOut.radius
+    ? Math.abs(afterOut.radius - beforeOut.radius) / beforeOut.radius
+    : 0;
+
+  return { relIn, relOut, rel: Math.max(relIn, relOut) };
+}
+
+async function scenarioBaseline(browser) {
+  console.log('\n[S1] free-fly 직접 (baseline) — 줌 체감 + 시점 보존');
+  const context = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  const page = await context.newPage();
+  try {
+    await bootstrap(page);
+    await enterFreeFly(page);
+    const zoom = await measureZoomPerceptibility(page);
+    const pass = zoom.rel >= ZOOM_PERCEPTIBLE_THRESHOLD;
+    console.log(
+      `  rel(in/out)=${(zoom.relIn * 100).toFixed(2)}%/${(zoom.relOut * 100).toFixed(2)}% → ${pass ? 'PASS' : 'FAIL'}`,
+    );
+    return { scenario: 'S1', zoom, pass };
+  } finally {
+    await context.close();
+  }
+}
+
+async function scenarioSatellite(browser) {
+  console.log(`\n[S2] ${SATELLITE_ID}(galilean) focus → free-fly — 줌 체감 + 회전`);
+  const context = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  const page = await context.newPage();
+  try {
+    await bootstrap(page);
+    // 위성 focus (UI 버튼 경로 = store.setSelectedBody)
+    await page.evaluate(
+      (id) => window.__simStore?.getState?.().setSelectedBody?.(id),
+      SATELLITE_ID,
+    );
+    await page.waitForTimeout(SETTLE_MS);
+    await enterFreeFly(page);
+
+    // 회전 작동
+    const preRot = await measure(page);
+    await dragRotate(page);
+    const postRot = await measure(page);
+    const dAlpha = Math.abs(postRot.alpha - preRot.alpha);
+    const dBeta = Math.abs(postRot.beta - preRot.beta);
+    const rotates = dAlpha > 1e-4 || dBeta > 1e-4;
+
+    // 줌 체감 (회귀 핵심 — fix 전 0.03%)
+    const zoom = await measureZoomPerceptibility(page);
+    const state = await measure(page);
+    const zoomPass = zoom.rel >= ZOOM_PERCEPTIBLE_THRESHOLD;
+    const pass = zoomPass && rotates;
+    console.log(
+      `  tier=${state.tier} rel(in/out)=${(zoom.relIn * 100).toFixed(2)}%/${(zoom.relOut * 100).toFixed(2)}% 회전=${rotates}(dα=${dAlpha.toFixed(3)}) → ${pass ? 'PASS' : 'FAIL'}`,
+    );
+    return { scenario: 'S2', tier: state.tier, zoom, rotates, dAlpha, dBeta, pass };
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  console.log('\n=== #629 free-fly 줌 고정 회귀 가드 (wheelDeltaPercentage) ===');
+  console.log(
+    `  base URL: ${BASE_URL}  임계: 줌 5틱 누적 rel ≥ ${ZOOM_PERCEPTIBLE_THRESHOLD * 100}%`,
+  );
+
+  const browser = await chromium.launch({ headless: true });
+  const result = { timestamp: new Date().toISOString(), baseUrl: BASE_URL, scenarios: {} };
+  let allPass = true;
+  try {
+    result.scenarios.s1 = await scenarioBaseline(browser);
+    if (!result.scenarios.s1.pass) allPass = false;
+    result.scenarios.s2 = await scenarioSatellite(browser);
+    if (!result.scenarios.s2.pass) allPass = false;
+  } finally {
+    await browser.close();
+  }
+
+  console.log('\n=== 최종 요약 ===');
+  for (const [k, s] of Object.entries(result.scenarios)) {
+    console.log(`  ${k}: ${s.pass ? 'PASS' : 'FAIL'}`);
+  }
+  console.log(`  overall: ${allPass ? 'PASS' : 'FAIL'}`);
+
+  if (flags.json) {
+    console.log('\n--- JSON ---');
+    console.log(JSON.stringify(result, null, 2));
+  }
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/docs/decisions/20260606-627-satellite-orbit-structure-forensic.md
+++ b/docs/decisions/20260606-627-satellite-orbit-structure-forensic.md
@@ -37,52 +37,52 @@ R6 PR #627 의 실 Chrome D-T2 검증에서 사용자가 두 회귀를 보고 (h
 
 #### 측정 1 — LineSystem position/scaling (탐색 시점, tier=solar, 1280×720)
 
-| LineSystem | position | scaling | worldCenter | 비고 |
-|---|---|---|---|---|
-| `orbit-lines` (batch) | **(0, 0, 0)** | **(1, 1, 1)** | (-3.03, -0.81, 0.07) | **position 고정 + scale 1 — parent 미추적 + visual scale 미적용** |
-| `moon-orbit-line` (별도) | (-3.01, **11.98**, ~0) | **(30, 30, 30)** | (-3.02, 11.93, ~0) | position = earth scene 좌표 (parent 추적) + scaling 30 = `getOrbitVisualScale('earth')` |
+| LineSystem               | position               | scaling          | worldCenter          | 비고                                                                                    |
+| ------------------------ | ---------------------- | ---------------- | -------------------- | --------------------------------------------------------------------------------------- |
+| `orbit-lines` (batch)    | **(0, 0, 0)**          | **(1, 1, 1)**    | (-3.03, -0.81, 0.07) | **position 고정 + scale 1 — parent 미추적 + visual scale 미적용**                       |
+| `moon-orbit-line` (별도) | (-3.01, **11.98**, ~0) | **(30, 30, 30)** | (-3.02, 11.93, ~0)   | position = earth scene 좌표 (parent 추적) + scaling 30 = `getOrbitVisualScale('earth')` |
 
 - **관찰 1**: `moon-orbit-line` 은 position 이 earth scene 좌표 (11.98) 로 매 프레임 동기화 + scaling 30 적용 → moon mesh (distToOrigin 11.39) 와 정합.
 - **관찰 2**: `orbit-lines` 는 모든 비-moon 궤도를 하나의 LineSystem 에 담아 position (0,0,0) 고정. planet 궤도는 sun 중심이라 정상이지만, **satellite 궤도 점은 parent-relative ellipse (parent 0 원점 기준)** 라 parent offset 없이 sun 근처에 잘못 렌더.
 
 #### 측정 1b — `orbit-lines` vertex 원점 거리 분포 (715 점)
 
-| 거리 bucket (scene unit) | 점 개수 | 해석 |
-|---|---|---|
-| < 1 | **390 (54%)** | satellite 궤도 (phobos/deimos/galilean) — parent-relative 작은 ellipse 가 **태양 원점에 밀집** |
-| 1–5 | 40 | 내행성 궤도 일부 |
-| 5–20 | 199 | 내행성 ~ 중간 궤도 (정상) |
-| 20–40 | 21 | 외행성 궤도 |
-| 40–70 | 65 | jupiter 궤도 (~52 AU scene unit, 정상) |
+| 거리 bucket (scene unit) | 점 개수       | 해석                                                                                           |
+| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------- |
+| < 1                      | **390 (54%)** | satellite 궤도 (phobos/deimos/galilean) — parent-relative 작은 ellipse 가 **태양 원점에 밀집** |
+| 1–5                      | 40            | 내행성 궤도 일부                                                                               |
+| 5–20                     | 199           | 내행성 ~ 중간 궤도 (정상)                                                                      |
+| 20–40                    | 21            | 외행성 궤도                                                                                    |
+| 40–70                    | 65            | jupiter 궤도 (~52 AU scene unit, 정상)                                                         |
 
 - min 거리 = **7.76e-4** (io 가장 안쪽 궤도점), median = 0.158.
 - **결론**: 715 점 중 390 점 (54%) 이 원점 1 unit 이내에 satellite 궤도 ellipse 로 밀집 — 이것이 사용자가 본 "탐색 모드 궤도라인 잔상" (태양 주변 작은 링 다발) + "focus 시 불필요한 궤도라인" (jupiter focus 시 galilean 궤도가 jupiter 가 아닌 sun 에 있음).
 
 #### 측정 1c — satellite mesh vs parent 거리 (mesh 경로는 정상)
 
-| satellite | parent | distToParent | distToOrigin | mesh가 parent추적 |
-|---|---|---|---|---|
-| moon | earth | 1.023 | 11.39 | ✅ |
-| phobos | mars | 0.396 | 17.35 | ✅ |
-| deimos | mars | 0.986 | 16.52 | ✅ |
-| io | jupiter | 0.566 | 62.87 | ✅ |
-| europa | jupiter | 0.906 | 62.12 | ✅ |
-| ganymede | jupiter | 1.442 | 61.56 | ✅ |
-| callisto | jupiter | 2.547 | 60.79 | ✅ |
+| satellite | parent  | distToParent | distToOrigin | mesh가 parent추적 |
+| --------- | ------- | ------------ | ------------ | ----------------- |
+| moon      | earth   | 1.023        | 11.39        | ✅                |
+| phobos    | mars    | 0.396        | 17.35        | ✅                |
+| deimos    | mars    | 0.986        | 16.52        | ✅                |
+| io        | jupiter | 0.566        | 62.87        | ✅                |
+| europa    | jupiter | 0.906        | 62.12        | ✅                |
+| ganymede  | jupiter | 1.442        | 61.56        | ✅                |
+| callisto  | jupiter | 2.547        | 60.79        | ✅                |
 
 - **모든 satellite mesh 는 parent 를 정상 추적** (distToParent ≪ distToOrigin). `resolveWorld` (solar-system-scene.ts:1481-1485) 가 `parentWorld + local × getOrbitVisualScale(parentId)` 적용.
 - **핵심 비대칭**: mesh 경로 (✅ 정상) vs orbit-line 경로 (❌ 결함). 사용자 인지: galilean mesh 는 jupiter 옆에 있는데 galilean 궤도선은 sun 옆에 있어 **mesh ↔ 궤도선 분리** = "불필요한 궤도라인".
 
 #### 측정 2 — galilean world radius / jupiter 비율 (사용자 보고 1 분석)
 
-| body | worldRadius | ratioToJupiter | 비고 |
-|---|---|---|---|
-| jupiter | 0.4993 | 1.000 | BODY_SCALE 48 (R6 PM Q2=B 거성 예외) |
-| io | 0.0795 | **0.159** | BODY_SCALE 300 |
-| europa | 0.0681 | **0.136** | BODY_SCALE 300 |
-| ganymede | 0.1150 | **0.230** | BODY_SCALE 300, 태양계 최대 위성 |
-| callisto | 0.1052 | **0.211** | BODY_SCALE 300 |
-| (baseline) moon | 0.0506 | **0.068** (vs earth) | BODY_SCALE 200 |
+| body            | worldRadius | ratioToJupiter       | 비고                                 |
+| --------------- | ----------- | -------------------- | ------------------------------------ |
+| jupiter         | 0.4993      | 1.000                | BODY_SCALE 48 (R6 PM Q2=B 거성 예외) |
+| io              | 0.0795      | **0.159**            | BODY_SCALE 300                       |
+| europa          | 0.0681      | **0.136**            | BODY_SCALE 300                       |
+| ganymede        | 0.1150      | **0.230**            | BODY_SCALE 300, 태양계 최대 위성     |
+| callisto        | 0.1052      | **0.211**            | BODY_SCALE 300                       |
+| (baseline) moon | 0.0506      | **0.068** (vs earth) | BODY_SCALE 200                       |
 
 - **사용자 인지 단위** = jupiter focus zoom-in 시 galilean 의 시각적 크기 (jupiter 대비).
 - **ADR 박제 단위** = `BODY_SCALE.{io,europa,ganymede,callisto} = 300`.
@@ -92,12 +92,12 @@ R6 PR #627 의 실 Chrome D-T2 검증에서 사용자가 두 회귀를 보고 (h
 
 ### 가설 검증 결론
 
-| 가설 | 결론 | 근거 |
-|---|---|---|
-| **가설 1: satellite 궤도선이 parent 를 안 따라가 태양 원점에 렌더** | **확정 (보고 2 주된 원인)** | 측정 1 (`orbit-lines` position (0,0,0)) + 측정 1b (390/715 점 원점 밀집) + 측정 1c (mesh 는 정상 추적 — orbit-line 만 결함) |
+| 가설                                                                           | 결론                        | 근거                                                                                                                                                                 |
+| ------------------------------------------------------------------------------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **가설 1: satellite 궤도선이 parent 를 안 따라가 태양 원점에 렌더**            | **확정 (보고 2 주된 원인)** | 측정 1 (`orbit-lines` position (0,0,0)) + 측정 1b (390/715 점 원점 밀집) + 측정 1c (mesh 는 정상 추적 — orbit-line 만 결함)                                          |
 | **가설 2: satellite 궤도선에 visual scale 미적용으로 mesh 와 궤도선 mismatch** | **확정 (보고 2 부수 원인)** | 측정 1 (`orbit-lines` scaling (1,1,1) vs `moon-orbit-line` scaling 30). visual scale 적용해도 parent offset 없으면 여전히 sun 에 있음 → 가설 1 이 1차, 가설 2 가 2차 |
-| **가설 3: galilean BODY_SCALE 300 자체가 jupiter 대비 과대** | **확정 (보고 1 주된 원인)** | 측정 2 (galilean/jupiter 0.136~0.230 vs moon/earth 0.068). perspective 아닌 scale 자체 — focus zoom 무관하게 비율 일정 |
-| **가설 4: galilean 과대는 perspective (focus zoom 거리) 효과** | **기각** | world radius 비율은 카메라 거리 불변. 측정 2 의 ratioToJupiter 는 zoom 과 무관한 mesh 절대 비율 |
+| **가설 3: galilean BODY_SCALE 300 자체가 jupiter 대비 과대**                   | **확정 (보고 1 주된 원인)** | 측정 2 (galilean/jupiter 0.136~0.230 vs moon/earth 0.068). perspective 아닌 scale 자체 — focus zoom 무관하게 비율 일정                                               |
+| **가설 4: galilean 과대는 perspective (focus zoom 거리) 효과**                 | **기각**                    | world radius 비율은 카메라 거리 불변. 측정 2 의 ratioToJupiter 는 zoom 과 무관한 mesh 절대 비율                                                                      |
 
 > 가설 1+2 가 보고 2 (궤도선) 의 결합 원인 — parent offset 누락 (1차) + visual scale 누락 (2차). 둘 다 해소해야 moon 패턴과 정합. 가설 3 이 보고 1 (비율) 의 독립 원인.
 
@@ -162,14 +162,14 @@ R6 PR #627 의 실 Chrome D-T2 검증에서 사용자가 두 회귀를 보고 (h
 
 #### 축별 비교 매트릭스 (보고 2)
 
-| 축 | (A) parent별 일반화 | (B) parenting | (C) 비표시 |
-|---|---|---|---|
-| 사용자 인지 회귀 해소 | ✅ 완전 (mesh 정합) | ✅ (scaling 처리 시) | △ (정보 손실로 회피) |
-| moon 패턴 일관성 | ✅ 동일 메커니즘 | ❌ 다른 메커니즘 | ❌ moon 만 잔존 |
-| R7+ 확장성 | ✅ 데이터만 추가 | △ (parent scaling 보정 매번) | ❌ 위성 궤도 영구 손실 |
-| 부수 회귀 위험 | low (moon 검증됨) | **high** (scaling 전파/floating origin) | low |
-| 구현 비용 | 중 (moon 루프 일반화) | 중~고 (scaling 보정) | 1줄 (skip) |
-| ADR Amendment 필요 | R5 §결정 4 정정 1건 | R5 §결정 4 정정 1건 | R5/R6 satellite 가시화 결정 폐기 |
+| 축                    | (A) parent별 일반화   | (B) parenting                           | (C) 비표시                       |
+| --------------------- | --------------------- | --------------------------------------- | -------------------------------- |
+| 사용자 인지 회귀 해소 | ✅ 완전 (mesh 정합)   | ✅ (scaling 처리 시)                    | △ (정보 손실로 회피)             |
+| moon 패턴 일관성      | ✅ 동일 메커니즘      | ❌ 다른 메커니즘                        | ❌ moon 만 잔존                  |
+| R7+ 확장성            | ✅ 데이터만 추가      | △ (parent scaling 보정 매번)            | ❌ 위성 궤도 영구 손실           |
+| 부수 회귀 위험        | low (moon 검증됨)     | **high** (scaling 전파/floating origin) | low                              |
+| 구현 비용             | 중 (moon 루프 일반화) | 중~고 (scaling 보정)                    | 1줄 (skip)                       |
+| ADR Amendment 필요    | R5 §결정 4 정정 1건   | R5 §결정 4 정정 1건                     | R5/R6 satellite 가시화 결정 폐기 |
 
 ### 보고 1 (galilean 비율 과대) — 옵션 D/E
 
@@ -189,13 +189,13 @@ R6 PR #627 의 실 Chrome D-T2 검증에서 사용자가 두 회귀를 보고 (h
 
 #### 축별 비교 매트릭스 (보고 1)
 
-| 축 | (D) galilean 하향 | (E) jupiter 상향 |
-|---|---|---|
-| 사용자 "과대" 해소 | ✅ 직접 | ✅ 상대 |
-| galilean mesh 가시성 | △ fallback 의존 심화 | ✅ 유지 |
-| PM Q2=B 임계 충돌 | ❌ 없음 | ⚠️ 위반 (재합의) |
-| 결합 영향 | 낮음 (galilean 독립) | **높음** (orbit scale 동반) |
-| ADR Amendment | R6 §축 2 | R6 §축 1+2+4 + PM 재합의 |
+| 축                   | (D) galilean 하향    | (E) jupiter 상향            |
+| -------------------- | -------------------- | --------------------------- |
+| 사용자 "과대" 해소   | ✅ 직접              | ✅ 상대                     |
+| galilean mesh 가시성 | △ fallback 의존 심화 | ✅ 유지                     |
+| PM Q2=B 임계 충돌    | ❌ 없음              | ⚠️ 위반 (재합의)            |
+| 결합 영향            | 낮음 (galilean 독립) | **높음** (orbit scale 동반) |
+| ADR Amendment        | R6 §축 2             | R6 §축 1+2+4 + PM 재합의    |
 
 ### 권장 안 (사전 선호 — 사용자/cross-validate 결정 전 안내)
 
@@ -267,12 +267,12 @@ agy 가 옵션 A+D 조합을 지지 (구조적 완성도 / 기술 타당성 / �
 
 ## §6 위험 / 재검토 트리거
 
-| 위험 | 회귀 시점 | 임계 / 발동 조건 | 완화 방안 |
-|---|---|---|---|
-| satellite 궤도선 회귀 재잠복 (다음 R-Phase) | R7 (titan/saturn) 진입 | 신규 satellite 궤도선 worldCenter ≠ parent | `browser-verify-627-satellite-orbit.mjs` 회귀 가드 (모든 satellite 자동 검사) |
-| 옵션 A draw call 증가 | fix 머지 직후 | LineSystem 개수 × satellite parent 수 | parent 3개 (earth/mars/jupiter) 수준 — #77 최적화 대비 미미. fps DoD 재측정 |
-| galilean fallback 의존 심화 (옵션 D) | D 채택 시 | io mesh px < 4 | LOD Phase 2 (#391) billboard fallback 가 흡수 |
-| 궤도선 visual scale ↔ mesh visual scale drift | Amendment 시 | 두 경로 scale 불일치 | 단일 SSoT `getOrbitVisualScale` 양쪽 호출 (mesh: resolveWorld / line: rebuildOrbitLines) |
+| 위험                                          | 회귀 시점              | 임계 / 발동 조건                           | 완화 방안                                                                                |
+| --------------------------------------------- | ---------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| satellite 궤도선 회귀 재잠복 (다음 R-Phase)   | R7 (titan/saturn) 진입 | 신규 satellite 궤도선 worldCenter ≠ parent | `browser-verify-627-satellite-orbit.mjs` 회귀 가드 (모든 satellite 자동 검사)            |
+| 옵션 A draw call 증가                         | fix 머지 직후          | LineSystem 개수 × satellite parent 수      | parent 3개 (earth/mars/jupiter) 수준 — #77 최적화 대비 미미. fps DoD 재측정              |
+| galilean fallback 의존 심화 (옵션 D)          | D 채택 시              | io mesh px < 4                             | LOD Phase 2 (#391) billboard fallback 가 흡수                                            |
+| 궤도선 visual scale ↔ mesh visual scale drift | Amendment 시           | 두 경로 scale 불일치                       | 단일 SSoT `getOrbitVisualScale` 양쪽 호출 (mesh: resolveWorld / line: rebuildOrbitLines) |
 
 ### 재검토 트리거
 
@@ -296,13 +296,13 @@ agy 가 옵션 A+D 조합을 지지 (구조적 완성도 / 기술 타당성 / �
   - **agy 보강 ② (fallback 계약)**: `DEFAULT_ORBIT_VISUAL_SCALE=1.0` export + `getOrbitVisualScale` null/undefined/미매핑 시 1.0 보장 (단위 테스트 가드).
 - **재측정 실측 (2026-06-06, 1280×720, dev — D-627 검증)**:
 
-| satellite parent | scaling | worldCenter ↔ parent (D-627-1) | distToOrigin |
-|---|---|---|---|
-| earth (moon) | 30 | **0.053 unit** ✅ ≤ 0.2 | 12.31 |
-| mars (phobos/deimos) | 500 | **0.0003 unit** ✅ ≤ 0.2 | 17.50 |
-| jupiter (galilean 4) | 16 | **0.019 unit** ✅ ≤ 0.2 | 62.41 |
+| satellite parent     | scaling | worldCenter ↔ parent (D-627-1) | distToOrigin |
+| -------------------- | ------- | ------------------------------ | ------------ |
+| earth (moon)         | 30      | **0.053 unit** ✅ ≤ 0.2        | 12.31        |
+| mars (phobos/deimos) | 500     | **0.0003 unit** ✅ ≤ 0.2       | 17.50        |
+| jupiter (galilean 4) | 16      | **0.019 unit** ✅ ≤ 0.2        | 62.41        |
 
-  - planet `orbit-lines` 원점 1 unit 이내 vertex: **0.0% (0/325)** ← 결함기 54% (390/715). agy 보강 ③ 통계 테스트 PASS.
+- planet `orbit-lines` 원점 1 unit 이내 vertex: **0.0% (0/325)** ← 결함기 54% (390/715). agy 보강 ③ 통계 테스트 PASS.
 - **옵션 D 발동 (보고 1, 2단계 iteration)**: 옵션 A 적용 후 galilean 재측정 — ganymede/jupiter **0.230** (여전히 moon/earth 0.068 의 3.4배 과대) → **1차 `BODY_SCALE` 300 → 200** (ganymede 0.1535, D-627-3 ≤ 0.16 충족). **사용자 D-T2 (2026-06-06) "목성 대비 아직 큼" 재보고 → 2차 200 → 100** (dev iteration 합의): ganymede **0.077** (moon/earth 0.068 의 1.13배 정합) / io 0.053 / europa 0.046 / callisto 0.070. 사용자 "목성 대비 적당" 합의. galilean 4개 sub-4px → 4px fallback billboard 전면 의존 (LOD #391 흡수). R6 ADR §Amendment 2 박제 (300→200→100).
 - **회귀 가드**: `apps/web/scripts/browser-verify-627-satellite-orbit.mjs` (verify:627-satellite-orbit) — 2축 (A worldCenter ±0.2 / B 원점 밀집 0) + CI `detect-and-test` 통합 (port 3005). 단위 테스트 `packages/core/src/scene/satellite-orbit-structure.test.ts` (isSatelliteOrbit 분류 11 케이스 + getOrbitVisualScale fallback).
 - **D-T2 실 Chrome 육안**: 사용자 위임 (headless ≠ 실 브라우저, volt #77). PR #627 본문 명시.
@@ -312,7 +312,8 @@ agy 가 옵션 A+D 조합을 지지 (구조적 완성도 / 기술 타당성 / �
 
 ## §8 후속 / 분리 이슈
 
-- **카메라 free-fly 고정 (R6 무관)** — `focusOn` 의 `lowerRadiusLimit` 동적 완화 (camera-controller.ts:150-152) 가 free-fly 진입 (`detachToFreeFly` clearFollow only, sim-canvas.tsx:408-411) 시 원복 안 되어 satellite focus 후 자유 이동 제약 인지. **develop (R5) 재현 확정** (git diff 0) → R6 차단 사유 아님. **별도 이슈 분리 완료** ([#629](https://github.com/coseo12/astro-simulator/issues/629), priority:medium, 2026-06-06). 출발점: `clearFollow` 에 lowerRadiusLimit 원복 또는 free-fly 진입 시 tier-transition 의 `computeLowerRadiusLimit` 재적용.
+- **카메라 free-fly 고정 (R6 무관)** — `focusOn` 의 `lowerRadiusLimit` 동적 완화 (camera-controller.ts:150-152) 가 free-fly 진입 (`detachToFreeFly` clearFollow only, sim-canvas.tsx:408-411) 시 원복 안 되어 satellite focus 후 자유 이동 제약 인지. **develop (R5) 재현 확정** (git diff 0) → R6 차단 사유 아님. **별도 이슈 분리 완료** ([#629](https://github.com/coseo12/astro-simulator/issues/629), priority:medium, 2026-06-06).
+  - **⚠️ 정정 (2026-06-07, #629 forensic)**: 위 정적 분석의 "lowerRadiusLimit 미원복" 가설은 **#629 forensic 실측에서 기각**됨 (free-fly 후 lowerRadiusLimit = 467 로 극소 아님). 실제 원인은 **절대 `wheelPrecision` 이 tier=body 거대 radius(≈158386)에서 줌 변화율 0.03% 로 정지**. fix = `wheelDeltaPercentage`(radius 비례). 상세: [`20260607-629-freefly-camera-zoom-forensic.md`](20260607-629-freefly-camera-zoom-forensic.md). measurement-first 가 정적 가설을 정정한 사례 (volt #32).
 - **satellite orbit visual scale 잔여 gap** — 기존 [#622](https://github.com/coseo12/astro-simulator/issues/622) (satellite orbit visual scale 잔여 1.74배 gap forensic) 와 본 결함 연관. #622 는 visual scale **값** gap, 본 ADR 은 visual scale **적용 자체 누락** — 본 fix (옵션 A) 가 #622 의 전제 (satellite 궤도선이 실제로 visual scale 적용됨) 를 충족시킨 후 #622 재측정 권고. Builds on: #627.
 
 ---

--- a/docs/decisions/20260607-629-freefly-camera-zoom-forensic.md
+++ b/docs/decisions/20260607-629-freefly-camera-zoom-forensic.md
@@ -1,0 +1,191 @@
+# ADR: free-fly 진입 시 줌 "고정" 회귀 — 절대 wheelPrecision 이 tier=body(renderScale 거대화)에서 줌 정지 (R6 #621 D-T2 표면화, R5 잠복)
+
+- **상태**: **Accepted** (cross-validate 2026-06-07 agy outcome=applied — §교차검증 반영 사항 본문 통합 완료. 옵션 F1 채택 + fix 구현 + 3중 시뮬레이션 + 상수화)
+- **날짜**: 2026-06-07
+- **결정자**: developer (#629 fix 단계, forensic 실측 선행)
+- **관련**:
+  - [#629](https://github.com/coseo12/astro-simulator/issues/629) (본 이슈 — R6 D-T2 발견, R5 잠복)
+  - [`20260606-627-satellite-orbit-structure-forensic.md`](20260606-627-satellite-orbit-structure-forensic.md) §8 (본 회귀 분리 출발점 — **정적 가설 "lowerRadiusLimit 미원복" 을 본 forensic 이 실측으로 정정**)
+  - [`20260509-380-zoom-camera-freeze-forensic.md`](20260509-380-zoom-camera-freeze-forensic.md) (camera lowerRadiusLimit / tier 별 renderScale 비대칭 SSoT — 본 회귀의 scale 비대칭 근거)
+  - [#509](https://github.com/coseo12/astro-simulator/issues/509) (free-fly 진입 설계 — tier/origin/시점 보존 의도)
+  - [`docs/glossary.md`](../glossary.md) — [free-fly](../glossary.md) / [Tier](../glossary.md) / [D-T2](../glossary.md) 정의
+- **교훈 적용**:
+  - "수치 DoD 미달 시 측정 방법 검증 우선" / **measurement-first** (volt [#32](https://github.com/coseo12/volt/issues/32)) — #627 ADR §8 정적 가설(lowerRadiusLimit 극소 잔존)을 실측이 정정. 식부터 고쳤으면 오진 손실.
+  - "DoD PASS ≠ 제품 동작" (volt [#74](https://github.com/coseo12/volt/issues/74)) — 자동 DoD(px 비율/a11y/fps)는 줌 응답성을 검증하지 않아 잠복.
+  - "headless 브라우저 검증 ≠ 실 브라우저" (volt [#77](https://github.com/coseo12/volt/issues/77)) — 본 줌 응답은 수치 state 측정이라 headless 신뢰 가능하나, 최종 D-T2 육안은 사용자 위임.
+
+---
+
+## §1 배경
+
+### 본 이슈 핵심
+
+R6 PR [#627](https://github.com/coseo12/astro-simulator/pull/627) 실 Chrome D-T2 에서 사용자 보고: **"탐색(free-fly) 버튼 사용 시 자유롭게 시점이동이 안되고 고정되서 오히려 불편"**.
+
+- **회귀 발화점**: R6 galilean(io/europa/ganymede/callisto) focus 후 free-fly. 단 **R6 무관** — `git diff origin/develop HEAD -- camera-controller.ts sim-canvas.tsx camera.ts` = 0 라인. develop(R5)에서도 동일 재현 → **선행 잠복 결함**.
+- **영향 범위**: tier=body 로 진입하는 모든 body(위성 + 근접 행성) focus → free-fly. 위성(galilean)이 대표 케이스.
+
+### #627 ADR §8 정적 가설 (본 forensic 이 정정)
+
+#627 ADR §8 은 정적 분석으로 추정: `focusOn`(camera-controller.ts:150-152)이 satellite focus 시 `lowerRadiusLimit` 을 `desiredRadius × 0.5`(극소)로 완화하나 free-fly 진입 시 원복 안 함 → 좁은 줌 한계 잔존이 "고정" 원인. **본 forensic 이 이 가설을 기각** (lowerRadiusLimit 실측 = 467, 극소 아님).
+
+### Forensic 측정 결과 (2026-06-07, develop tip `7695a03`, 1280×720, headless)
+
+`apps/web/scripts/_debug-629-freefly-tmp.mjs`(volt #67 패턴, 실행 후 `rm`)로 실측. 데이터: [`docs/reports/629-freefly-camera-zoom-debug-output.json`](../reports/629-freefly-camera-zoom-debug-output.json) (raw).
+
+dev 핸들: `window.__solarScene`(getTier/meshes) / `window.__simStore`(setSelectedBody/enterFreeFly). focus = UI 버튼과 동일 store 경로.
+
+#### 측정 1 — free-fly 진입 후 카메라 state (3 시나리오)
+
+| 시나리오                             | tier     | radius     | lowerRadiusLimit | targetDistToOrigin               |
+| ------------------------------------ | -------- | ---------- | ---------------- | -------------------------------- |
+| A. free-fly 직접 (baseline)          | solar    | 35         | 0.5              | 0                                |
+| B. jupiter(행성) focus → free-fly    | solar    | 2.5        | 0.025            | 1144                             |
+| **C. io(galilean) focus → free-fly** | **body** | **158386** | **467**          | **8413 (io 위치, 공전 이동 중)** |
+
+#### 측정 2 — 입력별 응답 (5틱 누적 상대 변화율)
+
+| 시나리오            | 회전 (Δα) | **줌 (틱당 상대변화)** | 줌 체감            |
+| ------------------- | --------- | ---------------------- | ------------------ |
+| A. baseline         | ✅ 1.12   | 큼                     | ✅                 |
+| B. jupiter          | ✅ 1.17   | 큼                     | ✅                 |
+| **C. io(galilean)** | ✅ 1.12   | **0.03% / 0.03%**      | ❌ **사실상 정지** |
+
+- **관찰 1**: 위성 focus 는 tier=body 로 진입하고 free-fly 후에도 잔존. body tier 의 renderScale 은 거대화(io mesh radius ≈ 31677 scene unit → focus radius = ×5 ≈ 158386).
+- **관찰 2**: Babylon ArcRotateCamera 의 `wheelPrecision = 3` 은 **절대 줌 델타**(틱당 ~수십 unit). radius 158386 대비 변화율 **0.03%** → 줌이 체감상 완전히 멈춤.
+- **관찰 3**: 회전(alpha/beta)은 정상. 패닝은 설계상 비활성(`panningSensibility = 0`, camera.ts:40). target 은 io 의 동결 위치(공전으로 이미 이동)라 먼 빈 점만 공전.
+- **결론**: 사용자 "고정" = **줌 응답 정지(주 원인) + 먼 빈 점 공전(부 원인) + 패닝 부재**. lowerRadiusLimit(467)은 줌 한계 467~1e14 로 충분히 넓어 **원인 아님** (#627 §8 가설 기각).
+
+### 가설 검증 결론
+
+| 가설                                                                  | 결론                    | 근거                                                                                                                                                                                      |
+| --------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **가설 1 (#627 §8): satellite focus 의 극소 lowerRadiusLimit 미원복** | **기각**                | 측정 1 (C 의 lowerRadiusLimit = 467, 극소 아님). camera-controller.ts:150 의 완화 분기는 `desiredRadius < lowerRadiusLimit` 조건인데 body tier 의 desiredRadius(158386)는 미충족 → 미발동 |
+| **가설 2: 절대 wheelPrecision 이 tier=body 거대 radius 에서 줌 정지** | **확정 (주 원인)**      | 측정 2 (C 줌 rel 0.03% vs A/B 체감). 절대 델타 ÷ 거대 radius = 무시 가능 변화율                                                                                                           |
+| **가설 3: 회전도 고정**                                               | **기각**                | 측정 2 (C 회전 Δα 1.12, 정상)                                                                                                                                                             |
+| **가설 4: target 이 먼 동결점이라 공전만 가능**                       | **부분 확정 (부 원인)** | 측정 1 (C targetDist 8413, io 공전 이동). 줌 복구 시 줌아웃으로 탈출 가능하므로 2차                                                                                                       |
+
+---
+
+## §2 영향 모듈/파일
+
+### Fix 대상
+
+- `packages/core/src/scene/camera.ts:38-39` — 절대 `wheelPrecision`/`pinchPrecision` → `wheelDeltaPercentage`/`pinchDeltaPercentage` (radius 비례).
+
+### 측정/가드 박제
+
+- `docs/reports/629-freefly-camera-zoom-debug-output.json` — forensic raw 데이터
+- `apps/web/scripts/browser-verify-629-freefly-zoom.mjs` — 회귀 가드 (verify:629-freefly-zoom)
+- `.github/workflows/ci.yml` — detect-and-test 통합 (port 3006)
+
+### Fix 가 깨지 않는 영역 (검증됨)
+
+- `#380` 줌 freeze 가드 — tier 전환은 프로그램적 radius 애니메이션이라 wheel 감도와 직교. develop baseline 과 동일 결과 (§4 예측 3).
+
+---
+
+## §3 옵션 비교
+
+| 축                      | **(F1) wheelDeltaPercentage**  | (F2) free-fly 진입 시 카메라 정규화   | (F3) 패닝 활성화                   |
+| ----------------------- | ------------------------------ | ------------------------------------- | ---------------------------------- |
+| 측정 근본(줌 정지) 해소 | ✅ 직접 (모든 scale 일정 %)    | △ (tier 복원으로 간접)                | ❌ (줌 정지 잔존)                  |
+| #509 시점 보존 의도     | ✅ 유지 (진입 로직 무변경)     | ❌ **충돌** (tier/radius/target 변경) | ✅ 유지                            |
+| 변경 범위               | 2 라인 (전역 카메라 설정)      | 다 (detachToFreeFly + tier 전환)      | 1 라인 + floating origin 결합 검토 |
+| 부수 회귀 위험          | low (#380 직교 검증됨)         | 중 (#509 회귀)                        | 중 (floating origin × panning)     |
+| mobile(pinch) 동시 해소 | ✅ (pinchDeltaPercentage 동반) | ❌                                    | ❌                                 |
+
+### 결정
+
+- **채택: (F1) `wheelDeltaPercentage`/`pinchDeltaPercentage` = 0.01.** 측정된 근본 원인(절대 델타 ÷ 거대 radius)을 직접 해소하고, #509 시점 보존을 유지하며, 위험이 가장 낮다. pinch 동시 적용으로 모바일 동일 잠복(절대 pinchPrecision) 선제 차단.
+- **F2 기각**: #509 "시점 보존" 의도와 충돌.
+- **F3 기각**: 줌 정지(주 원인) 미해소 + floating origin 결합 위험. 단 "진짜 자유 이동(패닝)" UX 는 별도 가치 → §8 후속 분리 후보.
+
+---
+
+## §4 Concrete Prediction (사전 박제 → 실측 대조)
+
+| 예측                                               | 임계                          | 실측                                    | 정합 |
+| -------------------------------------------------- | ----------------------------- | --------------------------------------- | ---- |
+| 예측 1 — 코드 변경 라인 수                         | 카메라 설정 2~3 라인          | 2 라인 (wheel/pinch)                    | ✅   |
+| 예측 2 — D-629-1 (C 위성 free-fly 줌 5틱 누적 rel) | ≥ 0.5%(체감)                  | **38.85% / 55.30%** (fix 전 0.03%)      | ✅   |
+| 예측 3 — #380 무회귀                               | develop 과 동일 S1/S3/S4 PASS | 동일 (S2 는 develop 도 기존 FAIL, 후술) | ✅   |
+| 예측 4 — baseline(A) 줌 체감 유지 (#509)           | 체감 유지                     | rel 큼, PASS                            | ✅   |
+
+---
+
+## §5 결정 (구현 완료)
+
+채택 옵션 = **F1**. 구현:
+
+```ts
+// camera.ts — 절대 precision 제거, radius 비례 % 적용
+camera.wheelDeltaPercentage = 0.01;
+camera.pinchDeltaPercentage = 0.01;
+```
+
+### 회귀 가드 — 3중 시뮬레이션 (guard-pr-dod, volt #96/#109)
+
+| 단계                | 상태              | S2(io free-fly) 줌 rel | overall |
+| ------------------- | ----------------- | ---------------------- | ------- |
+| Positive (fix 적용) | PASS              | 38.85% / 55.30%        | PASS    |
+| Negative (fix 환원) | **FAIL** (exit 1) | **0.03% / 0.03%**      | FAIL    |
+| Recovery (fix 복원) | PASS              | 38.85% / 55.30%        | PASS    |
+
+가드: `browser-verify-629-freefly-zoom.mjs` — 2축 (S1 baseline 줌 체감 / S2 io focus→free-fly 줌 5틱 누적 rel ≥ 1% + 회전 작동). CI `detect-and-test` 통합 (port 3006).
+
+### #380 무회귀 실측
+
+develop baseline #380 = `S1 PASS / S2 FAIL / S3 PASS / S4 PASS`. fix 적용 후 **동일**. #380 S2 는 50ms race window 측정의 **기존 headless 타이밍 flaky** (signs=[1,-1], develop 3회 일관 FAIL)이며 **CI 미포함** — 본 fix 무관.
+
+### Fix 후 박제 의무
+
+- **#627 ADR §8 cross-link Amendment** — "lowerRadiusLimit 미원복 가설은 #629 forensic 에서 기각, 실제 원인은 절대 wheelPrecision" 정정 박제.
+
+---
+
+## §6 위험 / 재검토 트리거
+
+| 위험                       | 회귀 시점     | 임계                         | 완화                                                     |
+| -------------------------- | ------------- | ---------------------------- | -------------------------------------------------------- |
+| 줌 감도 체감 변화 (전역 %) | fix 머지 직후 | 사용자 D-T2 "너무 빠름/느림" | `0.01`(틱당 ~1%) 조정 가능. D-T2 피드백 시 튜닝          |
+| pinch 모바일 미검증        | iOS/Android   | 실기기 pinch 줌 응답         | 동일 메커니즘(% 비례). #219 iOS 실기기 측정 시 동반 확인 |
+| 신규 tier 추가 시 재발     | R7+           | 절대 precision 부활          | 본 가드(S2)가 deep tier 줌 자동 검사                     |
+
+### 재검토 트리거
+
+1. 사용자 D-T2 "줌 감도 부적절" → `wheelDeltaPercentage` 값 튜닝.
+2. free-fly 후 "먼 점 공전" 잔존 불편(부 원인) → §8 F3(패닝) 또는 target 정규화 후속.
+
+---
+
+## §교차검증 반영 사항 (cross-validate 2026-06-07 agy outcome=applied)
+
+agy 가 F1(반지름 비례 줌) 결정을 "거대 척도 시뮬레이션에 매우 타당" 으로 지지. 4축 분류:
+
+- **합의 (2)**: ① forensic 흐름(실측 → 가설 1 기각 → 원인 규명 → 옵션 비교 → 가드)의 정밀성 ② radius 비례 줌이 deep tier 확장(성간/은하 신규 tier)에도 재조정 불필요 — 확장성 우수.
+- **고유 발견 수용 (2, 본 PR 반영)**:
+  - ① **입력 채널 다각도 (키보드/트랙패드 줌)** — `grep` 전수 확인 결과 커스텀 줌 입력 채널 **없음** (focus-quick-buttons 키보드 핸들러는 Escape→free-fly 로 줌 무관, 트랙패드 2지 스크롤은 wheel 이벤트로 `wheelDeltaPercentage` 가 흡수). wheel + pinch 가 전 줌 경로 → fix 가 완전 커버. (실측 해소)
+  - ② **상수화** — `0.01` 리터럴을 `ZOOM_DELTA_PERCENTAGE` named const 로 승격 (프로젝트 매직넘버 상수화 원칙). 휠/핀치 단일 SSoT + D-T2 튜닝 지점 명확화.
+- **반려/과대 대응 필터 (2)**:
+  - ① **NaN/zero-division 방어** — radius=0 시 우려. 그러나 `lowerRadiusLimit`(tier 별 양수, 기본 0.5)이 radius 를 0 에 도달하지 못하게 보장하며 Babylon 내부가 비례 델타를 처리 → 추가 방어 코드 불필요 (기존 가드 충족, 과대 대응).
+  - ② **clamping 부드러운 감속** — Babylon ArcRotateCamera 가 lower/upperRadiusLimit 에서 자동 clamp + inertia 처리 → 별도 구현 불필요.
+- **고유 발견 후속 분리 (1)**: **OS/디바이스 감도 편차 + 사용자 줌 감도 설정 옵션** — `wheelDeltaPercentage` 가 deltaY 정규화로 OS 편차를 1차 흡수하나, 사용자 노출 줌 감도 설정은 현 PR 비목표(회귀 fix)와 직교 → §6 재검토 트리거에 박제(별도 이슈 생성은 수요 확인 후, 과한 이슈 자제). **부 원인(먼 빈 점 target 재설정)** 은 §8 후속 유지(#509 시점 보존 의도와 충돌 검토 필요).
+- **Claude 편향 셀프 체크**: F1 의 전역 줌 감도 변화가 baseline(solar tier)에서 "과민" 일 수 있다는 우려 — 측정 2 (baseline rel 큼, 기존 develop 도 동일 빠른 줌) 로 회귀 아님 확인. 단 D-T2 사용자 육안에서 감도 피드백 시 `ZOOM_DELTA_PERCENTAGE` 튜닝 (§6).
+
+## §7 Amendment 라운드 N
+
+(현재 없음 — D-T2 사용자 피드백 또는 후속 발견 시 추가)
+
+---
+
+## §8 후속 / 분리 이슈
+
+- **free-fly 패닝/탐색 UX (F3)** — 본 fix 는 줌 정지(주 원인)를 해소하나, target 이 동결점에 고정되어 "공전만 가능"한 부 원인은 남는다. "진짜 자유 이동(WASD/패닝)" 은 별도 가치 → 사용자 수요 확인 후 분리 검토 (floating origin 결합 설계 필요).
+- **#627 ADR §8** — 본 forensic 이 §8 정적 가설을 정정. #627 ADR 에 cross-link 박제.
+
+---
+
+## 변경 이력
+
+- 2026-06-07: 초안 (developer, #629 fix). Provisional — 절대 wheelPrecision 이 tier=body 거대 radius 에서 줌 정지(주 원인) 실측 확정 + #627 §8 lowerRadiusLimit 가설 기각 + 옵션 F1/F2/F3 비교 + 3중 시뮬레이션. cross-validate 후 Accepted 전이 예정.

--- a/docs/decisions/20260607-629-freefly-camera-zoom-forensic.md
+++ b/docs/decisions/20260607-629-freefly-camera-zoom-forensic.md
@@ -181,8 +181,9 @@ agy 가 F1(반지름 비례 줌) 결정을 "거대 척도 시뮬레이션에 매
 
 ## §8 후속 / 분리 이슈
 
-- **free-fly 패닝/탐색 UX (F3)** — 본 fix 는 줌 정지(주 원인)를 해소하나, target 이 동결점에 고정되어 "공전만 가능"한 부 원인은 남는다. "진짜 자유 이동(WASD/패닝)" 은 별도 가치 → 사용자 수요 확인 후 분리 검토 (floating origin 결합 설계 필요).
-- **#627 ADR §8** — 본 forensic 이 §8 정적 가설을 정정. #627 ADR 에 cross-link 박제.
+- **free-fly deep-tier 줌아웃 → 허공 (부 원인 표면화)** — **[#631](https://github.com/coseo12/astro-simulator/issues/631) 분리 완료** (2026-06-07 D-T2). 본 fix 로 줌 응답은 복구됐으나, D-T2 실 Chrome 에서 "줌아웃 시 갑자기 멀어져 허공" 보고. forensic 실측: body tier 의 floating origin 이 focus body(io)로 이동 → `sim-canvas.tsx:481-484` 의 `cameraFromSunMeters` 가 실제로는 io(이동 원점)로부터 거리를 측정 → `tierFromCameraDistance` 가 줌아웃해도 body tier 유지(escalate 안 됨) + target 동결점 → body-scale 허공 비행 (12틱 내내 tier=body / targetDist 8124 / 보이는 mesh 1개). floating-origin tier 좌표계 정밀 작업이라 독립 PR 권장.
+- **free-fly 패닝 (F3)** — "진짜 자유 이동(WASD/패닝)" 은 별도 가치 → #631 과 함께 또는 후속 검토.
+- **#627 ADR §8** — 본 forensic 이 §8 정적 가설을 정정. #627 ADR 에 cross-link 박제 완료.
 
 ---
 

--- a/docs/reports/629-freefly-camera-zoom-debug-output.json
+++ b/docs/reports/629-freefly-camera-zoom-debug-output.json
@@ -1,0 +1,167 @@
+[
+  {
+    "label": "A. free-fly 직접 (baseline)",
+    "focusId": null,
+    "beforeFreeFly": {
+      "tier": "solar",
+      "radius": 35,
+      "lowerRadiusLimit": 0.5,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "targetDistToOrigin": 0
+    },
+    "afterFreeFly": {
+      "tier": "solar",
+      "radius": 35,
+      "lowerRadiusLimit": 0.5,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "targetDistToOrigin": 0
+    },
+    "response": {
+      "rotate": {
+        "dAlpha": 1.1311937778027712,
+        "dBeta": 0.5655968889013859,
+        "rotates": true
+      },
+      "zoomIn": {
+        "dRadius": 516.8657728026312,
+        "rel": 14.767593508646607,
+        "perceptible": true
+      },
+      "zoomOut": {
+        "dRadius": 38.85349461359078,
+        "rel": 0.07040388538008918,
+        "perceptible": true
+      }
+    }
+  },
+  {
+    "label": "B. jupiter focus → free-fly",
+    "focusId": "jupiter",
+    "beforeFreeFly": {
+      "tier": "inner",
+      "radius": 45.76674772045837,
+      "lowerRadiusLimit": 0.5400476231014087,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": 915.0281982421875,
+        "y": 687.1533813476562,
+        "z": -23.332324981689453
+      },
+      "targetDistToOrigin": 1144.55265080507
+    },
+    "afterFreeFly": {
+      "tier": "solar",
+      "radius": 2.4963680574795473,
+      "lowerRadiusLimit": 0.024963680574795474,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": 915.0137329101562,
+        "y": 687.1734008789062,
+        "z": -23.332082748413086
+      },
+      "targetDistToOrigin": 1144.5531007231773
+    },
+    "response": {
+      "rotate": {
+        "dAlpha": 1.1703811775001194,
+        "dBeta": 0.5851905887500597,
+        "rotates": true
+      },
+      "zoomIn": {
+        "dRadius": -2.471404376904752,
+        "rel": -0.9900000000000001,
+        "perceptible": true
+      },
+      "zoomOut": {
+        "dRadius": 47.46573163237215,
+        "rel": 1901.3915632415126,
+        "perceptible": true
+      }
+    }
+  },
+  {
+    "label": "C. io(galilean) focus → free-fly",
+    "focusId": "io",
+    "beforeFreeFly": {
+      "tier": "body",
+      "radius": 158386.2122474665,
+      "lowerRadiusLimit": 467.23932613002626,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": -8337.4580078125,
+        "y": 518.4668579101562,
+        "z": -103.63997650146484
+      },
+      "targetDistToOrigin": 8354.20583655426
+    },
+    "afterFreeFly": {
+      "tier": "body",
+      "radius": 158386.2122474665,
+      "lowerRadiusLimit": 467.23932613002626,
+      "upperRadiusLimit": 100000000000000,
+      "minZ": 0.01,
+      "alpha": -1.5707963267948966,
+      "beta": 1.2566370614359172,
+      "panningSensibility": 0,
+      "wheelPrecision": 3,
+      "target": {
+        "x": -9572.3984375,
+        "y": 115.39495849609375,
+        "z": -136.19100952148438
+      },
+      "targetDistToOrigin": 9574.06266084431
+    },
+    "response": {
+      "rotate": {
+        "dAlpha": 1.1056156074112087,
+        "dBeta": 0.5528078037056048,
+        "rotates": true
+      },
+      "zoomIn": {
+        "dRadius": -43.424927023181226,
+        "rel": -0.0002741711314829163,
+        "perceptible": false
+      },
+      "zoomOut": {
+        "dRadius": 37.526322974707,
+        "rel": 0.0002369951889556531,
+        "perceptible": false
+      }
+    }
+  }
+]

--- a/packages/core/src/scene/camera.ts
+++ b/packages/core/src/scene/camera.ts
@@ -1,5 +1,16 @@
 import { ArcRotateCamera, Vector3, type Scene } from '@babylonjs/core';
 
+/**
+ * #629 — 줌(휠/핀치) 델타를 radius 비례(%)로 적용하는 비율 상수.
+ *
+ * 틱당 약 1% 줌. 절대 `wheelPrecision`/`pinchPrecision` 대신 사용하는 이유는 tier 별
+ * renderScale 비대칭(T1 solar radius≈35 ↔ T3 body radius≈158386) 때문이다 — 절대 델타는
+ * deep tier 에서 변화율이 0.03% 로 떨어져 줌이 체감상 멈춘다 (forensic ADR
+ * docs/decisions/20260607-629-freefly-camera-zoom-forensic.md). 휠/핀치 동일 값으로
+ * desktop·mobile 줌 감도를 일치시킨다. D-T2 피드백 시 본 상수만 조정.
+ */
+export const ZOOM_DELTA_PERCENTAGE = 0.01;
+
 export interface ArcCameraOptions {
   /** 수평 회전각 (rad) */
   alpha?: number;
@@ -35,8 +46,17 @@ export function setupArcRotateCamera(
   const camera = new ArcRotateCamera('camera', alpha, beta, radius, target, scene);
   camera.lowerRadiusLimit = lowerRadiusLimit;
   camera.upperRadiusLimit = upperRadiusLimit;
-  camera.wheelPrecision = 3;
-  camera.pinchPrecision = 50;
+  // #629 — 줌 델타를 radius 비례(%)로 적용한다.
+  //
+  // 절대 `wheelPrecision`/`pinchPrecision` 은 tier 별 renderScale 비대칭 (T1 solar radius≈35
+  // ↔ T3 body radius≈158386) 에서 동일 틱이 전혀 다른 비율 변화를 낳는다. 위성(galilean) focus
+  // 후 free-fly 진입 시 카메라가 tier=body / radius≈158386 으로 잔존하는데, 절대 델타(틱당 수십
+  // unit)는 radius 158386 대비 변화율이 0.03% 로 떨어져 줌이 체감상 완전히 멈춘다 → 사용자가
+  // "탐색 시 시점 고정" 으로 인지 (forensic ADR docs/decisions/20260607-629-freefly-camera-zoom-forensic.md).
+  // percentage 모드는 모든 tier/scale 에서 일정 비율(틱당 ~1%) 줌을 보장한다.
+  // (Babylon: deltaPercentage 설정 시 절대 precision 은 무시되므로 wheelPrecision/pinchPrecision 제거.)
+  camera.wheelDeltaPercentage = ZOOM_DELTA_PERCENTAGE;
+  camera.pinchDeltaPercentage = ZOOM_DELTA_PERCENTAGE;
   camera.panningSensibility = 0;
   // 로그 뎁스 버퍼 전제 — 극단 near/far (행성 표면 ~ 태양계 외곽 이상)
   camera.minZ = 0.01;


### PR DESCRIPTION
## 배경

R6 #621 D-T2 에서 사용자 보고: **"탐색(free-fly) 버튼 사용 시 자유롭게 시점이동이 안되고 고정"**. develop(R5) 재현 확정 → R6 무관 선행 잠복 (#627 ADR §8 에서 분리).

## Forensic — 정적 가설 기각 (measurement-first, volt #32)

`#627 ADR §8` 정적 가설("satellite focus 의 극소 lowerRadiusLimit 미원복")을 **runtime 실측이 기각**:

| 시나리오 | free-fly 후 tier/radius | lowerRadiusLimit | **줌 (틱당 rel)** | 회전 |
|---|---|---|---|---|
| A. baseline | solar / 35 | 0.5 | 큼 ✅ | ✅ |
| B. jupiter | solar / 2.5 | 0.025 | 큼 ✅ | ✅ |
| **C. io(galilean)** | **body / 158386** | **467 (극소 아님)** | **0.03% ❌ 정지** | ✅ |

**근본 원인**: 위성 focus 는 tier=body(거대 renderScale, radius≈158386)로 진입·잔존. Babylon `wheelPrecision=3`은 **절대 줌 델타**(틱당 ~수십 unit)라 radius 158386 대비 변화율 0.03% → 줌 체감 정지. 회전 정상, 패닝은 설계상 비활성. lowerRadiusLimit(467)은 원인 아님.

## Fix (옵션 F1)

`packages/core/src/scene/camera.ts`: 절대 `wheelPrecision`/`pinchPrecision` → `wheelDeltaPercentage`/`pinchDeltaPercentage` (`ZOOM_DELTA_PERCENTAGE = 0.01`, radius 비례). 모든 tier/scale 일정 비율 줌. desktop wheel + mobile pinch 동시 해소. #509 시점 보존 의도 유지(진입 로직 무변경).

옵션 F2(카메라 정규화, #509 충돌)·F3(패닝, 줌 정지 미해소)는 ADR §3 에서 기각.

## DoD (사용자 합의)

| # | 기준 | 결과 |
|---|---|---|
| D-629-1 | 위성 free-fly 줌 5틱 rel ≥ 0.5% | ✅ 38.95% (fix 전 0.03%) |
| D-629-2 | 회전·줌 baseline 동등 응답 | ✅ (실 Chrome 육안 D-T2 사용자 위임) |
| D-629-3 | 회귀 가드 신설 | ✅ verify:629-freefly-zoom + CI(3006) |
| D-629-4 | #509 시점 보존 회귀 0 | ✅ S1 baseline PASS |

## 회귀 가드 — 3중 시뮬레이션 (guard-pr-dod)

| 단계 | S2(io free-fly) 줌 rel | overall |
|---|---|---|
| Positive (fix) | 38.95% / 54.66% | **PASS** |
| Negative (환원) | 0.03% / 0.03% | **FAIL (exit 1)** |
| Recovery (복원) | 38.95% / 54.66% | **PASS** |

## 테스트 / 검증

- core 단위 테스트 437/437 PASS
- **#380 줌 가드 무회귀**: develop baseline 과 동일 (`S1 PASS / S2 FAIL / S3 PASS / S4 PASS`). #380 S2 는 50ms race window 의 **기존 headless 타이밍 flaky**(develop 3회 일관 FAIL) + **CI 미포함** → 본 fix 무관
- typecheck: `r-phase-allowlist.test.ts` 기존 에러(develop 동일, 본 변경 무관, CI 미포함)
- camera.ts build clean / 인코딩 정상 / prettier 정상

## Behavior Changes

- 줌(휠/핀치) 감도가 **radius 비례(%)**로 변경 — deep tier(body)에서 줌 응답 복구. 일반 scale 줌은 더 일관된 속도(틱당 ~1%).

## 영향 범위

- `camera.ts`(전역 카메라 설정), 신규 가드 + CI step, ADR 2건(신규 #629 forensic / #627 §8 cross-link 정정. 627 ADR diff 大 = 1 bullet 정정 + prettier 테이블 정규화)

## 후속 (ADR §8)

- free-fly 패닝/탐색 UX(F3), target 동결점 재설정 — 수요 확인 후 분리
- 사용자 줌 감도 설정 옵션 — §6 재검토 트리거 박제 (agy cross-validate 고유 발견)

Closes #629

---

### 체크리스트
- [x] **커밋 컨벤션** 준수 (`fix(scene): [#629] ...` / `docs(guard): [#629] ...`)
- [x] **불필요**한 변경 없음 (camera.ts 코어 2라인 + 상수 + 회귀 가드/CI/ADR)
- [x] **보안**: 카메라 줌 설정만 변경, 입력/네트워크/시크릿 무관 (N/A)
- [x] **SSoT**: reviewer/qa sub-agent 마무리 체크리스트 JSON 스키마 준수 + 메인 외부 박제 검증
- [x] **cross-validate**: forensic ADR 박제 직후 agy 교차검증 완료 (outcome=applied, §교차검증 반영 통합)
- [x] **ADR 호환성**: 신규 forensic ADR(Accepted) + #627 §8 cross-link 정정 — 의미적 충돌 0 (reviewer LLM 2차 확인)
- [x] **Test plan** (단위 테스트): core 437/437 PASS + `verify:629-freefly-zoom` 가드 신설 + 3중 시뮬레이션(neg 0.03% exit 1)
