### PR TITLE
[#713] v0.32.0 prep — CHANGELOG entry + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-06-20
+
+### Behavior Changes (#713 — canvas 클릭/터치 body 선택)
+
+- **[#713] canvas 클릭/터치로 body 선택 (raycast picking) — 위성 discoverability gap 해소 (MINOR)** ([#713](https://github.com/coseo12/astro-simulator/issues/713)) — 위성(galilean/titan/titania/triton 등)이 `showInShortcutBar=false`(#617)라 URL `?focus=io` 타이핑이 유일 선택 경로였던 **discoverability gap** 을, canvas 클릭/터치 picking 으로 해소. 이제 화면에서 body/위성을 직접 클릭(터치)해 focus 전환 가능. `#624` NO-OP ADR §4 인계 feature. **설계**: 기존 공통 진입점(`sendCommand({type:'focusOn', bodyId})` → `isRPhaseFocusable` 가드 → `bodySelected` emit → `setSelectedBody`)을 재사용 → store sync·카메라 전환·free-fly 해제 전부 자동. **Concrete Prediction 적중**: `simulation-core.ts`/`sim-store.ts`/`core-adapter` 변경 **0 라인** (`git diff --stat` 확인). 신규 `packages/core/src/scene/body-picking.ts` 순수 함수 `resolvePickedBodyId` = `scene.pick` predicate(활성 LOD variant + `mesh.metadata.bodyId` + allowlist) 1차 → occlusion 최전면 자동, miss 시 화면거리 fallback(`Vector3.Project` + `PICK_SCREEN_THRESHOLD_PX=12`) 2차로 작은 glow marker body 도 클릭 가능. **모바일 터치 포함** — cross-validate(agy) 가 보강한 입력 결합 가드 4종: click-through(UI 오버레이 위 클릭이 배경 천체 오선택 방지, `evt.target===canvas`) / 멀티터치(`activePointers.size===1` 일 때만, 핀치줌 중 오선택 방지) / 터치 jitter 임계 분리(마우스 5px / 터치 10px) / DPI 좌표계(`scene.pointerX/Y` engine px, #623 정합). ADR `20260620-713-click-body-select.md` (Accepted, cross-validate agy 통합). qa real Chrome GUI(WebGPU) DoD 7항 전부 PASS. 비-범위(후속): 겹침 cycle/multi-pick(반복 클릭 순환), 궤도선 클릭(#624 candidate C).
+
+### Notes
+
+- `PICK_SCREEN_THRESHOLD_PX=12` 는 measurement-first 실측값 — glow marker low quad 화면 px(parent 반경 3.18px = glow-marker 설계 4.5px × √2 일치) + 모바일 터치 조준 오차 여유. 변경 시 ADR Amendment + 테스트 SSoT 가드 동반.
+- 신규 picking 헬퍼는 core 순수 함수(단위 18 테스트), web(`sim-canvas.tsx`)은 pointer observable wiring + 기존 진입점 호출만 — 픽킹 로직 SSoT 분리.
+
 ## [0.31.0] — 2026-06-19
 
 ### Behavior Changes (#709 — fps-baseline-guard flake 완화)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## [#713] v0.32.0 릴리스 prep

릴리스 prep — CHANGELOG `[0.32.0]` entry + version bump (루트/core/web). 코드 변경 없음.

### 변경 사항
- `CHANGELOG.md` — `[0.32.0]` entry (#713 canvas 클릭/터치 body 선택, Behavior Changes + Notes)
- `package.json` / `packages/core/package.json` / `apps/web/package.json` — `0.31.0` → `0.32.0`

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=release/*` (prep PR)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (릴리스 prep)
- [x] 모든 완료 기준 충족

### 테스트 (Test plan)
- [x] 단위 테스트: N/A — 문서/버전 메타만
- [x] 기존 테스트 통과 확인: #714 (본문) CI green + qa DoD 7/7 검증 완료
- [x] 모노레포: 신규 워크스페이스 없음

### ADR 호환성 체크
- [x] **적용 비대상**: 본 PR은 `docs/decisions/` 미변경

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (CHANGELOG + version bump 만)
- [x] 보안 취약점 없음
- [x] SSoT 코어 필드 (sub-agent JSON 스키마): N/A — 에이전트 파일 미변경
- [x] cross-validate (정책·규약·ADR 박제 시): N/A — 릴리스 prep, 정책/ADR 박제 없음

### 관련 이슈
Refs #713 (이미 #714 머지로 close 완료, 본 PR 은 릴리스 메타)