### PR TITLE
[#626] fps/a11y baseline guard paths-ignore — docs-only PR timeout 제거

### DIFF
--- a/.github/workflows/a11y-baseline-guard.yml
+++ b/.github/workflows/a11y-baseline-guard.yml
@@ -8,8 +8,19 @@ name: a11y-baseline-guard
 on:
   pull_request:
     branches: [develop, main]
+    # #626 — docs/ADR/워크플로만 바뀐 PR 은 a11y 측정이 무의미(런타임 무관)한데 20분 실 브라우저
+    # 측정 후 timeout cancelled (PR #625 ADR-only 실측). 런타임 영향 없는 경로는 skip (fail-safe —
+    # 코드/데이터/config 가 하나라도 있으면 실행). paths filter 효과는 base 브랜치 반영 후 후속 PR 부터.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
   push:
     branches: [develop, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
 
 jobs:
   a11y-baseline-guard:

--- a/.github/workflows/fps-baseline-guard.yml
+++ b/.github/workflows/fps-baseline-guard.yml
@@ -7,8 +7,19 @@ name: fps-baseline-guard
 on:
   pull_request:
     branches: [develop, main]
+    # #626 — docs/ADR/워크플로만 바뀐 PR 은 fps 측정이 무의미(런타임 무관)한데 25분 실 브라우저
+    # 측정 후 timeout cancelled (PR #625 ADR-only 실측). 런타임 영향 없는 경로는 skip (fail-safe —
+    # 코드/데이터/config 가 하나라도 있으면 실행). paths filter 효과는 base 브랜치 반영 후 후속 PR 부터.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
   push:
     branches: [develop, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
 
 jobs:
   fps-baseline-guard:


### PR DESCRIPTION
## 배경
`fps-baseline-guard.yml` / `a11y-baseline-guard.yml` 가 paths filter 없이 모든 PR/push 에 실행 → docs-only PR(예: #625 ADR, 코드 0)에서도 25/20분 실 브라우저 측정 후 **timeout cancelled** (CI 자원 낭비 + PR 빨간불). #608(ci.yml timeout) 의 연장 — 두 가드는 별도 워크플로라 미적용이었음.

## 수정 (옵션 A — fail-safe)
두 워크플로의 `pull_request` + `push` 트리거에 `paths-ignore` 추가:
```yaml
paths-ignore: ['**/*.md', 'docs/**', '.github/**']
```
코드/데이터/config 가 하나라도 있으면 실행 — baseline 가드가 실 회귀를 놓칠 위험(옵션 B positive paths 단점) 회피.

## measurement-first
| PR | docs-only? | 결과 |
|---|---|---|
| #625 (R6 ADR) | ✅ | **SKIP** (보고된 케이스) |
| #627/#630/#632/#634/#635 | ❌ 코드 포함 | RUN (정상) |

## D-626-3 검증 (본 PR 자체가 실험)
본 PR은 `.github/**` 만 변경 = docs-only류. **fps/a11y 가 본 PR 에서 SKIP 되면** head-based 필터 즉시 효과 확인. **RUN 되면** pull_request paths 가 base-branch 기준인 "2단계 함정"(workflow_dispatch 사촌) → 머지 후 develop 반영되면 다음 docs PR(#625류)에서 skip. 어느 쪽이든 후속 docs PR 혜택.

## 비목표
timeout 단축 / 측정 freeze 근본원인(#606 Node 24.16 deadlock) = 옵션 C 별도.

---

### 체크리스트
- [x] **커밋 컨벤션** (fix(infra))
- [x] **불필요**한 변경 없음 (2 워크플로 트리거만, job/step/timeout 무변경)
- [x] **보안**: N/A (CI 트리거 필터)
- [x] **SSoT**: 두 가드 동일 paths-ignore 셋
- [x] **cross-validate**: 인프라 트리거 — 정책/ADR 박제 아님(비대상)
- [x] **ADR 호환성**: docs/decisions 미변경
- [x] **Test plan**: YAML 파싱 검증 + measurement-first 매핑 + D-626-3 자체 실험

Closes #626