### PR TITLE
[chore] pre-existing web lint 5 errors 정리

### DIFF
--- a/apps/web/src/components/panels/celestial-info-panel.test.tsx
+++ b/apps/web/src/components/panels/celestial-info-panel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as AstroCore from '@astro-simulator/core';
 import { useSimStore } from '@/store/sim-store';
 import { CelestialInfoPanel } from './celestial-info-panel';
 
@@ -11,7 +12,7 @@ import { CelestialInfoPanel } from './celestial-info-panel';
 // 가드 가상 ID 실모듈 테스트가 직교 커버 (ADR §위험 #5).
 const rPhaseMock = vi.hoisted(() => ({ disabledIds: [] as string[] }));
 vi.mock('@astro-simulator/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@astro-simulator/core')>();
+  const actual = await importOriginal<typeof AstroCore>();
   return {
     ...actual,
     isRPhaseFocusable: (bodyId: string | null | undefined) =>

--- a/apps/web/src/components/panels/celestial-tree.test.tsx
+++ b/apps/web/src/components/panels/celestial-tree.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoreCommand } from '@astro-simulator/shared';
+import type * as AstroCore from '@astro-simulator/core';
 import { useSimStore } from '@/store/sim-store';
 import { CelestialTree } from './celestial-tree';
 
@@ -19,7 +20,7 @@ vi.mock('@/core/sim-context', () => ({
 // 직교 커버 (ADR §위험 #5).
 const rPhaseMock = vi.hoisted(() => ({ disabledIds: [] as string[] }));
 vi.mock('@astro-simulator/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@astro-simulator/core')>();
+  const actual = await importOriginal<typeof AstroCore>();
   return {
     ...actual,
     isRPhaseFocusable: (bodyId: string | null | undefined) =>

--- a/apps/web/src/components/panels/scenario-presets.test.tsx
+++ b/apps/web/src/components/panels/scenario-presets.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoreCommand } from '@astro-simulator/shared';
+import type * as AstroCore from '@astro-simulator/core';
 import { useSimStore } from '@/store/sim-store';
 import { ScenarioPresets } from './scenario-presets';
 
@@ -17,7 +18,7 @@ vi.mock('@/core/sim-context', () => ({
 // membership 가드 가상 ID 실모듈 테스트가 직교 커버 (ADR §위험 #5).
 const rPhaseMock = vi.hoisted(() => ({ disabledIds: [] as string[] }));
 vi.mock('@astro-simulator/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@astro-simulator/core')>();
+  const actual = await importOriginal<typeof AstroCore>();
   return {
     ...actual,
     isRPhaseFocusable: (bodyId: string | null | undefined) =>

--- a/apps/web/src/components/ui/satellite-zoom-tooltip.tsx
+++ b/apps/web/src/components/ui/satellite-zoom-tooltip.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  resolveFocusMultiplier,
-  FOCUS_USER_RADIUS_MULTIPLIER,
-} from '@astro-simulator/core/scene';
+import { resolveFocusMultiplier, FOCUS_USER_RADIUS_MULTIPLIER } from '@astro-simulator/core/scene';
 import solarSystemData from '@astro-simulator/shared/data/solar-system.json';
 import { useSimStore } from '@/store/sim-store';
 import {
@@ -135,6 +132,9 @@ export function SatelliteZoomTooltip() {
   useEffect(() => {
     // focus 해제 또는 satellite-parent 아닌 body → 즉시 숨김 (전이 시점 cleanup)
     if (selectedBodyId === null || !isSatelliteParent) {
+      // selectedBodyId(외부 store) 변화에 반응하는 cleanup — visible 은 결과이고 trigger 가 아니라
+      // cascading 무한루프 없음 (정당한 외부 상태 sync). set-state-in-effect 규칙 보수적 false-positive.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisible(false);
       setFadingOut(false);
       currentBodyIdRef.current = null;
@@ -167,13 +167,10 @@ export function SatelliteZoomTooltip() {
     const fadeStartTimer = window.setTimeout(() => {
       setFadingOut(true);
     }, AUTO_FADE_OUT_MS);
-    const hideTimer = window.setTimeout(
-      () => {
-        setVisible(false);
-        setFadingOut(false);
-      },
-      AUTO_FADE_OUT_MS + FADE_DURATION_MS,
-    );
+    const hideTimer = window.setTimeout(() => {
+      setVisible(false);
+      setFadingOut(false);
+    }, AUTO_FADE_OUT_MS + FADE_DURATION_MS);
     return () => {
       window.clearTimeout(fadeStartTimer);
       window.clearTimeout(hideTimer);

--- a/apps/web/src/core/url-sync.test.tsx
+++ b/apps/web/src/core/url-sync.test.tsx
@@ -1,6 +1,7 @@
 import { render, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoreCommand } from '@astro-simulator/shared';
+import type * as AstroCore from '@astro-simulator/core';
 import { useSimStore } from '@/store/sim-store';
 
 /**
@@ -71,7 +72,7 @@ vi.mock('@/core/sim-context', () => ({
 // simulation-core 가드) + filterBodiesByPhase 순수 함수 경계 테스트가 직교 커버 (ADR §위험 #5).
 const rPhaseMock = vi.hoisted(() => ({ disabledIds: [] as string[] }));
 vi.mock('@astro-simulator/core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@astro-simulator/core')>();
+  const actual = await importOriginal<typeof AstroCore>();
   return {
     ...actual,
     isRPhaseFocusable: (bodyId: string | null | undefined) =>


### PR DESCRIPTION
## pre-existing web lint 5 errors 정리

여러 PR(#714/#722/#726/#729 등)에서 "pre-existing baseline, 별도 분리 권장"으로 누적 인계된 develop의 web lint 5 errors를 청산. **동작 변경 0**.

### 변경 사항
- **test 4개** (`celestial-info-panel`/`celestial-tree`/`scenario-presets`/`url-sync`.test.tsx) — 인라인 `importOriginal<typeof import('@astro-simulator/core')>()`의 `import()` type annotation을 `import type * as AstroCore` 변환 (`@typescript-eslint/consistent-type-imports`, 런타임 무관)
- **`satellite-zoom-tooltip.tsx`** — `useEffect` 내 `setVisible(false)`는 `selectedBodyId`(외부 store) 변화에 반응하는 cleanup으로 visible이 결과(trigger 아님)라 cascading 무한루프 없음 → `react-hooks/set-state-in-effect` false-positive로 `eslint-disable` + 사유 박제 (동작 변경 0). 같은 effect의 나머지 setState는 `setTimeout` 콜백이라 규칙 무관.

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=fix/*`

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (lint errors 0)
- [x] 모든 완료 기준 충족

### 테스트 (Test plan)
- [x] 단위 테스트: 수정 test 4개 68 PASS (import type 변환 — 동작 무변경)
- [x] 기존 테스트 통과 확인: **web lint 0 errors**(5→0), web/core typecheck 0
- [x] 모노레포: 신규 워크스페이스 없음

### ADR 호환성 체크
- [x] **적용 비대상**: `docs/decisions/` 미변경

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 (lint 정리만 — import type 변환 + 정당한 disable)
- [x] 보안 취약점 없음
- [x] SSoT 코어 필드 (sub-agent JSON 스키마): N/A — 에이전트 파일 미변경
- [x] cross-validate (정책·규약·ADR 박제 시): N/A — lint chore, 정책/ADR 박제 없음

### 비-범위
- MAX_DENSITY_POINTS / MAX_ARCS parity (별도 chore) — ring-shader 영역, 직교