### PR TITLE
chore(release): v0.38.0 prep — CHANGELOG + version bump (#762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.38.0] — 2026-06-29
+
+### Behavior Changes (#762 — 천체 표시 크기 비율 단조성)
+
+- **[#762] 천체 표시 크기 비율 단조성 회복 — sqrt 압축 곡선 (MINOR)** ([#762](https://github.com/coseo12/astro-simulator/issues/762)) — 카메라 focus 를 태양이 아닌 다른 천체(예: 목성)로 옮겨 줌아웃/회전해 거성과 안쪽 행성이 **함께 보일 때(co-visible)**, 지구·화성이 목성보다 크게 보이던 **비율 역전**을 해소. 근인은 per-body `bodyScale` 비대칭(안쪽 행성 800 vs 거성 48)이 거리 보정 없이 절대 적용돼 effective(=반경×scale) 가 실제 반경 순서를 뒤집던 것 — 각 R-Phase 가 천체별 단독 viewport 점유율만 합의하고 천체 간 상대 비율은 보지 않은 누적 결과. **fix**: 행성(8)+왜소행성(5) scale 을 `effective = 반경^p × k`(p=0.5 sqrt 압축, mercury floor 고정) **압축 곡선 SSoT** 로 전환 — 작은 천체 큰 배율 / 큰 천체 작은 배율이되 최종 mesh 가 실제 반경 순서를 **단조 보존**(jupiter 1위 회복). 위성(8) 은 per-parent 수렴대(0.05~0.09) 비율 유지(모듈 로드 시 1회 정적 역산 박제), 혜성·극소형 5000 그룹 유지(cross-group 단조 보존). **측정(qa 실 Chrome GUI)**: 구 정책 earth 10.12px > jupiter 8.81px(역전) → 신 정책 jupiter 21.36px > earth 5.88px(목성 3.6배), 사용자 시나리오(목성 focus 후 회전) 7.4배. 단독 focus 가시성 무회귀(auto-frame ~345px, 점으로 사라지는 천체 0), ring occlusion 시각 가림 없음, fps 회귀 0, r1-guard baseline 무회귀. **`?bodyScaleP=`** URL 플래그(기본 p=0.5, 0.1~1.0 reject-to-default)로 압축 강도 실시간 튜닝. info-panel "실제의 N배" 정수 표시(곡선 도입으로 float → `Math.round`). 단조성 단위 테스트(행성 cross-body + 위성 수렴대 + 그룹 경계 achievable invariant + NaN guard). 데이터 SSoT 불변(`solar-system.json` 반경 0), `packages/core/scene` diameter 식 0(콜백 인터페이스 불변). Forensic ADR `20260629-762-body-scale-monotonic-forensic.md`(Accepted, cross-validate agy). 정책 ADR `20260506` SUPERSEDED-BY 역참조.
+
+### Notes
+
+- 후속 분리 **#764** — `body-scale.ts` radius 미러 drift 가드를 위성(13)·혜성(5)까지 전수 직접 단언으로 확장(현재 행성·왜소 13 직접 / 위성 band 간접 / 혜성 존재만). 현재 32 body 0 drift 정합이라 비차단, volt #69 숨은 상수 회귀 방어 강화.
+
 ## [0.37.0] — 2026-06-28
 
 ### Behavior Changes (#756 — 절차적 행성 표면 셰이더)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",


### PR DESCRIPTION
## [#762] v0.38.0 prep — CHANGELOG + version bump

### 변경 사항
- CHANGELOG `[0.38.0]` entry 추가 (#762 천체 표시 크기 비율 단조성, **MINOR**, Behavior Changes + Notes)
- version bump `0.37.0 → 0.38.0` (루트 / `@astro-simulator/core` / `@astro-simulator/web` 3개 package.json)

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 형태**: `base=develop`, `head=release/0.38.0-prep` (release 준비 커밋. Release PR(`base=main`)은 본 PR 머지 후 별도 생성)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (#762 DoD)
- [x] 모든 완료 기준 충족 (#763 머지, qa DoD 통과)

### 테스트 (Test plan)
- [x] 단위 테스트 추가/수정 — 본 PR 은 CHANGELOG + version bump 만 (코드 동작 변화 0), 테스트 변경 비대상
- [x] 기존 테스트 통과 확인 — #763 에서 core 659 + web 470 PASS, CI 전부 green
- [x] 모노레포: 신규/변경 워크스페이스 없음 (`scripts.test` 변경 비대상)

### ADR 호환성 체크
- [x] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경 (Forensic ADR `20260629-762` 는 #763 에 포함됨)

### 체크리스트
- [x] 커밋 컨벤션 준수 (`chore(release)`)
- [x] 불필요한 변경 없음 — CHANGELOG + version 4파일만
- [x] 보안 취약점 없음
- [x] SSoT (sub-agent JSON 스키마) 미수정 — 해당 없음
- [x] cross-validate — 본 PR 은 정책·규약·ADR 박제 변경 없음 (CHANGELOG/version 문서. 해당 없음)

### 관련 이슈
- #762 은 #763 squash 머지로 이미 close. 본 PR 은 v0.38.0 release prep.
