### PR TITLE
[release] v0.33.0 prep — CHANGELOG entry + version bump (#719 #721 #715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-06-20
+
+### Behavior Changes (#719 — 겹침 cycle)
+
+- **[#719] 겹침 cycle — 같은 위치 반복 클릭 시 ray 뒤 body 순환 선택 (MINOR)** ([#719](https://github.com/coseo12/astro-simulator/issues/719)) — #713 클릭 선택의 occlusion 최전면 단일 선택을 확장 — jupiter disk 위/뒤 galilean 위성처럼 겹친 body 를 같은 화면 위치 반복 클릭으로 ray 상 다음(뒤) body 순환 선택(wrap). 신규 `resolvePickedBodyIds`(`scene.multiPick` + **명시 distance 정렬** + bodyId dedup 첫등장유지). cycle 상태는 web 클로저 로컬(`lastClickX/Y` + `lastSelectedBodyId`), 직전 id 앵커 `cands.indexOf(lastId)+1) % len` wrap. `PICK_CYCLE_SAME_POS_PX=14`(터치 jitter 10 + 손떨림 4 실측). 기존 `focusOn` 진입점 재사용 → core(simulation-core/sim-store/core-adapter) **변경 0라인**. ADR `20260620-719-overlap-cycle.md` (Accepted, cross-validate agy — 입력 결합 가드 4종 보강 + §결정1 Amendment: Babylon multiPick 미정렬 실측 보정). qa real Chrome GUI: 자연 겹침 galilean↔jupiter 50%(16/32 스캔) 빈도로 cycle 실효용 입증. 비-범위(후속): marker(작은 body) cycle, 겹침 후보 시각 UI.
+
+### Behavior Changes (#721 — 토성계 위성 확장 R11)
+
+- **[#721] 토성계 위성 3개 추가 — Rhea / Iapetus / Enceladus (MINOR)** ([#721](https://github.com/coseo12/astro-simulator/issues/721)) — 토성이 titan 1개뿐이던 것을 주요 위성 3개(Rhea 2대 위성 / Iapetus 두 얼굴 / Enceladus 간헐천)로 확장(R11=phase 12). 클릭(#713)/cycle(#719)/URL `?focus=rhea` 로 선택 가능. **신규 `ORBIT_VISUAL_SCALE_BY_PARENT_AND_BODY` per-body orbit 룩업 첫 발동** — enceladus(최내곽)·iapetus(최외곽) a 편차 15배로 단일 saturn=10 양립 불가 → enceladus ×47 / rhea ×20 / titan ×10(회귀 0) / iapetus ×10 (분리 마진 전부 ≥1.5). body scale 250(satellite 그룹, 물리비 정직). JPL Horizons **REF_PLANE=ECLIPTIC** 명시(미지정 시 Saturn 적도면 → titan 과 28° 어긋남, cross-validate 이견 수용). ADR `20260620-721-saturn-moons-rhea-iapetus-enceladus.md` (Accepted, cross-validate agy). Concrete Prediction: picking/카메라 0라인 적중(궤도선 per-body scale 은 +19줄 "코드 0 불가 축"). qa real Chrome GUI DoD 7/7, enceladus 250 유지(ring occlusion 미발생).
+
+### Fixed (#715 — PATCH)
+
+- **[#715] packages/core typecheck red 해소 — @types/node + test assertion** ([#715](https://github.com/coseo12/astro-simulator/issues/715)) — core 가 `@types/node` 직접 의존 안 해(pnpm strict) test 의 `node:*` import TS2591 + capture group TS2532. `tsconfig.build.json`(test 제외)은 통과해 빌드 게이트 무관이나 IDE/수동 typecheck red. `@types/node` devDep + `tsconfig types:["node"]` + capture group assertion 4곳으로 `tsc --noEmit -p tsconfig.json` 0 errors.
+
+### Notes
+
+- 본 릴리스는 위성 탐색 인프라(#713 클릭 선택 / #719 cycle, v0.32.0)와 그 위 첫 콘텐츠 확장(#721 토성 위성)을 묶는다. #715 는 #713 PR 에서 분리된 typecheck 정리(행동 변화 없음).
+- `PICK_CYCLE_SAME_POS_PX`/orbit per-body scale 값은 measurement-first 실측값 — 변경 시 ADR Amendment + 테스트 갱신 의무.
+
 ## [0.32.0] — 2026-06-20
 
 ### Behavior Changes (#713 — canvas 클릭/터치 body 선택)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## v0.33.0 릴리스 prep

CHANGELOG `[0.33.0]` entry + version bump (루트/core/web). 코드 변경 없음.

### 포함
- #719 겹침 cycle (MINOR)
- #721 토성계 위성 3개 R11 (MINOR)
- #715 packages/core typecheck red 해소 (PATCH)

### 변경 사항
- `CHANGELOG.md` — `[0.33.0]` entry (Behavior Changes #719/#721 + Fixed #715 + Notes)
- `package.json` ×3 — `0.32.0` → `0.33.0`

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=release/*` (prep PR)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (릴리스 prep)
- [x] 모든 완료 기준 충족

### 테스트 (Test plan)
- [x] 단위 테스트: N/A — 문서/버전 메타만
- [x] 기존 테스트 통과 확인: #720/#722 CI green + qa DoD 검증 완료
- [x] 모노레포: 신규 워크스페이스 없음

### ADR 호환성 체크
- [x] **적용 비대상**: 본 PR은 `docs/decisions/` 미변경

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (CHANGELOG + version bump 만)
- [x] 보안 취약점 없음
- [x] SSoT 코어 필드 (sub-agent JSON 스키마): N/A — 에이전트 파일 미변경
- [x] cross-validate (정책·규약·ADR 박제 시): N/A — 릴리스 prep, 정책/ADR 박제 없음 (#719/#721 ADR은 각 PR에서 cross-validate 완료)

### 관련 이슈
Refs #719 #721 #715 (모두 close 완료, 본 PR 은 릴리스 메타)