### PR TITLE
[#709] v0.31.0 prep — CHANGELOG entry + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.31.0] — 2026-06-19
+
+### Behavior Changes (#709 — fps-baseline-guard flake 완화)
+
+- **[#709] fps-baseline-guard 전역 부하 spike flake 흡수 — 워크플로 1회 자동 재시도 (MINOR)** ([#709](https://github.com/coseo12/astro-simulator/issues/709)) — `fps-baseline-guard` 가 swiftshader runner 의 일시 부하로 가끔 1회 fail → `gh run rerun --failed` green 하던 flake 에서, GitHub 이 첫 실패에 "All jobs failed" 메일을 발송해 릴리스/PR 사이클마다 쌓이던 alert fatigue 를 완화. **measurement-first 진단**(`--diagnose-variance` 모드 신설, `gh workflow run --ref feature/X -f diagnose_variance=true` 로 CI swiftshader 12샘플/scenario 실측): 정상 run 의 scenario-내 variance 는 극히 작고(cv 0~3.8%, p50 전부 60.1, 유일 outlier=desktop default 워밍업 1~2 샘플), v0.30.0 fail 은 전 scenario 동반 40대 하락 = **"runner 전체가 일시 느려지는 전역 부하 spike"** (scenario-내 noise 아님). ⇒ best-of-N(같은 run 내 재측정)은 윈도우 전체 동반 하락이라 흡수 불가(v0.30.0 이 best-of-2 였는데도 40.2 fail). **fix**: `fps-baseline-guard.yml` FPS 검증 step 을 bash retry loop 로 — 1차 fail 시 15s 후 1회 자동 재측정, **2회 연속 fail 이어야 job fail** → 일시 spike 는 job 성공으로 끝나 메일 미발송. GitHub 메일은 job conclusion=`failure` 시에만 발송되므로 메일 노이즈 직접 차단. 진짜 회귀는 매 시도 fail 하므로 은폐 불가(3중 시뮬 negative 검증). 보조로 `verify-fps-baseline.mjs` `MEASURE_MAX_ATTEMPTS` 2→3(워밍업/짧은 transient 흡수). margin(30%)/baseline 무변경 → 회귀 검출 민감도 보존.
+
+### Notes
+
+- 진단 인프라 박제: `--diagnose-variance` 모드 + workflow_dispatch input(`diagnose_variance`/`variance_samples`)은 향후 fps variance 재측정 경로로 영구 보존(workflow_dispatch 전용, 일반 CI 무영향). 측정 데이터 SSoT: `docs/benchmarks/fps-variance-diagnosis-20260619.json`.
+- 본 릴리스는 CI 가드 동작 변경(에이전트 행동 무관)이며 런타임/사용자 UI 변경 없음.
+
 ## [0.30.0] — 2026-06-18
 
 ### Behavior Changes (#704 — free-fly 감도 설정 UI)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## [#709] v0.31.0 릴리스 prep

릴리스 prep — CHANGELOG `[0.31.0]` entry + version bump (루트/core/web). 코드 변경 없음.

### 변경 사항
- `CHANGELOG.md` — `[0.31.0]` entry (#709 fps-baseline-guard flake 완화, Behavior Changes + Notes)
- `package.json` / `packages/core/package.json` / `apps/web/package.json` — `0.30.0` → `0.31.0`

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=release/*` (prep PR)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (릴리스 prep)
- [x] 모든 완료 기준 충족

### 테스트 (Test plan)
- [x] 단위 테스트 추가/수정: N/A — 문서/버전 메타만
- [x] 기존 테스트 통과 확인: #710 (본문 fix) CI 13개 all green 으로 검증 완료
- [x] 모노레포: 신규/변경 워크스페이스 없음

### ADR 호환성 체크
- [x] **적용 비대상**: 본 PR은 `docs/decisions/` 미변경

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (CHANGELOG + version bump 만)
- [x] 보안 취약점 없음
- [x] cross-validate (정책·규약·ADR 박제 시): N/A — 릴리스 prep, 정책/ADR 박제 없음

### 관련 이슈
Refs #709 (이미 #710 머지로 close 완료, 본 PR 은 릴리스 메타)
- [x] SSoT 코어 필드 (sub-agent JSON 스키마): N/A — 에이전트 파일 미변경 (릴리스 메타만)
