### PR TITLE
[release] v0.35.0 prep — CHANGELOG entry + version bump (#737 #738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-06-25
+
+### Behavior Changes (#737 — 첫 진입 온보딩 / #738 — 별 배경)
+
+- **[#737] 첫 진입 온보딩 + 조작 가이드 (MINOR)** ([#737](https://github.com/coseo12/astro-simulator/issues/737)) — v3 완주(27 body) 이후 첫 진입 사용자의 discoverability 갭 해소(방향성 기획 트랙 B). 첫 방문 시 온보딩 모달 자동 표시(조작 안내: 천체 이동 / 클릭·터치 선택+cycle / 휠 줌 / 드래그·방향키 회전 / free-fly WASD·Q/E·우클릭 패닝, 마우스·키보드 vs 터치 분기) + 상시 "조작 가이드" 버튼 재호출 + free-fly 진입 키 힌트 toast(글로벌 1회). `astro:onboarding-dismissed` `{version,value}` localStorage 영속. **Esc 충돌 가드** `data-modal-open`(about/sensitivity/onboarding 3 모달 일괄 — native window listener가 React stopPropagation 차단 못하던 잠복 버그 동시 해소). a11y(role=dialog / aria-modal / focus 관리, axe 0 위반). **`navigator.webdriver` testability 가드**(자동화 환경에서 자동표시 스킵 — 실사용자 무관, 클릭/픽셀 browser-verify backdrop 차단 방지). core 변경 0. 후속 #740(a11y 토큰 전수).
+- **[#738] 별 배경 + 은하수 — 절차적 starfield (MINOR)** ([#738](https://github.com/coseo12/astro-simulator/issues/738)) — "감상/탐험형" 정체성 핵심(방향성 기획 트랙 A1) — 단색 배경에 절차적 별 배경 + 은하수 띠 추가. `infiniteDistance` inverted sphere + 단일 draw call fragment shader(별 + 은하수, **신규 라이브러리·에셋 0**, ring-shader 답습). `infiniteDistance`가 floating-origin shift / tier scale / 줌 불변을 엔진 레벨 보장(D1 실측 Δ0px → 별 추종 코드 0). `?stars=off` 토글(기본 ON). **gpu tier-c(저성능/swiftshader)는 별 배경 비활성**(전체화면 shader fill-rate graceful degradation — `resolveStarfieldVisible = starsVisible && gpuTier !== 'c'`, ADR Amendment 1). WebGPU/WebGL2 shader parity 실측. ADR `20260624-738-procedural-starfield.md` (Accepted, cross-validate agy). 비-범위(후속): 실측 star catalog / 별자리 선·라벨 / 성운 에셋 / 토글 UI 버튼.
+
+### Notes
+
+- 두 기능 모두 2026-06-22 방향성 기획서의 "경험 레이어"(트랙 B 온보딩 → A 몰입) 첫 라운드 — v3(엔진·콘텐츠 완성) 이후 "도표형 → 감상형" 전환 착수.
+- **#737 testability 교훈**: 자동표시 모달 backdrop이 클릭/픽셀 browser-verify를 차단 → `navigator.webdriver` 가드로 근본 해결. 신규 자동표시 UI 추가 시 동일 가드 의무.
+- **#738 성능 교훈**: 전체화면 shader fill-rate 회귀는 CI swiftshader(tier-c)에서만 드러남(실 GPU PASS) — 시각 효과는 CI 소프트웨어 렌더 fps 검증 필수.
+
 ## [0.34.1] — 2026-06-22
 
 ### Behavior Changes: None — 회귀 가드 신설 + lint 정리 (제품 동작 무변화)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## 개요

v0.35.0 (MINOR) 릴리스 준비 — CHANGELOG entry + version bump. "경험 레이어"(방향성 기획 트랙 B 온보딩 + A 몰입) 첫 라운드 2건.

릴리스 범위 (develop 기준 v0.34.1 이후, 둘 다 MINOR):
- `[#737]` 첫 진입 온보딩 + 조작 가이드 (PR #739)
- `[#738]` 별 배경 + 은하수 절차적 starfield (PR #742)

## 변경 사항

- `CHANGELOG.md` — `[0.35.0]` entry (`### Behavior Changes` — 온보딩 + 별 배경)
- `package.json` / `apps/web/package.json` / `packages/core/package.json` — `0.34.1 → 0.35.0`

## SemVer 분류 근거

**MINOR** — 신규 기능 2개(행동 변화 동반): 온보딩 자동표시/조작 가이드/navigator.webdriver 가드 + 별 배경/은하수/tier-c graceful degradation.

## 태그 계획

prep 머지 → release PR (develop → main, **merge commit**) → `git push origin main:develop` (ff-sync) → `git tag v0.35.0` + `gh release create v0.35.0`

## 체크리스트

- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음 — 릴리스 메타데이터(version)/CHANGELOG 만
- [x] 보안 취약점 없음
- [x] SSoT — N/A (sub-agent JSON 스키마 미수정)
- [x] cross-validate — N/A (정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 없음, 릴리스 메타데이터만)
- [x] ADR 호환성 — N/A (ADR 변경 없음 — #738 ADR 은 PR #742 에서 반영 완료)

## Test plan

- [x] CHANGELOG `[0.35.0]` entry + 한글 인코딩 검증 (U+FFFD 0건)
- [x] version bump 3파일 (루트 / core / web) 0.34.1 → 0.35.0
- [x] 커밋 실제 반영 검증 (git show HEAD)
- [x] N/A — 단위 테스트 (릴리스 메타데이터만, 기능 코드 #739/#742 에서 검증 완료)
- [x] N/A — 브라우저 검증 (제품 코드 무변화)
- [x] N/A — 신규 의존성 없음

## 관련 이슈

Refs #737 #738
