### PR TITLE
[#633] Vercel 빌드 fix — 모노레포 풀빌드(wasm-pack+dist) vercel.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ apps/web/scripts/__diff__/
 # .claude/ 는 harness 관리 파일이므로 tracked — 런타임 생성 파일만 선별 ignore
 .claude/scheduled_tasks.lock
 .claude/logs/
+.vercel

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "cd ../.. && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && . \"$HOME/.cargo/env\" && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.14.0 --locked && pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && . \"$HOME/.cargo/env\" && pnpm -r build"
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && . \"$HOME/.cargo/env\" && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.14.0 --locked && pnpm install --frozen-lockfile",
-  "buildCommand": ". \"$HOME/.cargo/env\" && pnpm -r build"
+  "installCommand": "rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.14.0 --locked && pnpm i --frozen-lockfile",
+  "buildCommand": "pnpm -r build"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "cd ../.. && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && . \"$HOME/.cargo/env\" && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.14.0 --locked && pnpm install --frozen-lockfile",
-  "buildCommand": "cd ../.. && . \"$HOME/.cargo/env\" && pnpm -r build"
+  "installCommand": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && . \"$HOME/.cargo/env\" && rustup target add wasm32-unknown-unknown && cargo install wasm-pack --version 0.14.0 --locked && pnpm install --frozen-lockfile",
+  "buildCommand": ". \"$HOME/.cargo/env\" && pnpm -r build"
 }


### PR DESCRIPTION
## 배경
main/PR preview Vercel 배포가 빌드 실패. (사용자 main→Vercel production 배포 검증 시도 중 발견)

## 근본 원인 (실측)
Vercel 이 `next build`(apps/web)만 실행 → 워크스페이스 dist/wasm 미빌드 → Turbopack **19 errors "Can't resolve @astro-simulator/core/shared"**. 로컬 클린 재현으로 **core 의 tsc 빌드조차 physics-wasm 타입을 요구**(wasm-pack/Rust 가 체인 전제) 확인. CI 는 root `pnpm build`+Rust 환경이라 통과 / Vercel 엔 부재.

```
physics-wasm(wasm-pack) → pkg(core 타입)+pkg-bundler(런타임) → shared(dist) → core(dist) → web(next build)
```

## 수정 (옵션 A — 사용자 승인)
`apps/web/vercel.json` (Root Directory=apps/web):
- **installCommand**: rustup(minimal/stable) + wasm32 target + wasm-pack 0.14.0(CI 동일) + `pnpm install`
- **buildCommand**: `pnpm -r build` (CI 와 동일 — 전체 체인)

wasm gitignore 관습 유지(커밋 안 함). `.vercel` gitignore 추가(CLI 시크릿 커밋 방지).

## 검증
- **로컬**: 클린 후 `pnpm -r build` 전체 통과 (wasm-pack 컴파일 → dist → next build `Compiled successfully` + static 5/5)
- **Vercel installCommand(Rust 설치)**: 본 PR preview 배포 빌드 green 으로 검증 (코멘트에 결과 박제 예정)

## Behavior Changes
- Vercel 빌드만 변경(앱 런타임 무관). 배포 인프라 설정.

## 비목표
- production 자동배포 빈도 제어는 머지 게이트(develop→main 명시 지시 시에만)로 별도 관리.

---

### 체크리스트
- [x] **커밋 컨벤션** 준수
- [x] **불필요**한 변경 없음 (vercel.json + .gitignore 1줄)
- [x] **보안**: .vercel(시크릿) gitignore 추가로 유출 방지. 본 PR 에 시크릿 없음
- [x] **SSoT**: 빌드 명령이 CI(`pnpm build`)와 동일 체인 정합
- [x] **cross-validate**: 인프라 설정 — 정책/ADR 박제 아님(루틴 비대상). 로컬 실측으로 검증
- [x] **ADR 호환성**: docs/decisions 미변경
- [x] **Test plan**: 로컬 클린 `pnpm -r build` 전체 통과 + PR preview 배포로 Vercel 환경 검증

Closes #633