### PR TITLE
chore(release): v0.29.0 prep — 버전 bump + CHANGELOG (#699 통합 카메라 / #693 패닝)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-06-18
+
+### Behavior Changes (#693 — free-fly 패닝 F3)
+
+- **[#693] free-fly 패닝 (F3) — 우클릭/Ctrl 드래그 target 평면 이동 + floating origin 정합 (MINOR)** ([#693](https://github.com/coseo12/astro-simulator/issues/693)) — free-fly 모드에서 우클릭(또는 Ctrl+좌클릭) 드래그로 카메라 target 을 화면 평면 방향으로 이동(패닝). **radius 비례 `panningSensibility`** (`PANNING_DELTA_PERCENTAGE = 0.01`, `REFERENCE / (radius × pct)`) 로 tier별 renderScale 비대칭(solar≈35 ↔ body≈158386)에서도 drag 1px ↔ world 이동 비율 일정 (#629 `wheelDeltaPercentage` 철학 패닝 적용) — `onBeforeRender` 가 줌 중 radius 변동을 따라 매 프레임 재산출. **floating origin 정합**: free-fly originOffset=[0,0,0] 불변식상 좌표 보정 0 (architect measurement-first 로 #629 "floating origin × panning 위험" 정적 기각 사유를 실측 기각, 코어 12라인). focus 중에는 `panningSensibility=0` (followObserver 가 target 덮어쓰므로 무의미 + jitter 회피). 우클릭 contextmenu 차단 (canvas 한정). ADR `20260616-693-freefly-panning.md` SSoT. 비-범위: 패닝 감도 설정 UI / 모바일 2-finger 팬.
+
 ### Behavior Changes (#699 — free-fly 카메라 통합 재설계)
 
 - **[#699] free-fly 카메라 통합 재설계 — 진입/줌/이동/시점 일관 모델 (MINOR)** ([#699](https://github.com/coseo12/astro-simulator/issues/699)) — free-fly 진입(시점 보존 단일 규칙) + 줌 % + WASD 이동(deltaTime 정규화) + 패닝 일관 모델. ADR `20260617-699-freefly-camera-unified-redesign.md` SSoT.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## 릴리스 준비 v0.29.0

main(`1d723a4`) 대비 develop +5 누적의 릴리스 prep.

### 범위 (MINOR)
- **#693** free-fly 패닝 (F3) — 우클릭 드래그 target 이동 + floating origin 정합
- **#699** free-fly 카메라 통합 재설계 — 진입 단일화/줌아웃 상한/WASD/default 진입 + D-T2 2건 fix (탐색 reset / WASD 포커스)
- #696/#700 free-fly WASD/통합 설계 ADR (docs)

### 변경
- 버전 0.28.0 → 0.29.0 (root/web/core)
- CHANGELOG `[0.29.0] — 2026-06-18` (#693 + #699)

### 테스트 계획 (Test plan)
- 코드 변경 없음 (버전/CHANGELOG 문서만). develop 의 #699/#693 은 각 PR 에서 검증 완료 (verify:699 S1~S6 + 629/631/378/693 + 900 unit + CI 14/14)
- 머지 후 release PR(base=main, merge commit) → ff-sync → tag v0.29.0

### 영향 범위
- 문서/버전만. 머지 후 v0.29.0 릴리스 경로 진입.

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (버전/CHANGELOG 문서만)
- [x] 보안 취약점 없음
- [x] SSoT (sub-agent JSON 스키마) 해당 없음 — 릴리스 prep
- [x] cross-validate 해당 없음 — 정책·ADR 박제 미포함 (버전/CHANGELOG)
- [x] ADR 호환성: 적용 비대상 (`docs/decisions/` 미변경)
- [x] Test plan: 코드 변경 0 — develop #699/#693 각 PR 검증 완료 (verify:699 S1~S6 + 900 unit + CI 14/14)
