### PR TITLE
[#715] packages/core typecheck red 해소 — @types/node + test assertion

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "@babylonjs/core": "^8.0.0"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "typescript": "^6.0.0",
     "vitest": "^4.1.4"

--- a/packages/core/src/scene/r-phase-allowlist.test.ts
+++ b/packages/core/src/scene/r-phase-allowlist.test.ts
@@ -246,7 +246,9 @@ describe('#598 — browser-verify-378-focus.mjs FOCUS_BODIES SSoT 정합', () =>
     const source = fs.readFileSync(verifyScriptPath, 'utf-8');
     const match = source.match(/const\s+FOCUS_BODIES\s*=\s*\[([^\]]+)\]/);
     expect(match, 'FOCUS_BODIES 선언 패턴을 찾지 못함').toBeTruthy();
-    const focusBodies = match![1]
+    // capture group [1] 은 위 toBeTruthy 로 match 존재 보장 + 정규식에 캡처 그룹이 있어 항상 존재
+    // (noUncheckedIndexedAccess 로 string|undefined 추론되므로 non-null assertion).
+    const focusBodies = match![1]!
       .split(',')
       .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
       .filter((s) => s.length > 0);
@@ -267,7 +269,7 @@ describe('#619 — r1-ui-regression-guard.mjs targetIds SSoT 정합', () => {
   function extractArray(source: string, name: string): string[] {
     const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*\\[([^\\]]+)\\]`));
     expect(match, `${name} 선언 패턴을 찾지 못함`).toBeTruthy();
-    return match![1]
+    return match![1]!
       .split(',')
       .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
       .filter((s) => s.length > 0);
@@ -357,7 +359,7 @@ describe('#617 — showInShortcutBar 메타 SSoT 정합', () => {
     );
     const block = source.match(/const\s+FOCUS_BUTTONS\s*=\s*\[([\s\S]+?)\];/);
     expect(block, 'FOCUS_BUTTONS 선언을 찾지 못함').toBeTruthy();
-    const ids = [...block![1].matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1]);
+    const ids = [...block![1]!.matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1]);
     expect(ids).toEqual(shortcutBodies);
   });
 
@@ -371,7 +373,7 @@ describe('#617 — showInShortcutBar 메타 SSoT 정합', () => {
     const extract = (name: string) => {
       const m = source.match(new RegExp(`const\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]`));
       expect(m, `${name} 선언을 찾지 못함`).toBeTruthy();
-      return m![1]
+      return m![1]!
         .split(',')
         .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
         .filter((s) => s.length > 0);

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -76,10 +76,10 @@ const FLOATING_ORIGIN_THRESHOLD_METERS = AU;
 /**
  * P11-A #288 — dev-only assert gate.
  *
- * core 패키지는 `@types/node` 를 의존으로 두지 않으므로 `process` 가 types 에 없다.
- * runtime 에 `globalThis.process?.env?.NODE_ENV` 를 안전하게 읽고, Next.js webpack 이
- * 빌드 시점에 `NODE_ENV` 를 리터럴 치환 → prod bundle 에선 이 함수가 `false` 를 반환해
- * 하위 assert 블록이 DCE 된다.
+ * `process` 는 브라우저 번들 runtime 에 존재하지 않을 수 있다 (#715 부터 `@types/node` 로
+ * 타입은 있으나 — core 는 브라우저 타겟이라 런타임 부재 가능). 따라서 `globalThis.process?.env?.NODE_ENV`
+ * 를 안전하게 읽고, Next.js webpack 이 빌드 시점에 `NODE_ENV` 를 리터럴 치환 → prod bundle 에선
+ * 이 함수가 `false` 를 반환해 하위 assert 블록이 DCE 된다.
  */
 function floatingOriginAssertEnabled(): boolean {
   const g = globalThis as { process?: { env?: { NODE_ENV?: string } } };
@@ -1192,7 +1192,7 @@ export function createSolarSystemScene(
     }
 
     // P11-A #288 DoD β v2 — dev 빌드 assert: **focus body** local 좌표 절대값 ≤ 1e5 m (100 km).
-    // core 패키지는 `process` 타입이 없으므로 runtime guard 사용. Next.js webpack 이 `process.env.NODE_ENV`
+    // `process` 는 브라우저 번들 런타임에 없을 수 있어 runtime guard 사용. Next.js webpack 이 `process.env.NODE_ENV`
     // 를 빌드 타임 치환 → prod bundle 에서는 `'development' !== 'production'` 이 false 가 되어 DCE.
     // SSR / 테스트 환경은 `globalThis.process` 유/무 가드로 안전 접근.
     //

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)


### PR DESCRIPTION
## [#715] packages/core typecheck red 해소

`packages/core`가 `@types/node`를 직접 의존하지 않아(pnpm strict node_modules) test 파일의 `node:*` import가 `tsc --noEmit -p tsconfig.json`에서 TS2591, capture group 인덱스 접근이 TS2532/TS7006로 red였다. `tsconfig.build.json`(test 제외)은 통과해 빌드 게이트엔 안 잡히나 IDE/수동 typecheck가 red — #714(클릭 선택) reviewer + qa 공통 분리 권고.

### 변경 사항
- `packages/core/package.json` — `@types/node ^25.6.0` devDep 추가 (apps/web과 동일 버전, **이미 monorepo에 존재** — 새 라이브러리 아님, 워크스페이스 노출만)
- `packages/core/tsconfig.json` — `types: ["node"]` (node:* 인식 → TS2591/TS7006 해소). core devDeps에 @types/node만 있어 배제될 다른 @types 없음 (부작용 0)
- `r-phase-allowlist.test.ts` — regex capture group `[1]` 4곳 non-null assertion (`expect(match).toBeTruthy()`로 이미 검증된 곳, `noUncheckedIndexedAccess` TS2532 해소)

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=fix/*`

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (이슈 #715 = TS2591 해소 + typecheck green)
- [x] 모든 완료 기준 충족

### 테스트 (Test plan)
- [x] 단위 테스트: r-phase-allowlist + orbit-line 31 PASS (assertion 추가로 동작 무변경)
- [x] 기존 테스트 통과 확인: `tsc --noEmit -p tsconfig.json` **0 errors** / `tsconfig.build.json` 0 / build 무회귀
- [x] 모노레포: 신규 워크스페이스 없음

### ADR 호환성 체크
- [x] **적용 비대상**: 본 PR은 `docs/decisions/` 미변경

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (typecheck red 해소만 — 런타임/기능 0 변경)
- [x] 보안 취약점 없음 (dev 타입 정의 + assertion만)
- [x] SSoT 코어 필드 (sub-agent JSON 스키마): N/A — 에이전트 파일 미변경
- [x] cross-validate (정책·규약·ADR 박제 시): N/A — 타입 설정 chore, 정책/ADR 박제 없음

Closes #715