### PR TITLE
release: v0.40.0 — 표면 셰이더 광원 일관성 회복 + 지구 대륙 (#773 #775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Semantic Versioning을 따른다.
 
 ## [Unreleased]
 
+## [0.40.0] — 2026-07-01
+
+### Behavior Changes (#773 표면 셰이더 광원 일관성 회복 / #775 지구 대륙 표현)
+
+- **[#773] 표면 셰이더 행성 광원 일관성 회복 (MINOR)** ([#773](https://github.com/coseo12/astro-simulator/issues/773)) — #756 절차적 표면 셰이더 도입의 **광원 회귀** 수정. 표면 셰이더 행성(지구/화성/목성/달)이 커스텀 `ShaderMaterial`이라 Babylon `PointLight`를 자동 반영 못 해 **고정 방향 벡터(0.5,0.7,0.5) + 0.85~1.0 균일 명암**(태양 위치 무관 / 밤면 없음 / terminator 없음)으로 렌더되던 것을, 단색 행성(금성/토성 등 `StandardMaterial`+`PointLight`+`HemisphericLight`)과 **동일한 실제 태양 광원 명암**으로 전환. **구현**: `material.onBindObservable`에서 각 draw 직전 `uSunDirection = normalize(sunPos − mesh.getAbsolutePosition())` 갱신(`tmpVector` 재사용 alloc 0, 광원 상수는 scene SSoT → core 단방향 provider 주입) + 셰이더 `shade`를 **HemisphericLight 식 완전 재현**(`mix(ambientGround, ambientSky, dot(N,up)*0.5+0.5) + sunIntensity*sunDiffuse*smoothstep(0, W, dot(N,sunDir))`, soft terminator). 회전 0(self-rotation 미구현) 전제로 world normal == local normal(normalMatrix 불필요) — dev-only 회전 어서션 + 주석/테스트 계약으로 가드. moon(cratered) 동일 적용(월식 그림자는 범위 밖). **실측(실 Chrome GUI)**: 밤면/terminator 대비비 15.9~21.4(단색 행성 15.7~22.6 동일 범위, 회귀 전 1.12x), 태양 추종 명암 71.4° 이동, fps 회귀 0(tier-c는 override=low StandardMaterial 자동 우회), mid LOD 연속. forensic ADR Amendment 1(단색 행성 라이팅 식 재현 측정 — 낮면 2.547/terminator 0.173/극 0.300/밤면하단 0.046).
+- **[#775] 지구 대륙 표현 — rocky 셰이더 육지색 mix (MINOR)** ([#775](https://github.com/coseo12/astro-simulator/issues/775)) — rocky 셰이더가 대륙/해양을 **바다색 baseColor 밝기 ±35% 변조만**(색조 불변)으로 표현해 지구가 "바다만" 보이던 것을, `continents` noise로 **ocean ↔ land 색조 mix**(`mix(baseColor, LAND_COLOR_RGB, smoothstep(LAND_THRESHOLD_LO/HI, continents))`)로 전환. 육지색 = **코드 상수 `LAND_COLOR_RGB`**(올리브-브라운 R/G 우세 자연색, rendering-only — 데이터 SSoT 보존, `colorHint` 확장 거부), ocean = 기존 baseColor read-only. **실측**: 낮면 색조 2-모드 land 49.3%/ocean 44.0%(황록 대륙 + 청록 바다), 보라/마젠타 0.
+- 공통: 절차 표면 디테일 무회귀(#756 고주파 엔트로피 hfEnergy ON>OFF, 낮면 기준), 데이터(`solar-system.json`) 변경 0, picking/camera/orbit/tier/LOD 변경 0(Concrete Prediction 적중), GLSL↔JS 미러 parity 단위 테스트(46 신규). ADR `20260628-756-procedural-planet-surface.md` §Amendment 1 (Accepted, cross-validate agy). 사용자 발견(2026-06-30).
+
+### Notes
+
+- 후속 (cross-validate 고유 발견, mesh 미구현으로 시기상조) — 대기/구름 레이어 블렌딩 순서는 대기/구름 mesh 도입 시점 분리(ADR §Amendment 1 §재검토 조건 박제).
+- #774 (태양 절차적 표면 셰이더) 는 별도 진행 예정.
+
 ## [0.39.0] — 2026-06-30
 
 ### Behavior Changes (#766 — alert fatigue 카운트 모수 정제)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/web",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/decisions/20260628-756-procedural-planet-surface.md
+++ b/docs/decisions/20260628-756-procedural-planet-surface.md
@@ -1,8 +1,8 @@
 # ADR 20260628-756 — 절차적 행성 표면 셰이더 (1차: 인프라 + 대표 4개)
 
-- **상태**: Accepted (cross-validate 2026-06-28)
-- **날짜**: 2026-06-28
-- **이슈**: [#756](https://github.com/coseo12/astro-simulator/issues/756)
+- **상태**: Accepted (cross-validate 2026-06-28) — **Amendment 1 (#773/#775): Accepted (cross-validate 2026-06-30)**
+- **날짜**: 2026-06-28 (Amendment 1: 2026-06-30)
+- **이슈**: [#756](https://github.com/coseo12/astro-simulator/issues/756) / Amendment 1: [#773](https://github.com/coseo12/astro-simulator/issues/773) (광원 일관성 회귀, high) + [#775](https://github.com/coseo12/astro-simulator/issues/775) (지구 대륙 mix, low)
 - **관련**: [#738 절차적 별 배경](20260624-738-procedural-starfield.md) (트랙 A 선행), [`docs/architecture/principles.md` §1 Visual Fidelity](../architecture/principles.md)
 - **용어**: [Tier](../glossary.md#tier-t1--t2--t3), [R-Phase](../glossary.md#r-phase-roadmap-v3-phase), [LOD](../glossary.md) (high/mid/low variant)
 
@@ -192,3 +192,202 @@ cross-validate (Antigravity `agy`) 1회 수행 (2026-06-28, outcome=applied, exi
 1. **WebGL1 `highp float` 미지원 precision fallback** (agy 보안 ⑤) — **비대상** (후속 분리 불요). 이 프로젝트는 Babylon v9 + WebGPU/WebGL2 + tier 시스템 기반으로 WebGL1 을 지원 대상에서 제외한다 (starfield/ring-shader 도 `precision highp float;` 고정, WebGL1 fallback 없음 — 동일 선례). WebGL1 미지원 기기는 tier 감지 자체가 별도 경로. 범위 밖이며 기존 셰이더 정책과 정합하므로 후속 이슈 불요 (비대상 명시로 맥락 박제).
 2. **표면 타입 8종+ 초과 시 타입별 셰이더 인스턴스 전환** (agy 확장성) — **비대상** (1차 4종, 재검토 조건 3 에 흡수). agy 도 "임계치 (8종 이상) 초과 시" 미래 조건부 제안. 1차 단일 셰이더 + if-else 분기는 4종에서 divergence 0. 8종+ 도달 시 팩토리 전환은 재검토 조건 3 (표면 타입 확장) 의 자연 연장.
 3. **anti-pattern (보라/마젠타) 출력 색역 어서션** (agy 누락요소 ③) — **수용 (단위 테스트 흡수)**. starfield `starColorMirror` 의 보라/마젠타 부재 가드 패턴을 표면 셰이더 미러에도 적용 (baseColor 위 변조 후 출력 RGB 가 기괴 색역 미진입 어서션). Concrete Prediction 단위 테스트 항목에 이미 "보라-마젠타 부재" 명시 — 강화 확정.
+
+---
+
+## Amendment 1 (2026-06-30) — 광원 일관성 회귀 (#773) + 지구 대륙 mix (#775)
+
+- **상태**: Accepted (cross-validate 2026-06-30 — §A1.7 4축 박제 완료)
+- **이슈**: [#773](https://github.com/coseo12/astro-simulator/issues/773) (bug/회귀, high), [#775](https://github.com/coseo12/astro-simulator/issues/775) (type:feat, low)
+- **형식**: 본 Amendment 는 #756 셰이더의 **직접 보강 + 회귀 수정** 이라 신규 ADR 이 아닌 Amendment 로 박제 (광원 모델이 §결정 5 의 "간이 명암 shade" 를 대체하는 본문 결정의 갱신). **forensic 변형 채택** — 회귀 사실 확인 + runtime 측정 + DoD PASS 인데 사용자 회귀 + N≥2 옵션 비교 + cross-validate Amendment 라운드 예상 → [Forensic ADR 5조건](../../CLAUDE.md) 5/5 충족 (§Forensic 측정 결과 박제).
+
+### A1.1 배경 — #756 부작용 (광원 회귀)
+
+#756 §결정 5 가 도입한 fragment "간이 명암" 식이 회귀의 근원이다:
+
+```glsl
+// procedural-planet-shader.ts:223 (현행)
+float shade = 0.85 + 0.15 * clamp(dot(vNormal, normalize(vec3(0.5, 0.7, 0.5))), 0.0, 1.0);
+```
+
+- **고정 방향 벡터** `(0.5,0.7,0.5)` — 태양 실제 위치 무관 (공전/회전해도 명암 불변).
+- **범위 [0.85, 1.0]** — 밤면조차 0.85 이상 → **밤면 없음 / terminator 없음**.
+- 반면 단색 행성 (StandardMaterial + `disableLighting=false`) 은 태양 `PointLight` (원점, intensity 2.5) + `HemisphericLight` (ambient floor) 의 실제 명암을 받는다.
+
+→ 지구/화성/목성/달 (표면 셰이더) 은 균일하게 밝고, 금성/토성/천왕성/해왕성/수성 (단색) 은 낮/밤 terminator 가 뚜렷 → **시각적 이원화 회귀**.
+
+### A1.2 Forensic 측정 결과 (단색 행성 명암 모델 실측)
+
+`scripts/_debug-773-tmp.mjs` (volt #67 패턴, 측정 후 즉시 rm) 로 단색 행성의 Babylon StandardMaterial 라이팅 식을 재현 측정. 태양 방향 = +X 가정, 라이팅 계수 = `PointLight diffuseTerm + HemisphericLight diffuseTerm` (diffuseColor 곱 전).
+
+| 표면점 (world normal) | 단색행성 라이팅계수 (R,G,B) | 휘도 (Rec.709) | 현행 셰이더 shade |
+| --------------------- | --------------------------- | -------------- | ----------------- |
+| 낮면 중심 (N=+X)      | (2.67, 2.55, 2.18)          | **2.547**      | 0.925             |
+| terminator (N=+Z)     | (0.17, 0.17, 0.18)          | 0.173          | 0.925             |
+| 극/측면 (N=+Y)        | (0.30, 0.30, 0.30)          | 0.300          | 0.956             |
+| 밤면 중심 (N=−X)      | (0.17, 0.17, 0.18)          | **0.173**      | 0.850             |
+| 밤면 하단 (N=−Y)      | (0.04, 0.04, 0.05)          | 0.046          | 0.850             |
+
+**핵심 측정**:
+
+1. **단색 행성 낮/밤 대비비 = 14.74x** (낮면 휘도 2.547 / 밤면 휘도 0.173). 현행 셰이더 대비비 ≈ 1.12x ([0.85, 0.956]) → 거의 균일 = "밤면 없음" 정량 확정.
+2. **밤면 floor = HemisphericLight ground 단독** — `AMBIENT_INTENSITY(0.3) × groundColor(0.15,0.15,0.18) ≈ (0.045, 0.045, 0.054)` 이 **순수 ground 기여**. 단, HemisphericLight 은 `mix(ground, sky, dot(N,up)*0.5+0.5)` 라 **밤면이 균일하지 않다** — 위쪽 향한 밤면 (+Y, 0.30) vs 아래쪽 밤면 (−Y, 0.046) 이 다르다 (hemispheric 그라데이션).
+3. **미묘함 (설계 분기점)** — 단순 스칼라 ambient floor 로는 terminator (N=+Z, 단색 0.173 vs 스칼라 제안 0.046) 와 극지점 (N=+Y, 단색 0.300) 의 hemispheric 그라데이션을 재현 못 함. **단색 행성과 "완전 일치" 하려면 HemisphericLight 식 (`mix(ground, sky, ndl_up)`) 까지 재현해야 한다** → 결정 A1.3-결정 2 에서 비교.
+
+### A1.3 결정
+
+#### 결정 1 — sun direction 갱신 경로 (5 옵션 비교)
+
+표면 셰이더에 **실제 태양 방향**을 전달하는 메커니즘. scene 의 모든 mesh 와 `sunLight` 은 매 프레임 **동일 좌표계** (floating-origin shift + tier scale 적용된 scene-unit world) 로 갱신됨 (`solar-system-scene.ts:1159–1163` mesh, `:1208–1212` sunLight). body mesh 는 **회전 0 (self-rotation 미구현) + uniform scaling** → **world normal == local normal** (정규화 후) — 이 단순화가 설계 핵심.
+
+| 축                 | (a) world position uniform + fragment에서 `sunPos - fragWorldPos` | (b) CPU에서 sunDir(local) 계산 → uniform | (c) `material.onBindObservable` 에서 mesh별 sunDir uniform | (d) scene render loop 에서 material 추적 + uniform | (e) `world` matrix uniform + fragment world normal |
+| ------------------ | ----------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
+| world normal 처리  | fragment world position 필요 (vertex 추가 전달)                   | **불필요** (local==world, 회전 0)        | **불필요** (local==world)                                  | **불필요**                                         | normalMatrix 필요 (회전 0 이라 과잉)               |
+| sunDir 전달        | uniform vec3 (scene-unit)                                         | uniform vec3 (local)                     | uniform vec3 (mesh별)                                      | uniform vec3 (mesh별)                              | —                                                  |
+| material 핸들 추적 | scene가 추적 필요                                                 | scene가 추적 필요                        | **불요** (onBind 자체 콜백)                                | **필요** (Map 보관)                                | scene가 추적 필요                                  |
+| sun position 주입  | scene→material provider                                           | scene→material provider                  | scene→material provider                                    | scene loop 직접                                    | scene→material provider                            |
+| 코드 표면          | 중 (vertex+fragment)                                              | 소                                       | **소 (onBind 1 클로저)**                                   | 중 (Map + loop)                                    | 중                                                 |
+| 정합성             | floating-origin 좌표 직접                                         | local 변환 1회                           | local 변환 1회                                             | local 변환 1회                                     | 과잉                                               |
+
+→ **(c) `onBindObservable` 채택 (보조: provider 콜백)**. 근거:
+
+- ShaderMaterial 의 `onBindObservable.add((mesh) => {...})` 는 **각 draw 직전** mesh 핸들과 함께 호출됨 → scene 이 material 핸들을 별도 Map 으로 추적할 필요 없음 (옵션 d 대비 우월). high/mid 각 variant 의 material 이 자기 onBind 에서 자기 sunDir 을 설정.
+- body mesh 회전 0 + uniform scaling → `world normal == local normal` → **normalMatrix / world matrix uniform 불필요** (옵션 e 과잉 회피). `vNormal` (local) 을 그대로 dot 에 사용 가능.
+- sunDir = `normalize(sunPos_sceneUnit − meshPos_sceneUnit)` 을 CPU(JS)에서 계산 → `uniform vec3 uSunDirection` (mesh local 기준이지만 회전 0 이라 world 와 동일). 부동소수점/픽셀 비용 0 (per-mesh 벡터 1개).
+- **sun position 주입**: `createProceduralPlanetMaterial` 이 sun position provider 콜백 `() => Vector3` 을 인자로 받아 onBind 에서 호출 (scene 이 `sunLight.position` 또는 worldPositions 변환값을 넘김). scene→core 단방향 의존 유지 (core 가 web 미참조).
+- **satellite (달) 정합**: 달 mesh 는 parent(지구) 에 붙어 transform 상속하나 parent 도 회전 0 → `달 absolutePosition` 기준으로 sunDir 계산하면 동일. onBind 의 mesh 는 실제 그려지는 mesh 라 `mesh.getAbsolutePosition()` 이 정확.
+
+> **회전 미구현 전제의 명시적 박제 (drift 가드)**: 본 결정은 "body mesh 회전 0" 에 의존한다. 후속에 self-rotation / axialTilt 가 도입되면 `vNormal` 을 world matrix 로 변환해야 한다 (옵션 e 로 전환). 셰이더 주석 + 단위 테스트에 "회전 도입 시 normalMatrix 필요" 계약 박제 의무 (§A1.5 DoD).
+
+#### 결정 2 — ambient(밤면) 모델: 스칼라 floor vs HemisphericLight 재현 (3 옵션)
+
+| 축                 | (A) 스칼라 ambient floor (`shade = floor + sun·ndl`)        | (B) HemisphericLight 식 완전 재현 (`mix(ground,sky,ndl_up)`) | (C) 단색 행성도 셰이더로 전환 (통합) |
+| ------------------ | ----------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------ |
+| 단색 행성과 일치도 | △ 밤면 균일 (terminator/극 그라데이션 미재현, 측정 §A1.2-3) | ✓ **완전 일치** (ground/sky/up uniform 재현)                 | ✓ (정의상 동일)                      |
+| 셰이더 복잡도      | 소 (스칼라 1개)                                             | 중 (mix + up dir + ground/sky uniform 3개)                   | 대 (범위 폭증)                       |
+| 상수 SSoT          | `AMBIENT_INTENSITY`/`SUN_INTENSITY` 재사용                  | + `AMBIENT_GROUND_COLOR_RGB`/sky/up 재사용                   | 전체 재구조화                        |
+| 회귀 위험          | 밤면 톤 미세 차이 (사용자 인지 가능?)                       | 0 (식 동일)                                                  | 23개 단색 body 회귀 위험 (비범위)    |
+| 범위 정합          | ✓                                                           | ✓                                                            | ✗ (#773 비목표 — 단색 유지)          |
+
+→ **(B) HemisphericLight 식 재현 채택**. 근거:
+
+- #773 의 본질은 "단색 행성과 **일관**" 이다. 측정 §A1.2-3 이 보인 hemispheric 그라데이션 (terminator 0.173, 극 0.300, 밤면하단 0.046) 차이는 스칼라 floor (A) 로는 재현 불가 → terminator 부근에서 단색 행성과 톤이 어긋나 **부분적 회귀 잔존** 위험. (B) 는 `mix(ground, sky, dot(N,up)*0.5+0.5)` 를 그대로 재현해 완전 일치.
+- 상수 SSoT 재사용: `SUN_INTENSITY(2.5)`, `SUN_DIFFUSE(1,0.95,0.8)`, `AMBIENT_INTENSITY(0.3)`, `AMBIENT_GROUND_COLOR_RGB(0.15,0.15,0.18)`, sky(흰색), up `(0,1,0)` 을 scene 상수에서 uniform 으로 전달 (rendering-only, 데이터 SSoT 무관). **셰이더가 독립 상수를 재선언하면 drift** (volt #69) → scene 상수 SSoT 를 uniform 으로만 주입. **단, sunLight intensity 등 일부는 현재 scene 내 로컬 상수 (`sunLight.intensity = 2.5`) 라, 셰이더 일관성을 위해 이들을 export 상수로 승격 후 SSoT 재사용** (developer 인수인계 — 마법 숫자 중복 금지).
+- (C) 는 #773 비목표 (단색 행성 23개는 현행 StandardMaterial 유지). 통합은 scope creep — 기각.
+
+> **단순화 여지 (developer 실측 판단 위임)**: (B) 가 이론적 완전 일치이나, 실 Chrome GUI 에서 (A) 스칼라 floor 로도 사용자가 "일치" 로 인지하면 (B)의 up/sky uniform 2개는 과잉일 수 있다. **developer 는 (B) 를 1차 구현하되, qa 실 GUI 비교에서 (A) 대비 (B) 의 시각 이득이 인지 불가하면 (A) 로 단순화 가능** (measurement-first — ADR Amendment 박제). 단 §A1.2-3 측정상 terminator 차이 (0.173 vs 0.046, 3.7배) 는 인지 가능 영역이라 (B) 우선.
+
+#### 결정 3 — 절차 변조 합성 순서 (회귀 0)
+
+현행 fragment 는 `col = baseColor 변조` → `col *= shade` (line 268). 광원 모델 교체 후에도 **합성 순서 유지**:
+
+1. baseColor 위 절차 변조 (대륙/밴드/크레이터/대륙mix) → `col`
+2. `col *= shade_new(N, uSunDirection)` — 광원 명암을 변조 결과 위에 곱셈
+
+→ 절차 디테일 (#756 고주파 엔트로피) 은 변조 단계에서 생성되고, 광원은 그 위에 곱해지므로 **디테일 무회귀** (밤면에서도 대륙/밴드 패턴은 존재하되 어두움). #756 DoD 고주파 엔트로피 가드 유지 (단, ON/OFF 측정 시 밤면이 어두워져 절대 엔트로피가 낮아질 수 있음 — qa 는 **낮면(태양 정면) 기준 측정** 으로 #756 가드 재현).
+
+#### 결정 4 — #775 지구 대륙 색 mix + 육지색 SSoT
+
+rocky 셰이더 (uSurfaceType==0) 의 현행 `col = baseColor * (1.0 + mod_)` (밝기 변조만) 를 **ocean ↔ land 색 mix** 로 교체:
+
+```glsl
+float continents = fbm(p * 2.4);
+float landMask = smoothstep(LAND_THRESHOLD_LO, LAND_THRESHOLD_HI, continents);
+col = mix(oceanColor, landColor, landMask);
+// (선택, 후속 가능) 해안선 대비 / 극관 — 1차 비목표
+```
+
+**육지색 SSoT 결정 — 코드 상수 채택** (`colorHint` 데이터 확장 기각):
+
+| 축               | (A) 코드 상수 (`procedural-planet-shader.ts` 미학 상수)         | (B) 데이터 `colorHint` 확장 (2색)                          |
+| ---------------- | --------------------------------------------------------------- | ---------------------------------------------------------- |
+| 데이터 SSoT 정합 | ✓ rocky 변조용 land 색 = rendering-only 미학 (§Visual Fidelity) | ✗ colorHint 는 단색 1개 SSoT — 2색은 rendering 관심사 누수 |
+| #756 패턴 정합   | ✓ `ROCKY_CONTRAST` 등 변조 상수와 동일 레이어                   | △ 데이터 스키마 변경 (#756 §결정 2 C 와 상충)              |
+| 확장 비용        | 상수 1줄                                                        | 데이터 파일 + 스키마                                       |
+
+→ **(A) 코드 상수**. `LAND_COLOR_RGB` (갈색/녹색 — 예: 자연색 `(0.40, 0.45, 0.28)` 류 올리브-브라운, 실측 자연색 R/G 우세) + `LAND_THRESHOLD_LO/HI` 를 `procedural-planet-shader.ts` 미학 상수 SSoT 에 추가. ocean 색 = 기존 `baseColor` (colorHint.hex, 데이터 SSoT read-only) 유지. #756 §결정 2 (C) "표면 분류 = 코드 상수" 의 자연 연장 — 데이터 변경 0.
+
+- **보라/마젠타 anti-pattern 가드 유지**: land 색은 R/G 우세 자연 톤 (B 결핍) → `surfaceColorMirror` 의 보라/마젠타 부재 어서션 자동 충족. 단위 테스트가 mix 출력 색역도 검증 (landMask 0/0.5/1 샘플).
+- mix 는 색조(hue) 분리이므로 land/ocean 휘도 차이 + 색조 차이 둘 다 발생 → "바다만" 회귀 해소.
+
+### A1.4 Concrete Prediction (구현 후 `git diff --stat` 실측 재현)
+
+| 영역                      | 파일                                                           | 예측 라인        | 근거                                                                                                                                                                                                                                                             |
+| ------------------------- | -------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **셰이더 광원식**         | `procedural-planet-shader.ts` (FRAGMENT_SHADER)                | ~15–30 변경      | `shade` 식 교체 (uSunDirection + ambient hemi mix + smoothstep soft terminator) + uniform 선언 (uSunDirection, ambientGround, ambientSky, ambientUp, sunIntensity, sunDiffuse) + `SOFT_TERMINATOR_WIDTH` 미학 상수                                               |
+| **셰이더 대륙 mix**       | `procedural-planet-shader.ts` (rocky 분기 + 상수)              | ~10–18 변경/신규 | rocky 분기 mix 교체 + `LAND_COLOR_RGB`/`LAND_THRESHOLD_*` 상수 + uniform                                                                                                                                                                                         |
+| **onBind sunDir 배선**    | `procedural-planet-shader.ts` (createProceduralPlanetMaterial) | ~18–30 변경      | sun position provider 인자 + onBindObservable 클로저 (sunDir 계산 + setVector3, **tmpVector 재사용 = alloc 0** cross-validate 이견 2) + ambient/sun 상수 uniform 전달 + **dev-only 회전 어서션** (mesh rotation non-zero 시 console.warn, cross-validate 이견 3) |
+| **JS 미러 갱신**          | `procedural-planet-shader.ts` (surfaceColorMirror)             | ~15–25 변경      | rocky mix 미러 + 광원식 미러 (shade_new) — 단위 테스트 SSoT                                                                                                                                                                                                      |
+| **scene sun 상수 export** | `solar-system-scene.ts`                                        | ~5–12 변경       | `sunLight.intensity/diffuse` 를 export 상수 승격 + provider 콜백 전달 (createProceduralPlanetMaterial 호출 2곳: createBodyMesh/createBodyMeshMid)                                                                                                                |
+| **단위 테스트**           | `procedural-planet-shader.test.ts`                             | ~40–80 신규      | 광원식 미러 (밤면<낮면 단조) / 대륙 mix (landMask 0/1 색 분리) / 보라-마젠타 부재 / 상수 SSoT drift / 회전 도입 시 normalMatrix 계약                                                                                                                             |
+| **데이터**                | `solar-system.json`                                            | **0**            | 육지색 = 코드 상수 (결정 4 A). 데이터 불변                                                                                                                                                                                                                       |
+
+**핵심 예측**:
+
+- **데이터 파일 변경 0** — 육지색 코드 상수 수렴. 실패 (데이터 수정) 시 = SSoT 누수 신호.
+- **picking / camera / orbit / tier / LOD 변경 0** — 광원/색은 fragment uniform 만, mesh 기하/metadata/위치 불변. `mesh.position` 루프 (line 1159) / sunLight 갱신 (line 1208) 은 **기존 코드 그대로 재사용** (sunDir provider 가 그 값을 읽기만).
+- **scene 배선 ≤ 12줄** — sun 상수 export + provider 콜백 2곳 전달. 초과 시 = 광원 모델이 scene 레이어를 침범 (재검토).
+
+### A1.5 DoD (측정 가능 — 실 Chrome GUI 필수, CRITICAL #3 + #756 헤드리스 false positive 교훈)
+
+1. **밤면/terminator 일관성** — 지구/화성/목성/달이 단색 행성 (금성/토성 등) 과 **동일하게 밤면 어두움 + terminator** 표시 (실 Chrome GUI 스크린샷). 낮/밤 휘도 대비비 ≥ 5x (단색 행성 14.74x 의 보수적 하한 — 변조 디테일이 밤면 휘도를 살짝 올릴 수 있어 완화).
+2. **태양 추종 명암 + soft terminator** — 시간 진행 (공전) 또는 카메라 회전 시 명암 경계 (terminator) 가 **태양 위치를 따라 이동** (고정 방향 아님). focus=earth 에서 시간 가속 후 terminator 이동 관찰. 광원식은 `shade = ambient_hemi(N) + sun * smoothstep(0.0, SOFT_TERMINATOR_WIDTH, dot(N, uSunDirection))` (cross-validate 이견 수용 1 — segments 12/32 의 terminator 톱니 aliasing 완화). terminator 경계가 각지지 않고 부드럽게 전이.
+3. **단색 행성 톤 일치** — terminator 부근에서 표면 셰이더 행성과 인접 단색 행성의 밤면/낮면 톤이 시각적으로 이질감 없음 (결정 2 B 검증 — qa 가 (A) 스칼라 대비 (B) 이득 인지 여부 측정 후 단순화 가능 판정).
+4. **지구 대륙 시각 구분** — 지구에 갈색/녹색 대륙 + 파란 바다 명확 구분 (실 Chrome GUI). land/ocean 색조(hue) 차이 측정 가능.
+5. **절차 표면 무회귀** — #756 고주파 엔트로피 가드 PASS (**낮면 기준 측정** — 밤면은 광원으로 어두워져 절대 엔트로피 하락 정상). 지구/화성/목성/달 ON > OFF 유지.
+6. **보라/마젠타 0** — 출력 색역 anti-pattern 0 (단위 테스트 + 실 GUI). land 색 R/G 우세.
+7. **fps 회귀 0** — tier-a/b/c (CI swiftshader 포함) fps-baseline-guard PASS. 광원식은 fragment 추가 dot/mix 수 개 (per-pixel 경량) — tier-c 는 #756 §결정 3 대로 `forceOverride:'low'` 자동 단색 우회 (표면 셰이더 미진입).
+8. **회전 계약 박제** — 셰이더 주석 + 단위 테스트에 "world normal == local normal 은 회전 0 전제, self-rotation 도입 시 normalMatrix 필요" 계약 명시 (drift 가드).
+
+### A1.6 §Visual Fidelity 의무 체크리스트 (회귀 수정이라 왜곡 도입 아님 — 일치 확인)
+
+- [x] **데이터 SSoT 보존** — 광원 상수 (sun intensity/diffuse, ambient ground/sky/up) + 육지색 (`LAND_COLOR_RGB`) 은 **rendering-only 상수** (scene/셰이더 레이어). `solar-system.json` 의 radius/colorHint.hex/궤도 직접 수정 0. ocean 색 = colorHint.hex read-only.
+- [x] **rendering 시점 분리** — 광원/색은 fragment 단계, physics 엔진 (Rust+wasm) 무의존. P11-A 좌표 계약 위반 0.
+- [x] **사용자 D-T2 가이드** — 광원 명암/대륙 색은 순수 시각 표현. focus/Info 패널은 실측값 (반경 km / 색상 출처) 유지. 절차 변조/명암은 표기 대상 아님 (#756 동일).
+- [x] **점유율 / 사실 비율 baseline** — 광원/색은 mesh 크기/위치 불변 (diameter 식 무변경) → px diameter / 점유율 / 분리 마진 영향 0. r1-guard baseline 은 표면 픽셀 명암 변경 (밤면 추가) 으로 재생성 — qa 가 실 Chrome GUI 로 박제.
+
+### A1.7 교차검증 반영 사항
+
+cross-validate (Antigravity `agy`) 1회 수행 (2026-06-30, outcome=applied, exit 0, plan_bypass=false, rollback_failed=false). 로그: `.claude/logs/cross-validate-architecture-20260630-233707.log`.
+
+**호출 전 Claude 편향 셀프 체크** (4종): 낙관적 일정 (onBind 배선 ~12줄 과소평가 의심) / 결합 간과 ("회전 0 → world==local normal" 단정 + satellite/uniform scaling 의존) / 폐기 프레이밍 (기존 간이 shade 를 "회귀" 로 폐기 — 사용자 실측 회귀라 통과) / 순수주의 (결정 2 B HemisphericLight 완전 재현 선호가 과잉설계인가). **미통과 의심 3축 (결합 간과 / 순수주의 / 낙관적 일정) 을 cross-validate 프롬프트에 명시 질문으로 삽입** → 이하 합의/이견에서 검증.
+
+#### 합의 (현재 PR 즉시 반영 / 셀프 체크 통과 확인)
+
+1. **onBindObservable + provider 콜백 = 결합도 낮춤** [결정 1] — agy 가 "Scene 레이어가 셰이더 내부 uniform 을 직접 추적하지 않으면서 렌더 직전 데이터 주입 = 결합도 낮추는 훌륭한 패턴" 으로 호평. 옵션 (d) Map 추적 대비 우월성 교차 확인.
+2. **HemisphericLight 완전 재현 = 시각 이질감 차단** [결정 2 B, 순수주의 축 통과] — agy 가 "단순 스칼라 floor 대신 hemispheric 공식 재현 = 낮/밤 경계 및 극지점 점진 톤 그라데이션 차이로 발생할 이질감을 완벽 차단하는 타당한 결정" 으로 (B) 를 명시 지지. **순수주의 의심 해소** — terminator/극 톤 차이 (측정 §A1.2-3, 0.173 vs 0.046) 가 인지 가능 영역이라 (B) 가 과잉설계 아님이 외부 모델로 교차 확인됨. 단 §A1.8 재검토 조건 1 (qa 실 GUI 단순화 판정) 은 유지.
+3. **데이터 SSoT 코드 상수 격리** [결정 4] — 표면/육지색 코드 상수 격리를 "물리 시뮬레이션 순수성 보존" 으로 합의.
+4. **tier-c forceOverride 자동 우회 + `?surface=off` 회귀 baseline** — fps 보호 + 복구 baseline 인터페이스 호평.
+5. **회전 0 전제 + normalMatrix 후속 계약** [결합 간과 축 부분 통과] — agy 가 "world normal == local normal 은 회전 0 절대 의존, 자전/axialTilt 도입 시 normalMatrix 필수" 를 Claude 와 동일 인지. 단 **방어적 어서션 추가 권고** (이견 3 으로 격상).
+
+#### 이견 수용 (원안 수정)
+
+1. **Soft Terminator (smoothstep 경계 완화) 1차 선반영** — Claude 원안은 terminator aliasing 을 §재검토 조건 3 (후속) 으로 분류. agy 가 "segments mid(12)/high(32) 의 곡면 법선 변화가 조밀하지 못해 `clamp(dot(N,L),0,1)` 단순 적용 시 경계가 톱니처럼 각짐 → `smoothstep(0.0, 0.1, dot(N,L))` Soft Terminator 를 설계에 포함" 권고. **수용 (격상)** — 추가 비용이 `clamp → smoothstep` 1줄이라 후속 분리보다 선반영이 효율적. **결정 2 의 광원식을 `shade = ambient_hemi + sun * smoothstep(0.0, SOFT_TERMINATOR_WIDTH, dot(N,L))` 로 확정** (DoD 2 에 흡수). `SOFT_TERMINATOR_WIDTH` 미학 상수 SSoT 추가.
+2. **onBind Vector3 GC 회피 (tmpVector 재사용)** — Claude 원안 미명시. agy 가 "onBind 가 매 프레임×mesh 호출이라 sunDir 계산에서 매번 `new Vector3` alloc 시 GC 병목 → 팩토리 스코프 사전 할당 tmpVector 갱신·정규화 전달" 권고. **수용** — developer 인수인계 + Concrete Prediction (onBind 배선) 에 "tmpVector 재사용 (alloc 0)" 계약 명시.
+3. **방어적 회전 어서션 (dev only)** — Claude 원안은 회전 0 전제를 주석 + 단위 테스트 계약으로만 박제. agy 가 "런타임에 mesh rotation/quaternion 적용 여부 체크 후 경고 throw 하는 방어적 어서션 추가" 권고. **수용 (dev-only)** — onBind 에서 `mesh.rotationQuaternion` 또는 `rotation` non-zero 감지 시 dev 빌드 `console.warn` (floating-origin assert 패턴 — `process.env.NODE_ENV` DCE). 단위 테스트 계약과 직교하는 런타임 가드.
+
+#### Claude 재분석으로 기각한 외부 모델 제안
+
+1. **noise 입력 좌표 modulo 클램핑 (정밀도 손실 방지)** (agy 보안 ⑤) — **기각**. 본 셰이더의 noise 입력은 `p = normalize(vLocalPos)` 단위 벡터 (|p| ≤ 1) 기반이다 (FRAGMENT_SHADER line 221). fbm/cell noise 입력 최대 스케일은 `p * craterDensity(14)` = 최대 |14| 로 부동소수점 정밀도 손실 영역 (≥ 1e5 류) 과 무관. starfield/ring-shader 도 동일 단위 벡터 패턴으로 무문제 실증. 좌표 bounding 은 이미 normalize 로 구조 보장 — 추가 modulo 불요. (agy 가 "입력 좌표가 커질수록" 조건부 제안 — 본 셰이더는 그 조건 미해당.)
+2. **씬 dispose/재생성 (URL 플래그 런타임 변경 정합성)** (agy 구조 ①) — **비대상**. `?surface=off` 는 #756 §결정 4 (A) 대로 **생성 시점 분기 (URL-only, 런타임 토글 비목표)**. URL 변경 → 런타임 머티리얼 교체 시나리오 자체가 존재하지 않으므로 dispose/재생성 정합성 검토 불요. 광원 모델은 surface ON 경로에만 적용 — 무관.
+3. **specular(0.05) 재현** (추가 검토 질문) — **기각 (무시)**. 단색 행성 specular (0.05,0.05,0.05) 는 미미한 하이라이트로 시각 인지 거의 0. #773 핵심은 diffuse 명암 (낮/밤/terminator) 일치이며, specular 재현은 과잉 (셰이더 복잡도 ↑, 시각 이득 ≈ 0). DoD 는 "diffuse 명암 일치" 로 충분.
+
+#### 고유 발견 (범위 판정 — 후속 분리 후보)
+
+1. **대기/구름 레이어 블렌딩 순서 + depth 우선순위** (agy 누락 ⑥-2) — **후속 분리 후보 (현재 비대상)**. agy 가 "지구 표면 위 투명 대기/구름 셰이더 mesh 겹침 시 알파 블렌딩/depth 우선순위 미정리하면 렌더 순서 오류" 지적. **현재 프로젝트에 대기/구름 mesh 가 미구현** 이므로 본 Amendment 범위 밖 (비목표와 직교 — #775 본문도 "구름 레이어 = 선택/후속"). 대기/구름 도입 시점에 별도 이슈로 분리 (그때 표면 셰이더의 log-depth 기록 § 핵심 위험 1 과의 정합 검토). 현재는 ADR §재검토 조건 5 로 맥락 박제 (즉시 이슈 생성은 mesh 부재로 맥락 빈약 → 도입 시 분리). 메인이 즉시 분리 vs 기록 최종 판단.
+
+### A1.8 결과 · 재검토 조건
+
+**기대 결과**:
+
+- 지구/화성/목성/달 밤면 + terminator (단색 행성 일관), 태양 추종 명암.
+- 지구 갈색/녹색 대륙 + 파란 바다 구분.
+- 단색 23 body + 절차 디테일 무회귀, fps 회귀 0.
+
+**재검토 조건**:
+
+1. **(A) 스칼라 floor 로 충분** (qa 실 GUI 에서 (B) hemispheric 재현 이득 인지 불가) — (A) 로 단순화 (Amendment 2, up/sky uniform 제거).
+2. **self-rotation / axialTilt 도입** — `vNormal` world matrix 변환 (normalMatrix uniform) 필요 → 옵션 (e) 전환 (셰이더 주석 계약 발동).
+3. **terminator aliasing 잔존** — soft terminator (smoothstep, cross-validate 이견 1) 로 1차 완화했으나 segments=12 (mid) 에서 여전히 각지면 `SOFT_TERMINATOR_WIDTH` 확대 또는 per-pixel normal 보간 검토 (Amendment 2).
+4. **다른 rocky body 추가** — 화성도 미래에 land mix 요구 시 rocky 분기 land 색을 body별 상수로 확장 (현재 earth 만 Rocky).
+5. **대기/구름 레이어 도입** (cross-validate 고유 발견 1) — 지구 표면 위 투명 대기/구름 셰이더 mesh 도입 시 알파 블렌딩 + depth 우선순위 (표면 셰이더 log-depth § 핵심 위험 1 과의 정합) 검토 필요. **현재 대기/구름 mesh 미구현이라 본 Amendment 범위 밖** — 도입 시점에 별도 이슈로 분리 (맥락 박제용 기록).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-simulator",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": true,
   "description": "웹 기반 천체물리 시뮬레이터 — Babylon.js WebGPU 기반 멀티스케일 우주 탐험",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astro-simulator/core",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": true,
   "description": "Pure TypeScript simulation core for astro-simulator — Babylon.js only, framework-agnostic",
   "type": "module",

--- a/packages/core/src/scene/procedural-planet-shader.test.ts
+++ b/packages/core/src/scene/procedural-planet-shader.test.ts
@@ -24,8 +24,14 @@ import {
   GAS_TURBULENCE,
   CRATER_DEPTH,
   CRATER_DENSITY,
+  SOFT_TERMINATOR_WIDTH,
+  LAND_COLOR_RGB,
+  LAND_THRESHOLD_LO,
+  LAND_THRESHOLD_HI,
   fbmMirror,
   surfaceColorMirror,
+  lightingShadeMirror,
+  luminance709,
   PLANET_VERTEX_SHADER,
   PLANET_FRAGMENT_SHADER,
 } from './procedural-planet-shader.js';
@@ -240,5 +246,200 @@ describe('#756 procedural-planet — baseColor 데이터 SSoT (ADR §결정 5)',
     const out = surfaceColorMirror(base, SurfaceType.GasBands, [1, 0, 0]);
     // latitude(y)=0 이면 sin(turb*count*π) ≈ 작음 → base 에 근접 (shade 미적용 미러).
     expect(Math.abs(out[0] - base[0])).toBeLessThan(0.35);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Amendment 1 (#773/#775) — 광원 일관성 회귀 + 지구 대륙 mix.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('#773 광원식 미러 — 밤면 < 낮면 단조 + soft terminator (ADR §A1.5 DoD 1·2)', () => {
+  // 단색 행성(StandardMaterial + PointLight + HemisphericLight)과 동일 명암 재현 검증.
+  // 태양 방향 = +X 가정 (단색 행성 forensic 측정 §A1.2 와 동일 좌표계).
+  const SUN_DIR: [number, number, number] = [1, 0, 0];
+
+  it('낮면(N=+X) 휘도 > 밤면(N=−X) 휘도 (밤면 존재 — "밤면 없음" 회귀 해소)', () => {
+    const day = luminance709(lightingShadeMirror([1, 0, 0], SUN_DIR));
+    const night = luminance709(lightingShadeMirror([-1, 0, 0], SUN_DIR));
+    expect(day).toBeGreaterThan(night);
+    // 단색 행성 대비비 14.74x — 변조가 밤면을 살짝 올릴 수 있어 보수적 하한 5x (ADR §A1.5 DoD 1).
+    expect(day / night).toBeGreaterThan(5);
+  });
+
+  it('낮→밤 단조 감소 (태양 방향에서 멀어질수록 어두움)', () => {
+    // sunDir(+X) 과의 각도를 0 → 180° 로 증가시키며 휘도 단조 감소 확인.
+    const samples: number[] = [];
+    for (let i = 0; i <= 10; i++) {
+      const theta = (i / 10) * Math.PI; // 0 (낮면) → π (밤면)
+      const N: [number, number, number] = [Math.cos(theta), 0, Math.sin(theta)];
+      samples.push(luminance709(lightingShadeMirror(N, SUN_DIR)));
+    }
+    // soft terminator smoothstep 라 strict 단조는 아닐 수 있으나 (양 끝 plateau), 전체 추세 감소.
+    for (let i = 1; i < samples.length; i++) {
+      const cur = samples[i] ?? Number.NaN;
+      const prev = samples[i - 1] ?? Number.NaN;
+      expect(cur).toBeLessThanOrEqual(prev + 1e-9);
+    }
+    const first = samples[0] ?? Number.NaN;
+    const last = samples[samples.length - 1] ?? Number.NaN;
+    expect(first).toBeGreaterThan(last);
+  });
+
+  it('forensic 측정 §A1.2 재현 — 낮면 ≈ 2.55 / terminator ≈ 0.17 / 밤면하단 ≈ 0.046 휘도', () => {
+    // 단색 행성 라이팅 계수 (diffuseColor 곱 전) — ADR 측정값 (Rec.709 휘도) 와 정합.
+    const dayCenter = luminance709(lightingShadeMirror([1, 0, 0], SUN_DIR)); // N=+X
+    const terminator = luminance709(lightingShadeMirror([0, 0, 1], SUN_DIR)); // N=+Z
+    const pole = luminance709(lightingShadeMirror([0, 1, 0], SUN_DIR)); // N=+Y (밤면 위쪽)
+    const nightBottom = luminance709(lightingShadeMirror([0, -1, 0], SUN_DIR)); // N=−Y
+    expect(dayCenter).toBeGreaterThan(2.3); // 측정 2.547
+    expect(dayCenter).toBeLessThan(2.8);
+    expect(terminator).toBeGreaterThan(0.1); // 측정 0.173 (smoothstep 라 약간 변동)
+    expect(terminator).toBeLessThan(0.35);
+    expect(pole).toBeGreaterThan(0.25); // 측정 0.300 (hemispheric 극 그라데이션)
+    expect(pole).toBeLessThan(0.35);
+    expect(nightBottom).toBeGreaterThan(0.03); // 측정 0.046 (ground 단독)
+    expect(nightBottom).toBeLessThan(0.07);
+  });
+
+  it('hemispheric 그라데이션 — 극(+Y) > 밤면하단(−Y) (스칼라 floor 로 재현 불가, ADR §A1.2-3)', () => {
+    // 밤면이라도 위쪽(+Y) 향한 면이 아래쪽(−Y) 보다 밝다 (HemisphericLight mix). 결정 2 (B) 핵심.
+    const SUN_DIR_FAR: [number, number, number] = [0, 0, 1]; // 둘 다 밤면이 되도록 sunDir=+Z
+    const up = luminance709(lightingShadeMirror([0, 1, 0], SUN_DIR_FAR));
+    const down = luminance709(lightingShadeMirror([0, -1, 0], SUN_DIR_FAR));
+    expect(up).toBeGreaterThan(down);
+  });
+
+  it('soft terminator — clamp 가 아닌 smoothstep (경계 톱니 완화, cross-validate 이견 1)', () => {
+    // terminator 근처(ndl ≈ 0) 에서 부드럽게 전이 — ndl 미세 변화에 휘도가 연속적.
+    const near0a = luminance709(lightingShadeMirror([0.01, 0, 0.9999], [1, 0, 0]));
+    const near0b = luminance709(lightingShadeMirror([-0.01, 0, 0.9999], [1, 0, 0]));
+    // soft 폭 내에서 둘 다 0/full 이 아닌 중간 값 (clamp 였으면 한쪽이 0).
+    expect(near0a).toBeGreaterThan(near0b); // ndl 양수가 더 밝음 (단조)
+    // 둘 차이가 크지 않음 (smoothstep 연속) — clamp 였으면 step 불연속.
+    expect(Math.abs(near0a - near0b)).toBeLessThan(1.0);
+  });
+
+  it('GLSL fragment 광원식 uniform 선언 존재 (미러와 동기)', () => {
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 uSunDirection');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float sunIntensity');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 sunDiffuse');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float ambientIntensity');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 ambientGround');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 ambientSky');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 ambientUp');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float softTerminatorWidth');
+  });
+
+  it('GLSL fragment 가 smoothstep soft terminator + hemispheric mix 사용 (식 정합)', () => {
+    // smoothstep(0, W, ndl) — ndl ≤ 0 (밤면/terminator) 은 0, 0~W soft 전이 (ADR §A1.5 DoD 2).
+    expect(PLANET_FRAGMENT_SHADER).toContain('smoothstep(0.0, softTerminatorWidth, ndl)');
+    expect(PLANET_FRAGMENT_SHADER).toContain('mix(ambientGround, ambientSky');
+    // 고정 방향 회귀 벡터 (0.5, 0.7, 0.5) 가 더 이상 없어야 한다 (#773 회귀 원인 제거).
+    expect(PLANET_FRAGMENT_SHADER).not.toContain('vec3(0.5, 0.7, 0.5)');
+  });
+});
+
+describe('#773 광원식 미러 — SUN/AMBIENT 상수 일관성 (단색 행성 SSoT 일치)', () => {
+  it('기본 광원값이 단색 행성 PointLight/HemisphericLight 와 동일 (DEFAULT 미전달 경로)', () => {
+    // lightingShadeMirror 기본값 (DEFAULT_PLANET_LIGHTING) 이 scene 의 sunLight/ambient 와 같은 식 산출.
+    // 밤면하단(N=−Y) = ambientIntensity(0.3) × groundColor(0.15,0.15,0.18) → ground 단독.
+    const [r, g, b] = lightingShadeMirror([0, -1, 0], [1, 0, 0]);
+    expect(r).toBeCloseTo(0.3 * 0.15, 5); // 0.045
+    expect(g).toBeCloseTo(0.3 * 0.15, 5);
+    expect(b).toBeCloseTo(0.3 * 0.18, 5); // 0.054
+  });
+});
+
+describe('#775 지구 대륙 mix — ocean ↔ land 색 분리 (ADR §A1.5 DoD 4)', () => {
+  // earth base = 청록 (ocean), land = 올리브-브라운. landMask 로 색조(hue) mix → "바다만" 회귀 해소.
+  const EARTH_OCEAN: [number, number, number] = [0.23, 0.45, 0.6];
+
+  it('rocky 대륙 mix — ocean(landMask=0) + land(landMask=1) 색 둘 다 존재', () => {
+    // continents 가 LO 미만이 되는 표면점을 찾아 ocean 색 유지 확인 — 다수 샘플 중 ocean/land 둘 다 존재.
+    let foundOcean = false;
+    let foundLand = false;
+    for (let i = 0; i < 400; i++) {
+      const t = i * 0.0157;
+      const x = Math.sin(t * 1.3) * Math.cos(t * 0.7);
+      const y = Math.cos(t * 1.1);
+      const z = Math.sin(t * 0.9) * Math.sin(t * 0.6);
+      const len = Math.hypot(x, y, z) || 1;
+      const p: [number, number, number] = [x / len, y / len, z / len];
+      const continents = fbmMirror(p[0] * 2.4, p[1] * 2.4, p[2] * 2.4);
+      const [r, g, b] = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, p);
+      if (continents <= LAND_THRESHOLD_LO) {
+        // ocean 색 (baseColor) 에 근접.
+        expect(r).toBeCloseTo(EARTH_OCEAN[0], 4);
+        expect(g).toBeCloseTo(EARTH_OCEAN[1], 4);
+        expect(b).toBeCloseTo(EARTH_OCEAN[2], 4);
+        foundOcean = true;
+      }
+      if (continents >= LAND_THRESHOLD_HI) {
+        // land 색 (LAND_COLOR_RGB) 에 근접.
+        expect(r).toBeCloseTo(LAND_COLOR_RGB.r, 4);
+        expect(g).toBeCloseTo(LAND_COLOR_RGB.g, 4);
+        expect(b).toBeCloseTo(LAND_COLOR_RGB.b, 4);
+        foundLand = true;
+      }
+    }
+    // 지구 표면에 대륙과 바다가 둘 다 존재해야 (mix 가 의미 있음).
+    expect(foundOcean).toBe(true);
+    expect(foundLand).toBe(true);
+  });
+
+  it('ocean 과 land 가 색조(hue) 다름 — "바다만 밝기 변조" 회귀 해소', () => {
+    // ocean 청록 (B 우세) vs land 올리브-브라운 (R/G 우세) — B 채널 우세 관계 역전.
+    expect(EARTH_OCEAN[2]).toBeGreaterThan(EARTH_OCEAN[0]); // ocean: B > R
+    expect(LAND_COLOR_RGB.r).toBeGreaterThan(LAND_COLOR_RGB.b); // land: R > B
+    expect(LAND_COLOR_RGB.g).toBeGreaterThan(LAND_COLOR_RGB.b); // land: G > B (녹/갈)
+  });
+
+  it('land 색 보라/마젠타 부재 (R/G 우세, G ≥ min(R,B))', () => {
+    expect(LAND_COLOR_RGB.g).toBeGreaterThanOrEqual(Math.min(LAND_COLOR_RGB.r, LAND_COLOR_RGB.b));
+  });
+
+  it('GLSL rocky 분기가 mix(baseColor, landColor, landMask) 사용 (밝기 변조 → 색 mix)', () => {
+    expect(PLANET_FRAGMENT_SHADER).toContain('mix(baseColor, landColor, landMask)');
+    expect(PLANET_FRAGMENT_SHADER).toContain('smoothstep(landThresholdLo, landThresholdHi');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 landColor');
+  });
+});
+
+describe('Amendment 1 — 신규 미학 상수 SSoT (#69 drift 가드)', () => {
+  it('soft terminator / 육지색 / 임계 박제값 (drift 시 시각 회귀)', () => {
+    expect(SOFT_TERMINATOR_WIDTH).toBe(0.12);
+    expect(LAND_COLOR_RGB).toEqual({ r: 0.34, g: 0.4, b: 0.24 });
+    expect(LAND_THRESHOLD_LO).toBe(0.48);
+    expect(LAND_THRESHOLD_HI).toBe(0.62);
+  });
+
+  it('LAND_THRESHOLD_LO < HI (smoothstep 유효 구간)', () => {
+    expect(LAND_THRESHOLD_LO).toBeLessThan(LAND_THRESHOLD_HI);
+  });
+
+  it('soft terminator 폭이 합리 범위 (0 < W < 0.5 — 톱니 완화 ↔ 대비 보존)', () => {
+    expect(SOFT_TERMINATOR_WIDTH).toBeGreaterThan(0);
+    expect(SOFT_TERMINATOR_WIDTH).toBeLessThan(0.5);
+  });
+});
+
+describe('Amendment 1 — 회전 0 전제 계약 박제 (drift 가드, ADR §A1.5 DoD 8)', () => {
+  // world normal == local normal 은 "body mesh 회전 0" 에 의존. self-rotation 도입 시 normalMatrix 필요.
+  // 셰이더는 vNormal(local) 을 그대로 dot 에 사용 — normalMatrix / world matrix uniform 부재 확인.
+
+  it('vertex shader 가 vNormal 을 local normal 그대로 전달 (normalMatrix 변환 부재)', () => {
+    expect(PLANET_VERTEX_SHADER).toContain('vNormal = normalize(normal)');
+    // 회전 도입 전까지 normalMatrix uniform 이 없어야 한다 (있으면 옵션 e 전환된 것 — 계약 변경 신호).
+    expect(PLANET_VERTEX_SHADER).not.toContain('normalMatrix');
+  });
+
+  it('fragment shader 가 vNormal(local) 을 광원 dot 에 직접 사용 (회전 0 전제)', () => {
+    expect(PLANET_FRAGMENT_SHADER).toContain('vec3 N = normalize(vNormal)');
+    expect(PLANET_FRAGMENT_SHADER).toContain('dot(N, uSunDirection)');
+  });
+
+  it('셰이더 주석에 회전 0 전제 계약 박제 (self-rotation 도입 시 normalMatrix)', () => {
+    // 후속 개발자가 self-rotation 도입 시 광원 모델 깨짐을 인지하도록 주석 계약 박제 (DoD 8).
+    expect(PLANET_FRAGMENT_SHADER + PLANET_VERTEX_SHADER).toMatch(/world normal == local normal/);
   });
 });

--- a/packages/core/src/scene/procedural-planet-shader.ts
+++ b/packages/core/src/scene/procedural-planet-shader.ts
@@ -16,6 +16,27 @@
  *   - §결정 4 — `?surface=off` = StandardMaterial 현행 복귀 (생성 시점 분기, scene 옵션).
  *   - §결정 5 — `colorHint.hex` → `uniform vec3 baseColor`, 절차 변조는 그 위에 합성.
  *
+ * **Amendment 1 (#773/#775) — 광원 일관성 회귀 + 지구 대륙 mix** (ADR §Amendment 1):
+ *   - §A1.3 결정 1 — 고정 방향 명암 (`shade = 0.85 + 0.15 * dot(N, fixed)`) 을 **실제 태양 방향**
+ *     기반 명암으로 교체. `uniform vec3 uSunDirection` 을 `createProceduralPlanetMaterial` 의
+ *     `onBindObservable` 클로저에서 각 draw 직전 `normalize(sunPos − meshPos)` 로 갱신.
+ *     body mesh 회전 0 (self-rotation 미구현) + uniform scaling → world normal == local normal →
+ *     `vNormal` (local) 을 그대로 dot 에 사용 (normalMatrix 불필요).
+ *   - §A1.3 결정 2 — **HemisphericLight 식 완전 재현** (`mix(ground, sky, dot(N,up)*0.5+0.5)`) +
+ *     PointLight diffuse (`sunIntensity * sunDiffuse * smoothstep(0, W, dot(N, sunDir))`). 단색 행성
+ *     (StandardMaterial + PointLight 2.5 + HemisphericLight ambient) 과 시각 일치 (밤면/terminator/극).
+ *   - §A1.3 결정 4 (#775) — rocky 분기를 `mix(oceanColor, landColor, landMask)` 로 교체 (대륙 색 구분).
+ *
+ * ⚠️ **회전 0 전제 (drift 가드)**: 본 광원 모델은 "body mesh 회전 0 + uniform scaling" 에 의존한다
+ *   (world normal == local normal). self-rotation / axialTilt 도입 시 `vNormal` 을 world matrix 로
+ *   변환해야 한다 (ADR §A1.3 결정 1 옵션 e 전환). onBind 의 dev-only 회전 어서션이 조기 감지.
+ *
+ * **광원 물리 상수 SSoT 주입**: sun intensity/diffuse + ambient intensity/ground/sky/up 은
+ *   `solar-system-scene.ts` 가 SSoT 로 소유한다 (PointLight/HemisphericLight 와 동일 값 — 마법 숫자
+ *   중복 금지, volt #69). 셰이더는 scene 를 import 하지 않고 (순환 회피) `createProceduralPlanetMaterial`
+ *   인자로 주입받아 uniform 으로 설정한다 (단방향 의존). soft terminator / 육지색 등 rendering-only
+ *   미학 상수는 본 셰이더 모듈이 SSoT.
+ *
  * **표면 타입 4종 (§결정 5)**:
  *   - rocky (지구) — base 위 대륙/해양 대비 (저주파 noise) + 미세 명암.
  *   - desert (화성) — base 위 dust/협곡 결 (fbm) + 산화철 톤 변조.
@@ -31,7 +52,7 @@
  *   `gl_FragDepth` 를 Babylon logDepth 공식으로 기록해 정합.
  */
 
-import { Color3, Effect, ShaderMaterial, type Scene } from '@babylonjs/core';
+import { Color3, Effect, ShaderMaterial, Vector3, type Mesh, type Scene } from '@babylonjs/core';
 import type { LoadedCelestialBody } from '../ephemeris/solar-system-loader.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -110,6 +131,36 @@ export const CRATER_DEPTH = 0.4;
 /** cratered 크레이터 격자 밀도 (셀/방향). 클수록 크레이터가 촘촘. */
 export const CRATER_DENSITY = 14;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Amendment 1 (#773/#775) — 광원 모델 + 대륙 mix rendering-only 미학 상수 SSoT.
+// (광원 물리 상수 sun/ambient 는 scene 가 SSoT — 주입받음. 아래는 셰이더 고유 미학 상수.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * soft terminator 폭 (낮/밤 경계 부드러움) — `smoothstep(0.0, W, dot(N, sunDir))` (ADR §A1.3 이견 수용 1).
+ *
+ * 단색 행성의 `max(dot(N,L), 0)` 를 soft 근사 — ndl ≤ 0 (밤면/terminator) 은 0 (밤면 어두움 유지),
+ * 0 ~ W 구간만 부드럽게 전이. segments 12 (mid) / 32 (high) 의 곡면 법선 변화가 조밀하지 못해
+ * `clamp(dot,0,1)` 단순 적용 시 경계가 톱니처럼 각진다 → smoothstep 으로 완화 (cross-validate agy
+ * 이견 수용). 너무 크면 낮/밤 대비가 흐려지고, 0 이면 톱니 — 0.12 로 부드러움 ↔ 대비 균형 (measurement-first).
+ */
+export const SOFT_TERMINATOR_WIDTH = 0.12;
+
+/**
+ * #775 — rocky 육지색 RGB (rendering-only 미학 상수, 데이터 SSoT 무관 — ADR §A1.3 결정 4 A).
+ *
+ * ocean 색 = base color (colorHint.hex, 데이터 SSoT read-only). land 색 = 본 상수. 올리브-브라운
+ * 자연 톤 (R/G 우세, B 결핍 — 보라/마젠타 anti-pattern 구조적 회피, #756 가드 정합). landMask 로
+ * ocean↔land 색조(hue) mix → "바다만" 회귀 (밝기 변조만) 해소.
+ */
+export const LAND_COLOR_RGB = { r: 0.34, g: 0.4, b: 0.24 } as const;
+
+/** #775 — 대륙 mask smoothstep 하한 (continents fbm < LO → 100% ocean). */
+export const LAND_THRESHOLD_LO = 0.48;
+
+/** #775 — 대륙 mask smoothstep 상한 (continents fbm > HI → 100% land). LO~HI 사이 해안선 전이. */
+export const LAND_THRESHOLD_HI = 0.62;
+
 /** shader 이름 prefix — ShadersStore key 충돌 방지 (ring/starfield 패턴 답습). */
 const SHADER_NAME = 'proceduralPlanet';
 
@@ -181,6 +232,29 @@ uniform float craterDepth;
 uniform float craterDensity;
 uniform float logDepthConstant;
 
+// Amendment 1 (#773) — 광원 모델 uniform (HemisphericLight + PointLight 재현, scene SSoT 주입).
+//   uSunDirection: 실제 태양 방향 (normalize(sunPos − meshPos)) — onBind 에서 매 draw 갱신.
+//                  body mesh 회전 0 + uniform scaling → world normal == local normal 이라 local 기준.
+//   sunIntensity / sunDiffuse: PointLight (intensity 2.5 / diffuse (1,0.95,0.8)) 재현.
+//   ambientIntensity / ambientGround / ambientSky / ambientUp: HemisphericLight 재현
+//                  (mix(ground, sky, dot(N,up)*0.5+0.5) — terminator/극 그라데이션 일치).
+//   softTerminatorWidth: 낮/밤 경계 smoothstep 폭 (각짐 완화, cross-validate 이견 1).
+uniform vec3 uSunDirection;
+uniform float sunIntensity;
+uniform vec3 sunDiffuse;
+uniform float ambientIntensity;
+uniform vec3 ambientGround;
+uniform vec3 ambientSky;
+uniform vec3 ambientUp;
+uniform float softTerminatorWidth;
+
+// Amendment 1 (#775) — 지구 대륙 mix uniform (rendering-only 미학 상수, scene 무관).
+//   landColor: 육지색 (올리브-브라운, R/G 우세 — 보라/마젠타 회피).
+//   landThresholdLo/Hi: continents fbm → landMask smoothstep 임계 (해안선 전이).
+uniform vec3 landColor;
+uniform float landThresholdLo;
+uniform float landThresholdHi;
+
 // 3D hash — sin-free fract-mix (starfield.ts hash33 답습 — swiftshader/tier-c fps 보호).
 vec3 hash33(vec3 p) {
   p = fract(p * vec3(0.1031, 0.1030, 0.0973));
@@ -219,17 +293,34 @@ float fbm(vec3 p) {
 
 void main(void) {
   vec3 p = normalize(vLocalPos);
-  // 간이 명암 — 표면 법선 기준 미세 음영 (단색 대비 입체감, 과도하지 않게).
-  float shade = 0.85 + 0.15 * clamp(dot(vNormal, normalize(vec3(0.5, 0.7, 0.5))), 0.0, 1.0);
+  // ⚠️ 회전 0 전제 (Amendment 1 drift 가드): body mesh 회전 0 + uniform scaling → world normal ==
+  //    local normal 이라 vNormal(local) 을 광원 dot 에 직접 사용. self-rotation / axialTilt 도입 시
+  //    vNormal 을 world matrix 로 변환해야 한다 (ADR §A1.3 결정 1 옵션 e). onBind dev 어서션이 감지.
+  vec3 N = normalize(vNormal);
+
+  // Amendment 1 (#773) — 실제 태양 방향 기반 명암 (단색 행성 StandardMaterial 과 시각 일치).
+  //   회전 0 + uniform scaling → world normal == local normal 이라 vNormal(local) 을 그대로 사용.
+  // ① HemisphericLight 재현 — mix(ground, sky, dot(N,up)*0.5+0.5). 밤면 floor + 극 그라데이션.
+  float hemiFactor = dot(N, ambientUp) * 0.5 + 0.5;
+  vec3 ambientShade = ambientIntensity * mix(ambientGround, ambientSky, hemiFactor);
+  // ② PointLight diffuse 재현 — sunIntensity * sunDiffuse * smoothstep(0, W, dot(N, sunDir)).
+  //    단색 행성의 max(dot,0) 를 soft 근사 — ndl ≤ 0 (밤면/terminator) 은 0 (밤면 어두움 유지),
+  //    0 ~ W 구간만 부드럽게 전이해 segments 12/32 의 경계 톱니(aliasing) 완화 (cross-validate 이견 1).
+  float ndl = dot(N, uSunDirection);
+  float sunFactor = smoothstep(0.0, softTerminatorWidth, ndl);
+  vec3 sunShade = sunIntensity * sunDiffuse * sunFactor;
+  // 합성 명암 (StandardMaterial PointLight+HemisphericLight diffuse 항 재현 — diffuseColor 곱 전).
+  vec3 shade = ambientShade + sunShade;
   vec3 col = baseColor;
 
   // #756 §결정 2 — 표면 타입별 절차 변조 (if-else 분기만). 같은 draw = 같은 타입 (divergence 0).
   if (uSurfaceType == 0) {
-    // ── rocky (지구) — 대륙/해양 대비 (저주파 noise) ────────────────────────
+    // ── rocky (지구) — 대륙↔해양 색 mix (Amendment 1 #775) ──────────────────
+    // continents fbm → landMask. ocean = baseColor (실측 청록), land = landColor (올리브-브라운).
+    // 밝기 변조만 (col=base*(1+mod)) 하던 #756 → 색조(hue) mix 로 "바다만" 회귀 해소.
     float continents = fbm(p * 2.4);
-    // base 색 위에 명암 변조 (대륙=밝게, 해양=어둡게). ±rockyContrast.
-    float mod_ = (continents - 0.5) * 2.0 * rockyContrast;
-    col = baseColor * (1.0 + mod_);
+    float landMask = smoothstep(landThresholdLo, landThresholdHi, continents);
+    col = mix(baseColor, landColor, landMask);
   } else if (uSurfaceType == 1) {
     // ── desert (화성) — dust/협곡 결 (fbm) + 산화철 톤 ─────────────────────
     float detail = fbm(p * 3.6);
@@ -265,9 +356,12 @@ void main(void) {
   }
   // 미등록 타입 (테이블 미적용) 은 여기 도달하지 않음 (호출부에서 셰이더 자체 미생성).
 
+  // Amendment 1 (#773) §결정 3 — 합성 순서 유지: 절차 변조(대륙/밴드/크레이터) 위에 광원 명암 곱.
+  //   밤면에서도 절차 디테일(대륙/밴드 패턴)은 존재하되 어둡다 (#756 고주파 엔트로피는 낮면 기준 유지).
   col *= shade;
-  // 안전 clamp — 절차 변조 후 색역 이탈 방지 (디자인 루브릭 — 보라/마젠타 등 기괴 색역 차단은
-  // baseColor 가 실측 자연색이라 R/G/B 단조 변조로 구조적 보장. clamp 는 [0,1] 범위만 보정).
+  // 안전 clamp — 광원(낮면 휘도 > 1) + 절차 변조 후 색역 이탈 방지 (디자인 루브릭 — 보라/마젠타 등
+  // 기괴 색역 차단은 baseColor/landColor 가 실측 자연색이라 R/G/B 단조 합성으로 구조적 보장. clamp 는
+  // [0,1] 범위만 보정 — 낮면이 sunIntensity 2.5 로 1.0 초과해도 흰색으로 saturate, 단색 행성과 동일).
   col = clamp(col, 0.0, 1.0);
 
   gl_FragColor = vec4(col, 1.0);
@@ -290,6 +384,28 @@ function registerProceduralPlanetShader(): void {
   shaderRegistered = true;
 }
 
+/**
+ * Amendment 1 (#773) — 광원 물리 상수 (PointLight + HemisphericLight 재현용).
+ *
+ * scene (`solar-system-scene.ts`) 가 이 값들의 SSoT 다 (PointLight/HemisphericLight 와 동일 값).
+ * 셰이더는 scene 를 import 하지 않고 (순환 회피) 이 묶음을 주입받아 uniform 으로 설정한다
+ * (단방향 의존 — volt #69 마법 숫자 중복 금지). 모든 값은 rendering-only (데이터 SSoT 무관).
+ */
+export interface PlanetLightingConstants {
+  /** PointLight intensity (= sunLight.intensity, 2.5). */
+  sunIntensity: number;
+  /** PointLight diffuse RGB (= sunLight.diffuse, (1, 0.95, 0.8)). */
+  sunDiffuse: readonly [number, number, number];
+  /** HemisphericLight intensity (= AMBIENT_INTENSITY, 0.3). */
+  ambientIntensity: number;
+  /** HemisphericLight groundColor RGB (= AMBIENT_GROUND_COLOR_RGB). */
+  ambientGround: readonly [number, number, number];
+  /** HemisphericLight diffuse(sky) RGB (Babylon 기본 (1,1,1) 흰색). */
+  ambientSky: readonly [number, number, number];
+  /** HemisphericLight direction(up) (= (0,1,0)). */
+  ambientUp: readonly [number, number, number];
+}
+
 export interface CreateProceduralPlanetMaterialOptions {
   /**
    * ADR §결정 3 — detailLevel uniform 차등 훅 (예약). high/mid 모두 full (1.0) 고정.
@@ -297,7 +413,33 @@ export interface CreateProceduralPlanetMaterialOptions {
    * override 패턴 정합). 현재 셰이더 내부 미사용 — 인터페이스 예약만.
    */
   detailLevel?: number;
+
+  /**
+   * Amendment 1 (#773) §A1.3 결정 1 — 태양 월드 위치 provider (scene-unit world).
+   *
+   * `createSolarSystemScene` 가 매 프레임 `sunLight.position` (Floating Origin shift + tier scale 반영된
+   * scene-unit world) 을 갱신하므로, 그 값을 그대로 반환하는 콜백을 넘긴다. onBindObservable 클로저가
+   * 각 draw 직전 `normalize(sunPos − meshAbsPos)` 로 `uSunDirection` 을 갱신한다 (scene→core 단방향).
+   * 미전달 시 (테스트 등) onBind 미등록 — uSunDirection 은 기본 +X (호출부 setVector3 fallback).
+   */
+  sunPositionProvider?: () => Vector3;
+
+  /**
+   * Amendment 1 (#773) §A1.3 결정 2 — 광원 물리 상수 (scene SSoT 주입). 미전달 시 단색 행성과
+   * 불일치하므로 호출부 (scene) 가 반드시 전달. 테스트 등 미전달 시 안전 기본값 (단색 행성 값) 적용.
+   */
+  lighting?: PlanetLightingConstants;
 }
+
+/** Amendment 1 — lighting 미전달 시 기본값 (단색 행성 PointLight/HemisphericLight 값과 동일 — 일관). */
+const DEFAULT_PLANET_LIGHTING: PlanetLightingConstants = {
+  sunIntensity: 2.5,
+  sunDiffuse: [1, 0.95, 0.8],
+  ambientIntensity: 0.3,
+  ambientGround: [0.15, 0.15, 0.18],
+  ambientSky: [1, 1, 1],
+  ambientUp: [0, 1, 0],
+};
 
 /**
  * #756 — body 의 절차적 표면 ShaderMaterial 생성 (high/mid 공유).
@@ -344,6 +486,19 @@ export function createProceduralPlanetMaterial(
         'craterDepth',
         'craterDensity',
         'logDepthConstant',
+        // Amendment 1 (#773) — 광원 모델 uniform.
+        'uSunDirection',
+        'sunIntensity',
+        'sunDiffuse',
+        'ambientIntensity',
+        'ambientGround',
+        'ambientSky',
+        'ambientUp',
+        'softTerminatorWidth',
+        // Amendment 1 (#775) — 대륙 mix uniform.
+        'landColor',
+        'landThresholdLo',
+        'landThresholdHi',
       ],
     },
   );
@@ -367,6 +522,62 @@ export function createProceduralPlanetMaterial(
   // ADR §결정 3 — detailLevel 예약 (1차 미사용, 셰이더 uniform 미선언이라 setFloat 생략).
   // options.detailLevel 은 인터페이스 예약 — 후속 활성화 시 uniform 추가 + 셰이더 배선.
   void options.detailLevel;
+
+  // Amendment 1 (#773) — 광원 물리 상수 uniform (scene SSoT 주입, 단색 행성 PointLight/Hemispheric 일치).
+  const lighting = options.lighting ?? DEFAULT_PLANET_LIGHTING;
+  material.setFloat('sunIntensity', lighting.sunIntensity);
+  material.setColor3('sunDiffuse', new Color3(...lighting.sunDiffuse));
+  material.setFloat('ambientIntensity', lighting.ambientIntensity);
+  material.setColor3('ambientGround', new Color3(...lighting.ambientGround));
+  material.setColor3('ambientSky', new Color3(...lighting.ambientSky));
+  material.setVector3('ambientUp', new Vector3(...lighting.ambientUp));
+  material.setFloat('softTerminatorWidth', SOFT_TERMINATOR_WIDTH);
+
+  // Amendment 1 (#775) — 대륙 mix 미학 상수 uniform (rendering-only).
+  material.setColor3('landColor', new Color3(LAND_COLOR_RGB.r, LAND_COLOR_RGB.g, LAND_COLOR_RGB.b));
+  material.setFloat('landThresholdLo', LAND_THRESHOLD_LO);
+  material.setFloat('landThresholdHi', LAND_THRESHOLD_HI);
+
+  // Amendment 1 (#773) §A1.3 결정 1 — 태양 방향 uniform.
+  //   기본 +X (provider 미전달 시 테스트 fallback). provider 가 있으면 onBind 에서 매 draw 갱신.
+  material.setVector3('uSunDirection', new Vector3(1, 0, 0));
+
+  const sunPositionProvider = options.sunPositionProvider;
+  if (sunPositionProvider) {
+    // onBindObservable — 각 draw 직전 mesh 핸들과 함께 호출 (scene 이 material 핸들 별도 추적 불요,
+    // 옵션 d Map 대비 우월 — ADR §A1.3 결정 1 c). tmpVector 재사용으로 alloc 0 (cross-validate 이견 2).
+    const tmpSunDir = new Vector3();
+    material.onBindObservable.add((mesh) => {
+      const sunPos = sunPositionProvider();
+      // sunDir = normalize(sunPos − meshAbsPos). 회전 0 + uniform scaling → world normal == local normal.
+      // satellite (달) 도 parent 상속 위치를 getAbsolutePosition 이 정확히 반영 (ADR §A1.3 결정 1).
+      const meshPos = (mesh as Mesh).getAbsolutePosition();
+      sunPos.subtractToRef(meshPos, tmpSunDir);
+      tmpSunDir.normalize();
+      material.setVector3('uSunDirection', tmpSunDir);
+
+      // dev-only 방어적 회전 어서션 (cross-validate 이견 3) — world normal == local normal 전제가
+      // 회전 0 에 의존. self-rotation / axialTilt 도입 시 vNormal 을 world matrix 로 변환해야 한다
+      // (ADR §A1.3 결정 1 옵션 e). production 무영향 (NODE_ENV DCE).
+      if (process.env.NODE_ENV !== 'production') {
+        const m = mesh as Mesh;
+        const rotNonZero =
+          m.rotationQuaternion != null
+            ? Math.abs(m.rotationQuaternion.w - 1) > 1e-6 ||
+              Math.abs(m.rotationQuaternion.x) > 1e-6 ||
+              Math.abs(m.rotationQuaternion.y) > 1e-6 ||
+              Math.abs(m.rotationQuaternion.z) > 1e-6
+            : Math.abs(m.rotation.x) > 1e-6 ||
+              Math.abs(m.rotation.y) > 1e-6 ||
+              Math.abs(m.rotation.z) > 1e-6;
+        if (rotNonZero) {
+          console.warn(
+            `[procedural-planet-shader] mesh "${m.name}" 회전 non-zero 감지 — 광원 모델은 world normal == local normal (회전 0) 전제. self-rotation 도입 시 normalMatrix 필요 (ADR §A1.3 결정 1 옵션 e).`,
+          );
+        }
+      }
+    });
+  }
 
   // #756 §핵심 위험 1 — 로그 depth 상수 (Babylon logDepth 공식: 2 / log2(maxZ + 1)).
   // maxZ 는 setupArcRotateCamera 가 1e14 로 고정 (ring-shader 와 동일 선례). 카메라 부재
@@ -436,9 +647,10 @@ export function fbmMirror(px: number, py: number, pz: number): number {
 /**
  * #756 — FRAGMENT_SHADER 의 표면 변조 GLSL 의 **순수 JS 미러** (anti-pattern 계약 검증용).
  *
- * 주어진 구면 좌표 + 표면 타입에 대해 변조된 출력 RGB 를 반환한다 (간이 명암 shade 제외 —
- * 색역 검증은 변조 식만으로 충분). GLSL 과 동일 식 — 보라/마젠타 부재 (R+B 동시 우세 & G 결핍
- * 금지) / 출력 [0,1] 범위 / 변조 강도 상수 SSoT 를 결정적으로 검증한다.
+ * 주어진 구면 좌표 + 표면 타입에 대해 변조된 출력 RGB 를 반환한다 (광원 명암 shade 제외 —
+ * 색역 검증은 변조 식만으로 충분, 광원 단조성은 `lightingShadeMirror` 가 별도 검증). GLSL 과
+ * 동일 식 — 보라/마젠타 부재 (R+B 동시 우세 & G 결핍 금지) / 출력 [0,1] 범위 / 변조 강도 상수
+ * SSoT 를 결정적으로 검증한다. rocky 는 Amendment 1 (#775) 대륙 mix (ocean=base ↔ land=landColor).
  *
  * ⚠️ FRAGMENT_SHADER 의 GLSL 분기와 동일 식이어야 한다 (SSoT — 한쪽 수정 시 양쪽 동기화).
  *
@@ -459,11 +671,17 @@ export function surfaceColorMirror(
   const [px, py, pz] = p;
 
   if (surfaceType === SurfaceType.Rocky) {
+    // Amendment 1 (#775) — 대륙↔해양 색 mix (밝기 변조 → 색조 mix). GLSL rocky 분기와 동일 식.
     const continents = fbmMirror(px * 2.4, py * 2.4, pz * 2.4);
-    const mod = (continents - 0.5) * 2 * ROCKY_CONTRAST;
-    r = bx * (1 + mod);
-    g = by * (1 + mod);
-    b = bz * (1 + mod);
+    const t =
+      (continents - LAND_THRESHOLD_LO) / Math.max(LAND_THRESHOLD_HI - LAND_THRESHOLD_LO, 1e-6);
+    const landMask = (() => {
+      const c = Math.min(Math.max(t, 0), 1);
+      return c * c * (3 - 2 * c);
+    })();
+    r = bx + (LAND_COLOR_RGB.r - bx) * landMask;
+    g = by + (LAND_COLOR_RGB.g - by) * landMask;
+    b = bz + (LAND_COLOR_RGB.b - bz) * landMask;
   } else if (surfaceType === SurfaceType.Desert) {
     const detail = fbmMirror(px * 3.6, py * 3.6, pz * 3.6);
     const mod = (detail - 0.5) * 2 * DESERT_DETAIL;
@@ -504,6 +722,55 @@ export function surfaceColorMirror(
 
   const clamp01 = (n: number): number => Math.min(Math.max(n, 0), 1);
   return [clamp01(r), clamp01(g), clamp01(b)];
+}
+
+/**
+ * Amendment 1 (#773) — FRAGMENT_SHADER 광원식 (`shade`) 의 순수 JS 미러 (단조성/일관성 검증용).
+ *
+ * `shade = ambientIntensity * mix(ground, sky, dot(N,up)*0.5+0.5) + sunIntensity * sunDiffuse *
+ *  smoothstep(0.0, W, dot(N, sunDir))`. GLSL main() 의 광원 합성과 동일 식 — 밤면 < 낮면 단조,
+ * terminator soft 전이, hemispheric 극 그라데이션을 결정적으로 검증한다 (단색 행성 일관성 SSoT).
+ *
+ * ⚠️ FRAGMENT_SHADER 의 GLSL 광원 합성과 동일 식이어야 한다 (한쪽 수정 시 양쪽 동기화).
+ *
+ * @param N 표면 법선 (단위 벡터 — 회전 0 전제로 local == world)
+ * @param sunDir 태양 방향 (단위 벡터)
+ * @param lighting 광원 물리 상수 (scene SSoT — 미전달 시 DEFAULT_PLANET_LIGHTING)
+ * @returns 광원 명암 RGB (diffuseColor 곱 전 — 낮면은 1.0 초과 가능, clamp 미적용)
+ */
+export function lightingShadeMirror(
+  N: readonly [number, number, number],
+  sunDir: readonly [number, number, number],
+  lighting: PlanetLightingConstants = DEFAULT_PLANET_LIGHTING,
+): readonly [number, number, number] {
+  const dot = (
+    a: readonly [number, number, number],
+    b: readonly [number, number, number],
+  ): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+  const smoothstep = (e0: number, e1: number, x: number): number => {
+    const t = Math.min(Math.max((x - e0) / Math.max(e1 - e0, 1e-6), 0), 1);
+    return t * t * (3 - 2 * t);
+  };
+  // ① HemisphericLight — mix(ground, sky, dot(N,up)*0.5+0.5).
+  const hemiFactor = dot(N, lighting.ambientUp) * 0.5 + 0.5;
+  const mix = (a: number, b: number, t: number): number => a + (b - a) * t;
+  const ambient: [number, number, number] = [
+    lighting.ambientIntensity * mix(lighting.ambientGround[0], lighting.ambientSky[0], hemiFactor),
+    lighting.ambientIntensity * mix(lighting.ambientGround[1], lighting.ambientSky[1], hemiFactor),
+    lighting.ambientIntensity * mix(lighting.ambientGround[2], lighting.ambientSky[2], hemiFactor),
+  ];
+  // ② PointLight diffuse — sunIntensity * sunDiffuse * smoothstep(0, W, dot(N, sunDir)).
+  const sunFactor = smoothstep(0, SOFT_TERMINATOR_WIDTH, dot(N, sunDir));
+  return [
+    ambient[0] + lighting.sunIntensity * lighting.sunDiffuse[0] * sunFactor,
+    ambient[1] + lighting.sunIntensity * lighting.sunDiffuse[1] * sunFactor,
+    ambient[2] + lighting.sunIntensity * lighting.sunDiffuse[2] * sunFactor,
+  ];
+}
+
+/** Rec.709 휘도 (광원식 단조성 검증용 — 밤면 < 낮면 비교 스칼라화). */
+export function luminance709(rgb: readonly [number, number, number]): number {
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
 }
 
 /** hex → RGB tuple ∈ [0,1]³ (solar-system-scene `hexToColor3` 동형 — 테스트 입력 변환용). */

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -28,7 +28,10 @@ import { createAsteroidBelt, type AsteroidBeltHandles } from './asteroid-belt.js
 import { createRingPlaceholder, type RingPlaceholderHandles } from './ring-placeholder.js';
 import { createRingShaderMesh, type RingShaderHandles } from './ring-shader.js';
 import { createStarfield } from './starfield.js';
-import { createProceduralPlanetMaterial } from './procedural-planet-shader.js';
+import {
+  createProceduralPlanetMaterial,
+  type PlanetLightingConstants,
+} from './procedural-planet-shader.js';
 import {
   renderScaleForTier,
   initialTier as defaultInitialTier,
@@ -114,6 +117,22 @@ function floatingOriginAssertEnabled(): boolean {
  */
 export const AMBIENT_INTENSITY = 0.3;
 export const AMBIENT_GROUND_COLOR_RGB = { r: 0.15, g: 0.15, b: 0.18 } as const;
+
+/**
+ * #773 Amendment 1 — 광원 물리 상수 SSoT (PointLight + HemisphericLight).
+ *
+ * 절차 표면 셰이더 (`procedural-planet-shader.ts`) 가 단색 행성 (StandardMaterial) 과 **동일한 명암**
+ * 을 내려면 PointLight/HemisphericLight 의 값을 정확히 재현해야 한다. 셰이더는 scene 를 import 하지
+ * 않으므로 (순환 회피), 이 상수들을 `createProceduralPlanetMaterial` 인자로 주입한다 (단방향 의존,
+ * volt #69 마법 숫자 중복 금지). 아래 sunLight/ambient 생성부가 이 상수를 그대로 사용한다 (SSoT).
+ *
+ * AMBIENT_SKY 는 HemisphericLight 의 `diffuse` (Babylon 기본 흰색 (1,1,1)), AMBIENT_UP 은 light
+ * direction (0,1,0). 셰이더 hemispheric mix(ground, sky, dot(N,up)*0.5+0.5) 재현용.
+ */
+export const SUN_INTENSITY = 2.5;
+export const SUN_DIFFUSE_RGB = { r: 1, g: 0.95, b: 0.8 } as const;
+export const AMBIENT_SKY_COLOR_RGB = { r: 1, g: 1, b: 1 } as const;
+export const AMBIENT_UP_DIR = { x: 0, y: 1, z: 0 } as const;
 
 export interface SolarSystemSceneHandles {
   /** id → 메쉬 */
@@ -483,7 +502,12 @@ export function createSolarSystemScene(
   }
 
   // 회귀 #372 fix — 행성 그림자측 인지 가능 ambient (AMBIENT_* 상수 SSoT, 단위 테스트 가드).
-  const ambient = new HemisphericLight('hemi', new Vector3(0, 1, 0), scene);
+  // #773 — 절차 표면 셰이더가 이 HemisphericLight 식을 재현하므로 값은 PLANET_LIGHTING 으로도 전달.
+  const ambient = new HemisphericLight(
+    'hemi',
+    new Vector3(AMBIENT_UP_DIR.x, AMBIENT_UP_DIR.y, AMBIENT_UP_DIR.z),
+    scene,
+  );
   ambient.intensity = AMBIENT_INTENSITY;
   ambient.groundColor = new Color3(
     AMBIENT_GROUND_COLOR_RGB.r,
@@ -491,10 +515,33 @@ export function createSolarSystemScene(
     AMBIENT_GROUND_COLOR_RGB.b,
   );
 
-  // 태양 중심 포인트 라이트
+  // 태양 중심 포인트 라이트 (#773 — SUN_* 상수 SSoT, 절차 표면 셰이더와 공유).
   const sunLight = new PointLight('sun-light', new Vector3(0, 0, 0), scene);
-  sunLight.intensity = 2.5;
-  sunLight.diffuse = new Color3(1, 0.95, 0.8);
+  sunLight.intensity = SUN_INTENSITY;
+  sunLight.diffuse = new Color3(SUN_DIFFUSE_RGB.r, SUN_DIFFUSE_RGB.g, SUN_DIFFUSE_RGB.b);
+
+  // #773 Amendment 1 — 절차 표면 셰이더 광원 상수 묶음 (scene SSoT → createProceduralPlanetMaterial
+  // 단방향 주입). PointLight/HemisphericLight 와 동일 값 (위 생성부) — 마법 숫자 중복 0 (volt #69).
+  const planetLighting: PlanetLightingConstants = {
+    sunIntensity: SUN_INTENSITY,
+    sunDiffuse: [SUN_DIFFUSE_RGB.r, SUN_DIFFUSE_RGB.g, SUN_DIFFUSE_RGB.b],
+    ambientIntensity: AMBIENT_INTENSITY,
+    ambientGround: [
+      AMBIENT_GROUND_COLOR_RGB.r,
+      AMBIENT_GROUND_COLOR_RGB.g,
+      AMBIENT_GROUND_COLOR_RGB.b,
+    ],
+    ambientSky: [AMBIENT_SKY_COLOR_RGB.r, AMBIENT_SKY_COLOR_RGB.g, AMBIENT_SKY_COLOR_RGB.b],
+    ambientUp: [AMBIENT_UP_DIR.x, AMBIENT_UP_DIR.y, AMBIENT_UP_DIR.z],
+  };
+  // #773 — 태양 월드 위치 provider (scene-unit world). updateAt 가 매 프레임 sunLight.position 을
+  // 갱신 (Floating Origin shift + tier scale 반영) → 셰이더 onBind 가 이 값으로 sunDir 계산.
+  const sunPositionProvider = (): Vector3 => sunLight.position;
+  // #773 — createBodyMesh/createBodyMeshMid 에 단방향 전달할 광원 배선 묶음 (surfaceDetail=true 일 때만 사용).
+  const surfaceLightingArgs: SurfaceLightingArgs = {
+    lighting: planetLighting,
+    sunPositionProvider,
+  };
 
   // 각 바디 메쉬 생성 — Phase A: 생성 시점 tier 의 renderScale 로 실측 직경 계산 (ADR §주석 계약 §2).
   //
@@ -503,7 +550,14 @@ export function createSolarSystemScene(
   const bodyInitialRenderScale = activeTier; // 모든 body 가 동일 tier 로 생성됨 → Tier 만 기억하면 충분.
   const bodyBaseDiameter = new Map<string, number>(); // body.radius × 2 (m, tier 중립, 진단용)
   for (const body of system.bodies) {
-    const mesh = createBodyMesh(body, scene, activeTier, bodyScale, surfaceDetail);
+    const mesh = createBodyMesh(
+      body,
+      scene,
+      activeTier,
+      bodyScale,
+      surfaceDetail,
+      surfaceLightingArgs,
+    );
     meshes.set(body.id, mesh);
     bodyBaseDiameter.set(body.id, body.radius * 2);
   }
@@ -1619,6 +1673,7 @@ export function createSolarSystemScene(
           highMesh,
           bodyScale,
           surfaceDetail,
+          surfaceLightingArgs,
         );
         midVariants.set(body.id, m);
       }
@@ -1857,12 +1912,22 @@ function defaultBodyScale(_bodyId: string): number {
   return 1.0;
 }
 
+/**
+ * #773 Amendment 1 — 절차 표면 셰이더 광원 배선 인자 (createBodyMesh/createBodyMeshMid 공유).
+ * scene 가 소유한 광원 상수 + sun position provider 를 셰이더 팩토리로 단방향 전달.
+ */
+interface SurfaceLightingArgs {
+  lighting: PlanetLightingConstants;
+  sunPositionProvider: () => Vector3;
+}
+
 function createBodyMesh(
   body: LoadedCelestialBody,
   scene: Scene,
   tier: Tier,
   bodyScale: (bodyId: string) => number,
   surfaceDetail = false,
+  surfaceLighting?: SurfaceLightingArgs,
 ): Mesh {
   // P12-A #298 — 실측 직경 × 현재 tier 의 renderScale 로 메쉬 생성.
   // R1 #329 — × bodyScale (시각 과장 배수, ADR `20260425-r1-sun-visualization.md` §결정 3).
@@ -1872,9 +1937,9 @@ function createBodyMesh(
 
   // #756 — 절차적 표면 셰이더 (surfaceDetail=true + 테이블 등록 body 만). 미등록/OFF 면 null →
   // 기존 StandardMaterial 경로 (단색, 무회귀). 항성(sun)은 표면 테이블 미등록이라 자동 단색.
-  // ADR `docs/decisions/20260628-756-procedural-planet-surface.md` §결정 1·4.
+  // ADR `docs/decisions/20260628-756-procedural-planet-surface.md` §결정 1·4 + Amendment 1 (#773).
   const surfaceMat = surfaceDetail
-    ? createProceduralPlanetMaterial(scene, body, `${body.id}-surface-mat`)
+    ? createProceduralPlanetMaterial(scene, body, `${body.id}-surface-mat`, surfaceLighting ?? {})
     : null;
   if (surfaceMat) {
     mesh.material = surfaceMat;
@@ -1913,6 +1978,7 @@ function createBodyMeshMid(
   parent: Mesh,
   bodyScale: (bodyId: string) => number,
   surfaceDetail = false,
+  surfaceLighting?: SurfaceLightingArgs,
 ): Mesh {
   // R1 #329 — high variant 와 동일 식 (× bodyScale) 로 비율 보존. LOD 전환 시 사용자가 크기 변화 인지 못함.
   const diameter = body.radius * 2 * renderScaleForTier(tier) * bodyScale(body.id);
@@ -1923,8 +1989,14 @@ function createBodyMeshMid(
 
   // #756 — mid variant 도 high 와 동일 절차 셰이더 공유 (segments 만 다름 — ADR §결정 1).
   // LOD 전환 시 표면 연속성 (사용자 인지 불변). 미등록/OFF 면 null → StandardMaterial 무회귀.
+  // #773 Amendment 1 — 동일 광원 인자 (high/mid 명암 일관 — 각 variant 의 onBind 가 자기 sunDir 갱신).
   const surfaceMat = surfaceDetail
-    ? createProceduralPlanetMaterial(scene, body, `${body.id}-lod-mid-surface-mat`)
+    ? createProceduralPlanetMaterial(
+        scene,
+        body,
+        `${body.id}-lod-mid-surface-mat`,
+        surfaceLighting ?? {},
+      )
     : null;
   if (surfaceMat) {
     mesh.material = surfaceMat;


### PR DESCRIPTION
## v0.40.0 릴리스 (develop → main)

### CHANGELOG 범위

`[0.40.0]` — 2026-07-01. MINOR (#773 + #775).

### Behavior Changes

- **[#773] 표면 셰이더 행성 광원 일관성 회복 (MINOR)** — #756 표면 셰이더의 광원 회귀 수정. 표면 셰이더 행성(지구/화성/목성/달)이 커스텀 ShaderMaterial이라 PointLight 미반영 → 고정 방향 균일 명암(밤면 없음)이던 것을 단색 행성과 동일한 실제 태양 광원 명암으로 전환. onBindObservable uSunDirection + HemisphericLight 식 재현 + soft terminator. 실측(실 Chrome GUI): 밤면/terminator 대비비 15.9~21.4(단색 행성 동일 범위), 태양 추종 71.4° 이동, fps 회귀 0(tier-c override 자동 우회).
- **[#775] 지구 대륙 표현 (MINOR)** — rocky 셰이더 바다색 밝기 변조만 → ocean↔land 색조 mix(LAND_COLOR_RGB 코드상수). 실측 land 49.3%/ocean 44.0%.
- 공통: 절차 표면 무회귀, 데이터/picking/camera/orbit/tier/LOD 0, GLSL↔JS 미러 parity. ADR §Amendment 1(Accepted, cross-validate).

### 포함 PR

- #776 — 광원 일관성 + 대륙 mix (squash 980d863)
- #777 — v0.40.0 prep (squash d0f26b2)

### 태그 계획

머지(merge commit) 직후 `git push origin main:develop`(ff-sync) → `git tag v0.40.0`(annotated) + `gh release create v0.40.0`.

## 테스트 (Test plan)

- #773/#775 코드(#776)는 develop 에서 전체 페르소나 파이프라인 통과(architect→cross-validate→developer→메인 직접검증→reviewer→qa 실 Chrome GUI 3단계) + CI 전체 pass.
- prep PR #777 CI 전체 pass 확인 후 머지.

## 체크리스트

- [x] **커밋 컨벤션** 준수 (release PR, merge commit 방식 — squash 금지)
- [x] **불필요**한 변경 없음 (develop tip = 검증 완료된 #776 + prep)
- [x] **보안** 영향 없음 (rendering-only 셰이더 변경)
- [x] **SSoT** 정합 (CHANGELOG/version/ADR Amendment 1 단일 출처)
- [x] **cross-validate** 완료 (ADR Amendment 1 — agy, Accepted)
- [x] **ADR 호환성** 유지 (#756 Amendment 1, 신규 ADR 없음)
- [x] **Test plan** 명시 (위)
