### PR TITLE
[#774] 태양 emissive 절차 표면 셰이더 — granulation + limb darkening + 색온도

### DIFF
--- a/docs/decisions/20260703-774-sun-emissive-shader.md
+++ b/docs/decisions/20260703-774-sun-emissive-shader.md
@@ -1,6 +1,6 @@
 # ADR 20260703-774 — 태양 emissive 절차 표면 셰이더 (granulation / limb darkening / 색온도 그라데이션)
 
-- **상태**: Provisional (cross-validate 대기 — 통합 후 Accepted 전이, #370 옵션 C)
+- **상태**: Accepted (cross-validate 2026-07-03)
 - **날짜**: 2026-07-03
 - **결정자**: architect (sub-agent), 이슈 [#774](https://github.com/coseo12/astro-simulator/issues/774)
 - **관련**: #756 (절차적 행성 표면 셰이더 — 본 ADR 의 직접 선행), #782 (self-rotation + 광원 world normal 옵션 e), #675 (glow pixel marker), #738 (starfield)
@@ -148,7 +148,7 @@ ring-shader (#641 D-T2 fix) → planet-shader (#756 핵심 위험 1) 로 2회 �
 | 2   | limb darkening: disk 반경 방향 Rec.709 휘도 프로파일 **단조 감소** + 가장자리 (r≈0.9R) / 중심 휘도비 **< 0.85**                                                                   | 스크린샷 disk 중심→가장자리 radial 샘플링                                                                                                             |
 | 3   | 색온도: 가장자리 B/R 채널비 **< 중심 B/R 채널비** (가장자리가 더 주황)                                                                                                            | 동일 radial 샘플링의 채널비 비교                                                                                                                      |
 | 4   | `?surface=off` 복귀: 태양 disk 픽셀 분산 ≈ 단색 수준 (현행 동일) + planet 4종 OFF 동작 유지                                                                                       | OFF 스크린샷 disk 내부 stddev 비교                                                                                                                    |
-| 5   | glow-marker 무회귀: 대줌아웃에서 sun glow marker 발동 유지                                                                                                                        | 기존 `browser-verify-glow-marker.mjs` 시나리오 PASS                                                                                                   |
+| 5   | glow-marker 무회귀: 대줌아웃에서 sun glow marker 발동 유지 + 줌아웃 연속 경로에서 LOD mid→low 전환 경계 급변 (팝핑) 관찰 (cross-validate Q1 부분 수용)                            | 기존 `browser-verify-glow-marker.mjs` 시나리오 PASS + 전환 경계 연속 캡처 관찰                                                                        |
 | 6   | fps 회귀 0: fps-baseline-guard PASS (CI swiftshader tier-c 포함) — `?focus=sun` 대면적 fill-rate                                                                                  | CI workflow                                                                                                                                           |
 | 7   | 단위 테스트: 미러 결정성 / limb 단조성 (μ↓ ⇒ 휘도↓) / warm 색역 (R ≥ B 유지 — 보라·마젠타 부재) / 상수 SSoT / GLSL 정적 계약 (if-else only·`gl_FragDepth` 존재·world normal 배선) | `sun-shader.test.ts`                                                                                                                                  |
 | 8   | 무회귀: 26 body (planet 셰이더 4 + 단색 22) 픽셀 불변 + `pnpm --filter core typecheck` 0 (#719) + r1-guard                                                                        | 기존 가드 전수                                                                                                                                        |
@@ -169,14 +169,33 @@ ring-shader (#641 D-T2 fix) → planet-shader (#756 핵심 위험 1) 로 2회 �
 3. **시간 변동 granulation 요구** — jd 직접 전달 금지 (#782 규약) 유지. wrap-around 소수 시간 uniform (engine 시간 mod 주기) 설계 + r1-guard/verify 결정성 대책 (surface=off 캡처 등) 동시 필요.
 4. **태양 자전 사실 표현 요구** — 차등 자전 (위도별 각속도) 은 mesh 강체 회전으로 불가 — 셰이더 내 위도별 경도 offset 접근 검토. `rotationPeriodHours` 데이터 추가는 그때 재론.
 5. **코로나/플레어** — 별도 빌보드/glow 레이어 후속 이슈 (mesh fragment 범위 밖).
+6. **시각 튜닝 분리 요구** (cross-validate Q4) — 단일 `LIMB_DARKENING_U_RGB` 로 감광 프로파일과 색온도를 독립 조정할 수 없다는 요구가 실제 발생하면, 감광 지수 (exponent) 와 색 보간 (mix) 상수 분리로 전환 (fragment 수 줄 추가 예상).
 
 ---
 
-## 교차검증 반영 사항
+## 교차검증 반영 사항 (agy, 2026-07-03 — 로그 `.claude/logs/cross-validate-architecture-774.log`)
 
-> cross-validate 대기 (Provisional) — 메인 오케스트레이터가 본 ADR 박제 직후 1회 수행 (CLAUDE.md `## 교차검증` 앵커: ADR 신규). 수행 결과 (합의 / 이견 수용 / 기각 / 고유 발견 / 편향 셀프 체크) 를 본 섹션에 통합 후 상태를 `Accepted (cross-validate YYYY-MM-DD)` 로 전이한다.
+**합의 (즉시 반영 또는 이미 반영됨)**:
 
-**호출 전 Claude 편향 4종 셀프 체크 (초안)**: 낙관적 일정 — 해당 없음 (라인 예측은 planet 실측 기반). 결합 간과 — **주의 축**: glow-marker 정합 (결정 5) 을 "구조적 자동 보장" 으로 단정 — cross-validate 프롬프트에 명시 질문 권장. 폐기 프레이밍 — sunspot/시간 변동을 후속 유지 (재검토 조건 2·3 으로 재도입 경로 박제, 통과). 순수주의 — 채널별 u 계수의 물리 근사가 시각 튜닝 (measurement-first) 을 배제하지 않도록 결정 8 에 developer 재량 명시 (통과).
+1. **Q2 모듈 분리 지지** — 관심사 분리 / uniform 표면 분리 근거로 별도 `sun-shader.ts` 채택 타당 판정. 결정 1 유지.
+2. **Q3 정적 granulation 단기 타당** — 스크린샷 검증 결정성 확보 평가. 장기 차등 자전은 "셰이더 내 위도별 경도 offset" 경량 GPU 접근 제안 — **재검토 조건 4 에 이미 동일 내용 박제됨** (맥락 보존 완료, 별도 이슈 불요. 발동 트리거: 사용자 요구).
+3. **cameraPosition auto-bind 신뢰성** — 결정 8 의 developer 실측 확인 + onBind 폴백과 동일 지적 (합의 재확인).
+
+**부분 수용**:
+
+4. **Q1 glow-marker "변경 0 자동 보장" 단정 반박** — agy 는 mid(셰이더)→low(billboard) LOD 전환 경계 팝핑 위험 지적. 사실관계 재검증: (i) LOD cross-fade 는 존재하나 #756 에서 ShaderMaterial alpha 1.0 고정 + high·mid 동일 셰이더로 "구조적 비문제" 실증, (ii) mid→low 전환은 #756 이후 planet 도 동일 구조 (셰이더→billboard) 로 운영 중 무보고 — 전환 거리에서 disk 가 소면적이라 휘도 차 비가시. 단 **limb darkening 은 disk 평균 휘도를 낮추므로 sun 은 신규 휘도 스텝이 생기는 것이 사실** → 설계 변경 없이 **DoD 5 실측에 "줌아웃 연속 경로에서 LOD 전환 경계 급변 관찰" 을 포함** 하는 것으로 수용. 결정 5 의 "코드 변경 0" 은 유지 (marker 발동 로직 자체는 low 전용 사실 불변).
+
+**기각 (오탐 — 근거 실측)**:
+
+5. **머티리얼 dispose 수명주기 부재** — `surfaceDetail` 은 scene **생성 시점** 옵션 (기본 false, 런타임 토글 없음 — `?surface=off` 는 페이지 로드 시 적용). 머티리얼은 1회 생성 후 LOD 는 `isVisible` 토글만 (dispose/재생성 없음, `solar-system-scene.ts` L1805 주석 계약). 런타임 교체 시나리오 자체가 부재.
+6. **Glow/HDR 톤매핑 에너지 정합 규약 부재** — 씬에 GlowLayer / 톤매퍼 / bloom 포스트 프로세싱 파이프라인이 **존재하지 않음** (grep 실측 — glow-marker 는 billboard 마커이며 포스트 프로세싱 아님). 전제 부재로 기각.
+7. **근접 시 granulation 앨리어싱/모아레** — fbm 은 밴드리미티드 smooth noise 로 텍스처 샘플링 앨리어싱과 발생 기전이 다르고, #756 planet 4종이 동일 fbm 구조로 focus 근접 운영 중 무보고. 카메라 lowerRadiusLimit 이 근접 거리를 제한. qa DoD 1 근접 캡처에서 자연 관찰되므로 별도 대책 불요.
+
+**이견 — 기각 (YAGNI, 재검토 경로 박제)**:
+
+8. **Q4 감광 지수 / 색 mix 분리 설계** — agy 는 아티스트 튜닝 유연성을 위해 감광 커브 (exponent) 와 색 보간 (mix) 분리를 권장. 기각 근거: (i) 본 프로젝트는 1인 개발 + 사용자 D-T2 피드백 구조로 "아티스트 별도 튜닝 요구" 는 현재 가설적, (ii) 물리 근사 단일 상수는 감광·색이 실제 물리처럼 결합된 정직한 표현 + 상수 표면 최소, (iii) 분리가 필요해지면 fragment 수 줄 추가로 후속 가능. → **재검토 조건 6 신설** 로 경로 박제.
+
+**Claude 편향 셀프 체크 결과**: 결합 간과 (주의 축이었던 glow-marker 단정) 는 agy 반박 → 사실 재검증 → DoD 관찰 보강으로 해소. 낙관적 일정 / 폐기 프레이밍 / 순수주의는 초안 판정 유지 (agy 도 반대 근거 미제시).
 
 ## 참고
 

--- a/docs/decisions/20260703-774-sun-emissive-shader.md
+++ b/docs/decisions/20260703-774-sun-emissive-shader.md
@@ -1,0 +1,186 @@
+# ADR 20260703-774 — 태양 emissive 절차 표면 셰이더 (granulation / limb darkening / 색온도 그라데이션)
+
+- **상태**: Provisional (cross-validate 대기 — 통합 후 Accepted 전이, #370 옵션 C)
+- **날짜**: 2026-07-03
+- **결정자**: architect (sub-agent), 이슈 [#774](https://github.com/coseo12/astro-simulator/issues/774)
+- **관련**: #756 (절차적 행성 표면 셰이더 — 본 ADR 의 직접 선행), #782 (self-rotation + 광원 world normal 옵션 e), #675 (glow pixel marker), #738 (starfield)
+
+## 배경
+
+#756 이 절차적 행성 표면 셰이더 (rocky/desert/gas-bands/cratered 4종) 를 도입했으나 태양은 의도적으로 범위 밖이었다 (`SURFACE_TYPE_BY_BODY` 미등록 → 자동 단색). 현재 태양은 `createBodyMesh` 의 star 분기에서 `mat.emissiveColor = colorHint.hex; mat.disableLighting = true` — **단색 발광 disk** 로만 렌더된다. 사용자 관찰 (2026-06-30, #774): "태양의 사실적 표현이 가장 핵심일 수 있으나 적용되지 않음" — granulation (쌀알 무늬) / limb darkening (주연 감광) / 색온도 그라데이션 전부 0.
+
+태양이 #756 셰이더를 재사용할 수 없는 근본 이유: **광원 모델이 정반대다**. #756 fragment 는 "외부 광원 (PointLight+HemisphericLight) 재현 명암 (`shade`) × 절차 변조" 구조인데, 태양은 self-luminous 라 외부광 명암이 무의미하다 (태양 자신이 그 PointLight 의 광원). 필요한 것은 **emissive 전용** 절차 셰이더 — `gl_FragColor` 가 곧 발광색이며, 명암 대신 **limb darkening** (시선각 μ = dot(N, viewDir) 기반 주연 감광 — 광구 깊이별 온도 차의 시각 결과) 이 사실감의 핵심이다.
+
+## 후보 비교
+
+### 결정 1 — 모듈 구조: 별도 `sun-shader.ts` vs `SurfaceType.Star` 추가 (이슈 설계 고려 1)
+
+| 축                       | A. `SurfaceType.Star = 4` 를 `procedural-planet-shader.ts` 에 추가                                                                      | B. 신규 `sun-shader.ts` (독립 모듈, 4번째 절차 셰이더)                                                                                                              | C. `procedural-planet-shader.ts` 내 별도 star ShaderMaterial (동일 파일 2 셰이더) |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 광원 모델 정합           | ✗ 기존 fragment 말미 `col *= shade` (외부광 곱) 를 star 분기만 우회하는 특수화 — "광원 적용 여부" 라는 직교 관심사가 4 타입 계약에 혼입 | ✓ emissive 전용 fragment — 외부광 uniform 자체가 없음 (uSunDirection/ambient 4종/land 3종 등 9+ uniform 무의미 제거)                                                | ✓ 셰이더는 분리되나                                                               |
+| uniform 표면             | ✗ 태양에 무의미한 광원 uniform 9종 + 유의미한 신규 uniform (cameraPosition/limb 상수) 이 한 셰이더에 동거                               | ✓ 각 셰이더가 자기 uniform 만 소유                                                                                                                                  | △ 파일 비대 (이미 824줄)                                                          |
+| viewDir (limb darkening) | ✗ 기존 4 타입은 viewDir 불필요 — star 만 위해 varying/uniform 추가                                                                      | ✓ vWorldPos varying + cameraPosition uniform 을 sun 셰이더만 소유                                                                                                   | ✓ 동일                                                                            |
+| #756 무회귀              | ✗ 기존 셰이더 소스 수정 → planet 4종 재검증 필요                                                                                        | ✓ **`procedural-planet-shader.ts` 변경 0** — planet 4종 픽셀 불변 구조 보장                                                                                         | ✗ 파일 수정 발생                                                                  |
+| 모듈 구조 정합           | ✗                                                                                                                                       | ✓ ring/starfield/procedural-planet 과 동형 "1 모듈 = 1 셰이더군" (#756 결정 1 의 "ring 과 표면은 책임 다름" 논리 재적용 — 반사광 표면 vs 자체발광 표면은 책임 다름) | △                                                                                 |
+| 단위 테스트              | △ 미러 함수에 star 분기 혼입                                                                                                            | ✓ 독립 `sun-shader.test.ts` (sunColorMirror)                                                                                                                        | △                                                                                 |
+
+→ **B 채택**. 신규 `packages/core/src/scene/sun-shader.ts`. ring/starfield/procedural-planet 의 모듈 구조 (ShaderMaterial 팩토리 + GLSL 미러 + 상수 SSoT re-export + ShadersStore 1회 등록) 를 답습한다. `SURFACE_TYPE_BY_BODY` 에 sun 을 **등록하지 않는다** — 테이블은 "외부광 반사 표면" 전용으로 유지 (#756 결정 2 의 의미 보존). 호출부 (`createBodyMesh`/`createBodyMeshMid`) 의 기존 star 분기가 `surfaceDetail=true` 일 때 `createSunSurfaceMaterial` 을 호출한다.
+
+### 결정 2 — 표면 효과 범위: granulation + limb darkening + 색온도 (sunspot/코로나 제외)
+
+| 효과                                            | 1차 포함  | 근거                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| granulation (쌀알 무늬)                         | ✓         | fbm 고주파 변조 (starfield/planet 미러 재사용) — 이슈 핵심 요구. DoD 라플라시안 엔트로피로 측정 가능                                                                                                                                                                         |
+| limb darkening (주연 감광)                      | ✓         | μ = dot(N, viewDir) 기반 — 태양 사실감의 최대 기여 요소. 물리 근사 `I(μ) = 1 − u(1 − μ)` (Eddington 근사)                                                                                                                                                                    |
+| 색온도 그라데이션 (중심 흰노랑 → 가장자리 주황) | ✓         | **별도 색 mix 가 아닌 채널별 limb darkening 계수로 자동 도출** — 실제 물리에서 u 는 파장 함수 (blue 가 더 어두워짐: u_B > u_G > u_R). `LIMB_DARKENING_U_RGB ≈ [0.5, 0.6, 0.9]` (Allen's Astrophysical Quantities 근사) 하나로 감광 + 붉어짐 동시 달성. 상수 1묶음 = 효과 2개 |
+| sunspot (흑점)                                  | ✗ 후속    | 이슈 명시 "선택". 저주파 어두운 패치는 granulation 과 시각 혼동 → DoD 측정 기준 (엔트로피/휘도 프로파일) 오염. §재검토 조건 2                                                                                                                                                |
+| 시간 변동 granulation                           | ✗ 후속    | (a) #782 규약 — jd 를 float32 uniform 으로 넘기면 하위 비트 손실 jitter (금지, cross-validate Q3 박제). (b) 시간 변동 픽셀은 r1-guard / browser-verify 의 **결정적 스크린샷 비교를 비결정화** — 검증 인프라 정합이 우선. §재검토 조건 3                                      |
+| 코로나 / 플레어                                 | ✗ 비-범위 | 이슈 명시 권장 — disk 밖 효과는 별도 빌보드/glow 레이어 (mesh fragment 로 불가). 후속 이슈 분리 대상                                                                                                                                                                         |
+
+### 결정 3 — 자전 / painted-on (이슈 "설계 고려" — #782 정합)
+
+**실측**: `solar-system.json` 의 sun 레코드에 `rotationPeriodHours` **없음** (2026-07-03 확인 — major 9 행성 + moon 만 보유). 즉 sun 은 #782 self-rotation **비대상** 이며 `rotationStates` 에 포함되지 않는다 (mesh rotationQuaternion identity).
+
+| 축          | A. sun 에 `rotationPeriodHours` 추가 (Carrington ~609h) + granulation 자전 추종                                                                                                                             | B. 데이터 불변 — granulation 은 painted-on 정적                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 물리 사실성 | △ 실제 태양은 **차등 자전** (적도 25일 / 극 35일) — 강체 자전 데이터 1개는 이미 근사 왜곡. 게다가 실제 granule 수명은 ~10분 — 자전 추종 자체가 물리적으로 무의미 (자전 1회전 동안 granule 은 3500세대 교체) | ✓ 정적 패턴도 물리 대비 왜곡 정도는 동급 (rendering-only 근사)                          |
+| 데이터 SSoT | ✗ 데이터 파일 수정 — "데이터 0" 예측 파괴                                                                                                                                                                   | ✓ **데이터 0** 유지                                                                     |
+| 검증        | ✗ 자전 픽셀 변동 — 스크린샷 결정성 훼손                                                                                                                                                                     | ✓ 결정적                                                                                |
+| #782 규약   | 강체 근사 값 논쟁 (적도? Carrington?)                                                                                                                                                                       | ✓ 비대상 경계가 데이터 부재로 자동 표현 (#756 "테이블 미등록 = 자동 단색" 과 동형 원리) |
+
+→ **B 채택**. granulation 은 **painted-on 정적** (vLocalPos 기반 — #782 규약의 vLocalPos local 유지 원칙 그대로). 단 **vNormal 은 #782 옵션 e 규약대로 world 변환을 답습한다** — sun 은 현재 회전 identity 지만 (i) limb darkening 의 viewDir(world) 와 dot 정합에 world normal 이 필요하고 (tier scaling 은 uniform scale 이라 normalize 로 해소), (ii) 미래 sun 자전 데이터 추가 시 셰이더 무수정 안전. 태양 차등 자전의 사실적 표현은 §재검토 조건 4.
+
+### 결정 4 — emissive 메커니즘: `disableLighting` 대응 (이슈 설계 고려 3)
+
+`ShaderMaterial` 에는 `StandardMaterial.disableLighting` 개념 자체가 없다 — **씬 광원을 명시적으로 uniform 배선하지 않는 한 fragment 출력이 곧 최종색** 이다. 따라서 "emissive 전용" 은 별도 플래그가 아니라 **광원 uniform 을 선언하지 않는 것** 으로 자동 달성된다 (#756 planet 셰이더가 광원을 재현하려고 9 uniform 을 _일부러_ 주입한 것의 정확한 역방향). 태양 중심의 PointLight (`sun-light`) 는 sun mesh 내부에 있지만 ShaderMaterial 이 이를 참조하지 않으므로 간섭 0.
+
+- `gl_FragColor = vec4(baseColor × granulation × limbDarkening, 1.0)` — 알파 1 고정 (OPAQUE, 기존 star StandardMaterial 과 동일 블렌딩 특성 → 렌더 순서/투명도 정렬 무회귀)
+- `?surface=off` 시 기존 star 분기 (emissiveColor + disableLighting) 100% 복귀 — #756 결정 4 의 생성 시점 분기 메커니즘 재사용 (`surfaceDetail=false` → 셰이더 미생성)
+
+### 결정 5 — glow-marker / 줌아웃 정합 (이슈 설계 고려 2)
+
+**구조적 자동 보장** — 코드 변경 0. 근거 체인:
+
+1. sun 표면 셰이더는 **high/mid variant 에만** 적용 (#756 결정 3 동형 — 아래 결정 6)
+2. glow marker 는 `resolveGlowMarker` 판정상 `nextLevel === 'low'` (billboard) 에서만 발동 (`glow-marker.ts` L131)
+3. low variant (`createBodyBillboard`) 의 star 분기 (full emissive StandardMaterial + alpha mask) 는 **본 ADR 이 건드리지 않는다**
+4. `resolveGlowMarkerRestoreEmissiveScale('star') = 1` 원복도 low variant material 에만 작용 — high/mid ShaderMaterial 과 무관
+
+∴ 줌아웃 → LOD low 진입 → billboard 전환 → glow marker 발동의 전 경로가 현행과 동일 코드 (sun 포함 27 body 전수 계약 유지, `glowMarker` scene 옵션 주석 L409). DoD 5 가 이를 실측 재확인한다.
+
+### 결정 6 — LOD / tier 적용 범위
+
+#756 결정 3 을 그대로 답습 (동형이라 표만 요약):
+
+| variant                        | 적용                           | 근거                                                                            |
+| ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------- |
+| high (seg=32)                  | ✓ sun 셰이더                   | focus=sun 근접 관찰 대상                                                        |
+| mid (seg=12)                   | ✓ 동일 셰이더 공유             | LOD 전환 표면 연속성 (팝핑 0 — #756 qa "구조적 불가" 실증 선례)                 |
+| low (billboard)                | ✗ 현행 star full emissive 유지 | glow-marker 정합 (결정 5) + sub-pixel 에서 무의미                               |
+| tier-c (`forceOverride:'low'`) | ✗ 자동 단색                    | 전 body low 강제 → 셰이더 자동 미진입 (swiftshader fill-rate 보호, 별도 코드 0) |
+
+**fill-rate 주의** (이슈 DoD 명시): 태양은 `?focus=sun` 에서 화면 대면적 점유 — fragment 비용이 planet 대비 큰 화면 배수로 곱해진다. 예산 근거: fbm 3-옥타브 + limb darkening (dot 1회 + 채널별 1차식) 은 #756 planet fragment (fbm 3-옥타브 + 광원 모델 + 분기 4종) **이하** 비용이고, planet 은 earth focus 대면적에서 fps-baseline-guard PASS 실증. tier-c 는 구조 차단. → 1차 상수 예산으로 수용, 회귀 시 §재검토 조건 1 (detailLevel 약화 훅 — #756 과 동일한 YAGNI 예약).
+
+### 결정 7 — log-depth 정합 (이슈 설계 고려 4)
+
+ring-shader (#641 D-T2 fix) → planet-shader (#756 핵심 위험 1) 로 2회 실증된 패턴 그대로 복제: vertex 에서 `vFragmentDepth = 1.0 + clip.w`, fragment 에서 `gl_FragDepth = log2(max(vFragmentDepth, 1e-6)) × logDepthConstant × 0.5`, `logDepthConstant = 2 / log2(maxZ + 1)` (camera maxZ=1e14, 부재 시 fallback). 누락 시 태양이 수성/금성 통과 시 항상 위로 그려지는 가림 버그 — 단위 테스트가 GLSL 소스에 `gl_FragDepth` 존재를 정적 계약으로 가드.
+
+### 결정 8 — 상수 SSoT (rendering-only 미학 상수)
+
+`sun-shader.ts` 가 SSoT 소유 (starfield/planet 패턴 — export + 단위 테스트 가드). 물리 근사 출발값 (measurement-first 로 시각 튜닝 후 최종 박제 — developer 실측 재량):
+
+| 상수                   | 출발값            | 근거                                                                                                                   |
+| ---------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `LIMB_DARKENING_U_RGB` | `[0.5, 0.6, 0.9]` | 태양 가시광 limb darkening 계수 u(λ) 근사 (700nm ~0.5 / 550nm ~0.6 / 400nm ~0.85–0.9) — 감광 + 가장자리 주황 동시 달성 |
+| `GRANULATION_SCALE`    | ~48               | fbm 입력 배율 — 쌀알 크기 (화면 실측 튜닝 대상)                                                                        |
+| `GRANULATION_CONTRAST` | ~0.12             | 변조 진폭 — 실제 granule 명암 대비는 낮음 (base 색 보존 우선, #756 상수 철학 동형)                                     |
+
+`baseColor` 는 `colorHint.hex` (#FFE9A8) read-only uniform — 데이터 SSoT 불변 (#756 결정 5 동형). viewDir 용 `cameraPosition` 은 Babylon ShaderMaterial 표준 auto-bind uniform (uniforms 배열 선언 시 bind 단계에서 `scene.activeCamera.globalPosition` 자동 설정) — developer 가 dev 빌드에서 배선 실측 확인, 미동작 시 onBind 갱신 폴백 (planet uSunDirection 패턴).
+
+---
+
+## 결정 (요약)
+
+1. **모듈** — 신규 `packages/core/src/scene/sun-shader.ts` (emissive 전용, ring/starfield/planet 답습 4번째 절차 셰이더). `SURFACE_TYPE_BY_BODY` 에 sun **미등록 유지** — `procedural-planet-shader.ts` 변경 0.
+2. **효과 범위** — granulation (fbm, painted-on 정적) + limb darkening + 색온도 그라데이션 (채널별 u 계수로 자동 도출). sunspot / 시간 변동 / 코로나는 후속.
+3. **자전** — sun `rotationPeriodHours` 데이터 부재 유지 (자전 비대상, 데이터 0). vNormal 은 #782 옵션 e (world normal) 규약 답습, vLocalPos 는 local (painted-on).
+4. **emissive 메커니즘** — ShaderMaterial 은 광원 uniform 미선언으로 자동 무광 — fragment 출력 = 발광색. 알파 1 (OPAQUE).
+5. **glow-marker 정합** — low variant 불변으로 구조적 자동 보장 (변경 0). DoD 실측 재확인.
+6. **LOD/tier** — high/mid 공유, low + tier-c 자동 단색 (#756 결정 3 동형).
+7. **log-depth** — ring/planet 2회 실증 패턴 복제 (`gl_FragDepth` 로그 공간 기록).
+8. **`?surface=off` 재사용** — 신규 URL 파라미터 0. OFF = 현행 star 단색 emissive 100% 복귀.
+
+---
+
+## Visual Fidelity §의무 체크리스트 4항목 (principles.md §1)
+
+- [x] **데이터 SSoT 보존 확인** — limb/granulation 상수는 `sun-shader.ts` 의 rendering-only 상수. `solar-system.json` 직접 수정 0 (`rotationPeriodHours` sun 미추가 포함). base color 는 기존 `colorHint.hex` read-only uniform.
+- [x] **rendering 시점 분리** — physics 엔진 (Rust+wasm) 은 sun 셰이더에 의존 0. 표면 효과는 `packages/core/src/scene` 레이어 단독 — P11-A 좌표 계약 위반 0.
+- [x] **사용자 D-T2 가이드** — granulation/limb darkening 은 순수 시각 표현 (물리 근사 왜곡). Info/focus 패널은 여전히 실측값 (반경 km / temperatureK 5778 / colorSource) 표기 — 표기 대상 변경 0.
+- [x] **점유율 / 사실 비율 baseline 박제** — mesh diameter 식 불변 (머티리얼만 교체) → px diameter / 점유율 / bodyScale 단조성 (#762) 에 영향 0. r1-guard baseline 은 태양 표면 픽셀 변경분만 재생성 가능성 (qa 실측 판정).
+
+---
+
+## Concrete Prediction (구현 후 `git diff --stat` 실측 재현)
+
+| 영역                 | 파일                                       | 예측 라인 (신규/변경) | 근거                                                                                                                                                     |
+| -------------------- | ------------------------------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **core 셰이더 신설** | `sun-shader.ts` (신규)                     | ~220–320 신규         | planet (824줄) 대비 소형 — 표면 타입 1, 광원 모델 0, land/ambient uniform 0. GLSL (vertex+fragment) + 팩토리 + 상수 3묶음 + JS 미러                      |
+| **core 배선**        | `solar-system-scene.ts`                    | ~10–25 변경           | `createBodyMesh`/`createBodyMeshMid` star 분기 2곳에서 `surfaceDetail` 시 `createSunSurfaceMaterial` 호출 + import 1줄. LOD pass / tier / picking 무변경 |
+| **단위 테스트**      | `sun-shader.test.ts` (신규)                | ~100–170 신규         | 미러 결정성 / limb 단조성 / warm 색역 / 상수 SSoT / GLSL 정적 계약                                                                                       |
+| **planet 셰이더**    | `procedural-planet-shader.ts`              | **0**                 | sun 미등록 유지 (결정 1). 예측 실패 시 = 관심사 혼입 신호                                                                                                |
+| **web 레이어**       | `parse-surface-mode.ts` / `sim-canvas.tsx` | **0**                 | `?surface=off` 플래그 재사용 (결정 8). `surfaceDetail` 옵션이 이미 scene 에 도달                                                                         |
+| **데이터**           | `solar-system.json`                        | **0**                 | 자전 비대상 유지 (결정 3). 예측 실패 시 = SSoT 누수 신호                                                                                                 |
+
+**핵심 예측** (reviewer/qa 실측 대상):
+
+- **web 0 / 데이터 0 / planet 셰이더 0** — 신규 효과가 core scene 레이어 2 파일 (신규 1 + 배선 1) 로 수렴.
+- **무침범 모듈**: picking (#713 bodyId metadata 는 mesh 에 있고 불변) / camera / orbit / tier-transition / LOD pass / `glow-marker.ts` / `createBodyBillboard` — 변경 0.
+- 예측 초과 시 = sun 셰이더가 LOD/광원 레이어를 침범 (재검토).
+
+---
+
+## DoD (측정 가능 — 실 Chrome GUI 필수, CRITICAL #3 + WebGPU readback 금지 #756/#728 교훈)
+
+| #   | 기준                                                                                                                                                                              | 측정 방법                                                                                                                                             |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | granulation 실재: 태양 disk 라플라시안 고주파 엔트로피 **ON > OFF**                                                                                                               | `?focus=sun` vs `?focus=sun&surface=off` — Playwright composited screenshot + pngjs (#756 qa 방법론. WebGPU canvas drawImage readback = 빈 버퍼 금지) |
+| 2   | limb darkening: disk 반경 방향 Rec.709 휘도 프로파일 **단조 감소** + 가장자리 (r≈0.9R) / 중심 휘도비 **< 0.85**                                                                   | 스크린샷 disk 중심→가장자리 radial 샘플링                                                                                                             |
+| 3   | 색온도: 가장자리 B/R 채널비 **< 중심 B/R 채널비** (가장자리가 더 주황)                                                                                                            | 동일 radial 샘플링의 채널비 비교                                                                                                                      |
+| 4   | `?surface=off` 복귀: 태양 disk 픽셀 분산 ≈ 단색 수준 (현행 동일) + planet 4종 OFF 동작 유지                                                                                       | OFF 스크린샷 disk 내부 stddev 비교                                                                                                                    |
+| 5   | glow-marker 무회귀: 대줌아웃에서 sun glow marker 발동 유지                                                                                                                        | 기존 `browser-verify-glow-marker.mjs` 시나리오 PASS                                                                                                   |
+| 6   | fps 회귀 0: fps-baseline-guard PASS (CI swiftshader tier-c 포함) — `?focus=sun` 대면적 fill-rate                                                                                  | CI workflow                                                                                                                                           |
+| 7   | 단위 테스트: 미러 결정성 / limb 단조성 (μ↓ ⇒ 휘도↓) / warm 색역 (R ≥ B 유지 — 보라·마젠타 부재) / 상수 SSoT / GLSL 정적 계약 (if-else only·`gl_FragDepth` 존재·world normal 배선) | `sun-shader.test.ts`                                                                                                                                  |
+| 8   | 무회귀: 26 body (planet 셰이더 4 + 단색 22) 픽셀 불변 + `pnpm --filter core typecheck` 0 (#719) + r1-guard                                                                        | 기존 가드 전수                                                                                                                                        |
+| 9   | 자전 비대상 유지: `rotationStates` 에 sun 미포함 (데이터 부재로 자동)                                                                                                             | 기존 #782 단위 테스트 무회귀                                                                                                                          |
+
+---
+
+## 결과 · 재검토 조건
+
+**기대 결과**: `?focus=sun` 에서 granulation + limb darkening + 색온도 그라데이션의 사실적 태양 (실 Chrome GUI). 나머지 26 body + ring + starfield + glow-marker 무회귀. `?surface=off` 로 100% 현행 복귀.
+
+**수용한 트레이드오프**: (a) granulation 정적 (시간 변동/자전 없음) — 검증 결정성 우선. (b) sunspot/코로나 미포함 — 범위 절제. (c) 강체 자전 데이터 미추가 — 차등 자전을 강체 근사로 왜곡 박제하는 것보다 부재가 정직.
+
+**재검토 조건**:
+
+1. **fps 회귀 발생** (focus=sun 대면적 fill-rate 초과) — detailLevel 약화 훅 측정 기반 도입 (#756 재검토 1 동형).
+2. **sunspot 요구** — 저주파 fbm threshold 패치 추가 (상수 2개 + fragment ~5줄 예상). DoD 1/2 측정 기준과의 분리 방법 선행 설계.
+3. **시간 변동 granulation 요구** — jd 직접 전달 금지 (#782 규약) 유지. wrap-around 소수 시간 uniform (engine 시간 mod 주기) 설계 + r1-guard/verify 결정성 대책 (surface=off 캡처 등) 동시 필요.
+4. **태양 자전 사실 표현 요구** — 차등 자전 (위도별 각속도) 은 mesh 강체 회전으로 불가 — 셰이더 내 위도별 경도 offset 접근 검토. `rotationPeriodHours` 데이터 추가는 그때 재론.
+5. **코로나/플레어** — 별도 빌보드/glow 레이어 후속 이슈 (mesh fragment 범위 밖).
+
+---
+
+## 교차검증 반영 사항
+
+> cross-validate 대기 (Provisional) — 메인 오케스트레이터가 본 ADR 박제 직후 1회 수행 (CLAUDE.md `## 교차검증` 앵커: ADR 신규). 수행 결과 (합의 / 이견 수용 / 기각 / 고유 발견 / 편향 셀프 체크) 를 본 섹션에 통합 후 상태를 `Accepted (cross-validate YYYY-MM-DD)` 로 전이한다.
+
+**호출 전 Claude 편향 4종 셀프 체크 (초안)**: 낙관적 일정 — 해당 없음 (라인 예측은 planet 실측 기반). 결합 간과 — **주의 축**: glow-marker 정합 (결정 5) 을 "구조적 자동 보장" 으로 단정 — cross-validate 프롬프트에 명시 질문 권장. 폐기 프레이밍 — sunspot/시간 변동을 후속 유지 (재검토 조건 2·3 으로 재도입 경로 박제, 통과). 순수주의 — 채널별 u 계수의 물리 근사가 시각 튜닝 (measurement-first) 을 배제하지 않도록 결정 8 에 developer 재량 명시 (통과).
+
+## 참고
+
+- 이슈: [#774](https://github.com/coseo12/astro-simulator/issues/774) / 선행: [#756](https://github.com/coseo12/astro-simulator/issues/756), [#782](https://github.com/coseo12/astro-simulator/issues/782)
+- 선행 ADR: [`20260628-756-procedural-planet-surface.md`](20260628-756-procedural-planet-surface.md) (결정 1–5 + Amendment 1–2), [`20260613-675-glow-pixel-marker.md`](20260613-675-glow-pixel-marker.md), [`20260624-738-procedural-starfield.md`](20260624-738-procedural-starfield.md)
+- 횡단 원칙: [`docs/architecture/principles.md`](../architecture/principles.md) §1 Visual Fidelity
+- limb darkening 물리 근거: Eddington 근사 `I(μ)/I(1) = 1 − u(1−μ)`, u(λ) 파장 의존 (Allen's Astrophysical Quantities)

--- a/packages/core/src/scene/solar-system-scene.ts
+++ b/packages/core/src/scene/solar-system-scene.ts
@@ -34,6 +34,10 @@ import {
   createProceduralPlanetMaterial,
   type PlanetLightingConstants,
 } from './procedural-planet-shader.js';
+// #774 — 태양 emissive 절차 표면 셰이더 (granulation + limb darkening + 색온도).
+// ADR `docs/decisions/20260703-774-sun-emissive-shader.md` §결정 1 — SURFACE_TYPE_BY_BODY 미등록
+// 유지 (테이블은 "외부광 반사 표면" 전용), star 분기가 직접 본 팩토리 호출.
+import { createSunSurfaceMaterial } from './sun-shader.js';
 import {
   renderScaleForTier,
   initialTier as defaultInitialTier,
@@ -2112,10 +2116,14 @@ function createBodyMesh(
   const mesh = MeshBuilder.CreateSphere(body.id, { diameter, segments: 32 }, scene);
 
   // #756 — 절차적 표면 셰이더 (surfaceDetail=true + 테이블 등록 body 만). 미등록/OFF 면 null →
-  // 기존 StandardMaterial 경로 (단색, 무회귀). 항성(sun)은 표면 테이블 미등록이라 자동 단색.
+  // 기존 StandardMaterial 경로 (단색, 무회귀).
   // ADR `docs/decisions/20260628-756-procedural-planet-surface.md` §결정 1·4 + Amendment 1 (#773).
+  // #774 — 항성(star)은 emissive 전용 sun 셰이더 (광원 인자 불요 — ADR 20260703-774 §결정 1·4).
+  // `?surface=off` (surfaceDetail=false) 면 기존 star 단색 emissive 100% 복귀 (§결정 8).
   const surfaceMat = surfaceDetail
-    ? createProceduralPlanetMaterial(scene, body, `${body.id}-surface-mat`, surfaceLighting ?? {})
+    ? body.kind === 'star'
+      ? createSunSurfaceMaterial(scene, body, `${body.id}-surface-mat`)
+      : createProceduralPlanetMaterial(scene, body, `${body.id}-surface-mat`, surfaceLighting ?? {})
     : null;
   if (surfaceMat) {
     mesh.material = surfaceMat;
@@ -2166,13 +2174,16 @@ function createBodyMeshMid(
   // #756 — mid variant 도 high 와 동일 절차 셰이더 공유 (segments 만 다름 — ADR §결정 1).
   // LOD 전환 시 표면 연속성 (사용자 인지 불변). 미등록/OFF 면 null → StandardMaterial 무회귀.
   // #773 Amendment 1 — 동일 광원 인자 (high/mid 명암 일관 — 각 variant 의 onBind 가 자기 sunDir 갱신).
+  // #774 — 항성(star)은 high 와 동일 sun 셰이더 공유 (팝핑 0 — ADR 20260703-774 §결정 6).
   const surfaceMat = surfaceDetail
-    ? createProceduralPlanetMaterial(
-        scene,
-        body,
-        `${body.id}-lod-mid-surface-mat`,
-        surfaceLighting ?? {},
-      )
+    ? body.kind === 'star'
+      ? createSunSurfaceMaterial(scene, body, `${body.id}-lod-mid-surface-mat`)
+      : createProceduralPlanetMaterial(
+          scene,
+          body,
+          `${body.id}-lod-mid-surface-mat`,
+          surfaceLighting ?? {},
+        )
     : null;
   if (surfaceMat) {
     mesh.material = surfaceMat;

--- a/packages/core/src/scene/sun-shader.test.ts
+++ b/packages/core/src/scene/sun-shader.test.ts
@@ -1,0 +1,269 @@
+/**
+ * #774 — 태양 emissive 절차 표면 셰이더 단위 테스트.
+ *
+ * 검증 축 (ADR `docs/decisions/20260703-774-sun-emissive-shader.md` §DoD 7):
+ *   1. GLSL↔JS 미러 결정성 (동일 입력 동일 출력).
+ *   2. limb darkening 단조성 (μ↓ ⇒ 휘도↓ — Eddington 근사).
+ *   3. warm 색역 (R ≥ B 유지 — 보라·마젠타 부재, starfield/planet anti-pattern 가드 동형).
+ *   4. 상수 SSoT drift 가드 (LIMB_DARKENING_U_RGB / GRANULATION_SCALE / GRANULATION_CONTRAST).
+ *   5. GLSL 정적 계약 — switch 부재 (if-else only) / gl_FragDepth 존재 (log-depth §결정 7) /
+ *      world normal 배선 (#782 옵션 e §결정 3) / 광원 uniform 부재 (emissive 전용 §결정 4) /
+ *      noise 텍스트 planet 동일성 (fbmMirror 재사용 계약).
+ *   6. 색온도 그라데이션 — 가장자리 B/R 채널비 < 중심 B/R (§결정 2 — 채널별 u 자동 도출).
+ *   7. SURFACE_TYPE_BY_BODY sun 미등록 유지 (§결정 1 — planet 테이블 "외부광 반사" 전용).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  LIMB_DARKENING_U_RGB,
+  GRANULATION_SCALE,
+  GRANULATION_CONTRAST,
+  limbDarkeningMirror,
+  sunColorMirror,
+  SUN_VERTEX_SHADER,
+  SUN_FRAGMENT_SHADER,
+} from './sun-shader.js';
+import {
+  SURFACE_TYPE_BY_BODY,
+  luminance709,
+  PLANET_FRAGMENT_SHADER,
+} from './procedural-planet-shader.js';
+
+/** 태양 실측 base 발광색 (colorHint.hex #FFE9A8 — 데이터 SSoT read-only). */
+const SUN_BASE: readonly [number, number, number] = [1.0, 233 / 255, 168 / 255];
+
+/** 구면 표면점 샘플 생성 (정규화 단위 벡터). */
+function spherePoint(t: number): [number, number, number] {
+  const x = Math.sin(t * 1.7) * Math.cos(t);
+  const y = Math.cos(t * 0.9);
+  const z = Math.sin(t * 0.5) * Math.sin(t);
+  const len = Math.hypot(x, y, z) || 1;
+  return [x / len, y / len, z / len];
+}
+
+describe('#774 sun-shader — GLSL↔JS 미러 결정성 (ADR §DoD 7)', () => {
+  it('sunColorMirror: 동일 입력 동일 출력 (결정성)', () => {
+    const p: [number, number, number] = [0.3, 0.6, 0.74];
+    expect(sunColorMirror(SUN_BASE, p, 0.7)).toEqual(sunColorMirror(SUN_BASE, p, 0.7));
+  });
+
+  it('limbDarkeningMirror: 동일 입력 동일 출력 + μ 범위 밖 clamp (GLSL clamp 정합)', () => {
+    expect(limbDarkeningMirror(0.5)).toEqual(limbDarkeningMirror(0.5));
+    // GLSL `clamp(dot(N, viewDir), 0.0, 1.0)` 과 동일 — 범위 밖 입력이 경계값으로 수렴.
+    expect(limbDarkeningMirror(-0.3)).toEqual(limbDarkeningMirror(0));
+    expect(limbDarkeningMirror(1.7)).toEqual(limbDarkeningMirror(1));
+  });
+
+  it('sunColorMirror: 출력 [0,1] 범위 (clamp 보장 — 다수 표면점 × μ 전수)', () => {
+    for (let i = 0; i < 100; i++) {
+      const p = spherePoint(i * 0.0628);
+      const mu = (i % 11) / 10;
+      for (const c of sunColorMirror(SUN_BASE, p, mu)) {
+        expect(c).toBeGreaterThanOrEqual(0);
+        expect(c).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+describe('#774 sun-shader — limb darkening 단조성 (μ↓ ⇒ 휘도↓, ADR §결정 2)', () => {
+  it('Eddington 근사 — μ 1→0 감소 시 휘도 strict 단조 감소', () => {
+    // granulation 제외 (limb 만) — 고정 표면점에서 μ 만 변화시켜 limb 항 단조성 격리 검증.
+    const lums: number[] = [];
+    for (let i = 10; i >= 0; i--) {
+      const mu = i / 10; // 1.0 (중심) → 0.0 (가장자리)
+      lums.push(luminance709(limbDarkeningMirror(mu)));
+    }
+    for (let i = 1; i < lums.length; i++) {
+      const cur = lums[i] ?? Number.NaN;
+      const prev = lums[i - 1] ?? Number.NaN;
+      expect(cur).toBeLessThan(prev); // strict (1차식 — plateau 없음)
+    }
+  });
+
+  it('가장자리 (r≈0.9R, μ≈0.436) / 중심 휘도비 < 0.85 (ADR §DoD 2 미러 사전 검증)', () => {
+    // disk 반경 r/R = sin(θ) → μ = cos(θ) = √(1 − (r/R)²). r=0.9R → μ ≈ 0.436.
+    const muEdge = Math.sqrt(1 - 0.9 * 0.9);
+    const center = luminance709([
+      SUN_BASE[0] * limbDarkeningMirror(1)[0],
+      SUN_BASE[1] * limbDarkeningMirror(1)[1],
+      SUN_BASE[2] * limbDarkeningMirror(1)[2],
+    ]);
+    const edge = luminance709([
+      SUN_BASE[0] * limbDarkeningMirror(muEdge)[0],
+      SUN_BASE[1] * limbDarkeningMirror(muEdge)[1],
+      SUN_BASE[2] * limbDarkeningMirror(muEdge)[2],
+    ]);
+    expect(edge / center).toBeLessThan(0.85);
+    expect(edge / center).toBeGreaterThan(0.3); // 완전 소등 아님 (u ≤ 1 — disk 가장자리 가시 유지)
+  });
+
+  it('중심 (μ=1) 은 감광 0 — limb = [1,1,1] (base 발광색 보존)', () => {
+    expect(limbDarkeningMirror(1)).toEqual([1, 1, 1]);
+  });
+
+  it('granulation 포함 (sunColorMirror) 에서도 μ 감소 추세 유지 (변조 진폭 < limb 격차)', () => {
+    // 동일 표면점 고정 — granulation 은 상수, μ 만 변화 → limb 단조가 그대로 드러남.
+    const p = spherePoint(1.234);
+    const lumCenter = luminance709(sunColorMirror(SUN_BASE, p, 1));
+    const lumEdge = luminance709(sunColorMirror(SUN_BASE, p, 0.1));
+    expect(lumEdge).toBeLessThan(lumCenter);
+  });
+});
+
+describe('#774 sun-shader — warm 색역 (R ≥ B — 보라·마젠타 부재, ADR §DoD 7)', () => {
+  it('다수 표면점 × μ 전수 — 출력 R ≥ B (u_R < u_B 라 limb 가 warm 방향으로만 이동)', () => {
+    // base (#FFE9A8) 는 R > G > B. limb 는 B 를 더 감광 (u_B > u_R) → R ≥ B 구조 보장.
+    // granulation 은 채널 공통 스칼라 곱이라 채널 순서 불변.
+    let violations = 0;
+    for (let i = 0; i < 200; i++) {
+      const p = spherePoint(i * 0.0314);
+      const mu = (i % 11) / 10;
+      const [r, , b] = sunColorMirror(SUN_BASE, p, mu);
+      if (r < b - 1e-9) violations++;
+    }
+    expect(violations).toBe(0);
+  });
+
+  it('보라/마젠타 부재 — G ≥ min(R,B) 위배 없음 (planet/starfield anti-pattern 가드 동형)', () => {
+    let violations = 0;
+    for (let i = 0; i < 200; i++) {
+      const p = spherePoint(i * 0.0314);
+      const mu = (i % 11) / 10;
+      const [r, g, b] = sunColorMirror(SUN_BASE, p, mu);
+      if (g < Math.min(r, b) - 1e-9) violations++;
+    }
+    expect(violations).toBe(0);
+  });
+
+  it('granulation 변조가 실재 (단색 아님 — 표면점 간 출력 분산 > 0)', () => {
+    const samples: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      samples.push(luminance709(sunColorMirror(SUN_BASE, spherePoint(i * 0.13), 1)));
+    }
+    const spread = Math.max(...samples) - Math.min(...samples);
+    expect(spread).toBeGreaterThan(0.01); // 변조 진폭 0 이면 feature 무의미
+  });
+});
+
+describe('#774 sun-shader — 색온도 그라데이션 (가장자리 B/R < 중심 B/R, ADR §DoD 3 미러)', () => {
+  it('채널별 u 계수만으로 가장자리가 더 주황 (별도 색 mix 없이 자동 도출 — §결정 2)', () => {
+    const p = spherePoint(0.777);
+    const [rC, , bC] = sunColorMirror(SUN_BASE, p, 1); // 중심
+    const [rE, , bE] = sunColorMirror(SUN_BASE, p, 0.1); // 가장자리
+    expect(bE / rE).toBeLessThan(bC / rC);
+  });
+
+  it('u 계수 파장 순서 — u_R < u_G < u_B (blue 가 더 감광 = warm 그라데이션의 구조 전제)', () => {
+    expect(LIMB_DARKENING_U_RGB[0]).toBeLessThan(LIMB_DARKENING_U_RGB[1]);
+    expect(LIMB_DARKENING_U_RGB[1]).toBeLessThan(LIMB_DARKENING_U_RGB[2]);
+  });
+});
+
+describe('#774 sun-shader — 상수 SSoT (#69 drift 가드)', () => {
+  it('rendering-only 미학 상수 박제값 (measurement-first — drift 시 시각 회귀)', () => {
+    expect(LIMB_DARKENING_U_RGB).toEqual([0.5, 0.6, 0.9]);
+    expect(GRANULATION_SCALE).toBe(48);
+    expect(GRANULATION_CONTRAST).toBe(0.12);
+  });
+
+  it('u 계수 유효 범위 (0 < u ≤ 1 — limb ≥ 0 구조 보장, 완전 소등 방지)', () => {
+    for (const u of LIMB_DARKENING_U_RGB) {
+      expect(u).toBeGreaterThan(0);
+      expect(u).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('granulation 진폭은 base 를 묻지 않는 합리 범위 (0 < contrast < 0.5 — #756 상수 철학)', () => {
+    expect(GRANULATION_CONTRAST).toBeGreaterThan(0);
+    expect(GRANULATION_CONTRAST).toBeLessThan(0.5);
+  });
+
+  it('GLSL fragment 에 상수 uniform 선언 존재 (미러와 동기)', () => {
+    expect(SUN_FRAGMENT_SHADER).toContain('uniform vec3 limbDarkeningU');
+    expect(SUN_FRAGMENT_SHADER).toContain('uniform float granulationScale');
+    expect(SUN_FRAGMENT_SHADER).toContain('uniform float granulationContrast');
+    expect(SUN_FRAGMENT_SHADER).toContain('uniform vec3 baseColor');
+  });
+});
+
+describe('#774 sun-shader — GLSL 정적 계약 (ADR §DoD 7)', () => {
+  it('switch 키워드 부재 — if-else only (WGSL 변환 깨짐 차단, #756 이견 수용 1)', () => {
+    expect(SUN_FRAGMENT_SHADER).not.toMatch(/\bswitch\b/);
+    expect(SUN_VERTEX_SHADER).not.toMatch(/\bswitch\b/);
+  });
+
+  it('log-depth — fragment 가 gl_FragDepth 를 로그 공간으로 기록 (§결정 7, ring #641 정합)', () => {
+    expect(SUN_FRAGMENT_SHADER).toContain('gl_FragDepth');
+    expect(SUN_FRAGMENT_SHADER).toContain('logDepthConstant');
+  });
+
+  it('log-depth — vertex 가 vFragmentDepth = 1.0 + clip.w 전달 (Babylon logDepth 공식)', () => {
+    expect(SUN_VERTEX_SHADER).toContain('vFragmentDepth');
+    expect(SUN_VERTEX_SHADER).toMatch(/vFragmentDepth\s*=\s*1\.0\s*\+/);
+  });
+
+  it('world normal 배선 (#782 옵션 e 규약 답습 — §결정 3)', () => {
+    expect(SUN_VERTEX_SHADER).toContain('uniform mat4 world');
+    expect(SUN_VERTEX_SHADER).toContain('vNormal = normalize((world * vec4(normal, 0.0)).xyz)');
+    // uniform scale 전제 — normalMatrix 도입은 비균일 scale 전환 신호 (planet 계약 동형).
+    expect(SUN_VERTEX_SHADER).not.toContain('uniform mat3 normalMatrix');
+  });
+
+  it('vLocalPos 는 local 유지 (painted-on granulation — §결정 3, world 변환 금지)', () => {
+    expect(SUN_VERTEX_SHADER).toContain('vLocalPos = normalize(position)');
+  });
+
+  it('viewDir 배선 — vWorldPos varying + cameraPosition auto-bind uniform (§결정 8)', () => {
+    expect(SUN_VERTEX_SHADER).toContain('vWorldPos = (world * vec4(position, 1.0)).xyz');
+    expect(SUN_FRAGMENT_SHADER).toContain('uniform vec3 cameraPosition');
+    expect(SUN_FRAGMENT_SHADER).toContain('normalize(cameraPosition - vWorldPos)');
+    expect(SUN_FRAGMENT_SHADER).toMatch(/clamp\(dot\(N,\s*viewDir\),\s*0\.0,\s*1\.0\)/);
+  });
+
+  it('emissive 전용 — 광원 uniform 부재 (§결정 4, planet 광원 모델의 역방향)', () => {
+    // planet 셰이더의 광원 uniform 9종이 하나도 선언되지 않아야 한다 (외부광 무간섭 = 자동 무광).
+    for (const lightUniform of [
+      'uSunDirection',
+      'sunIntensity',
+      'sunDiffuse',
+      'ambientIntensity',
+      'ambientGround',
+      'ambientSky',
+      'ambientUp',
+      'softTerminatorWidth',
+    ]) {
+      expect(SUN_FRAGMENT_SHADER).not.toContain(lightUniform);
+    }
+  });
+
+  it('Eddington 근사 식 존재 — vec3(1.0) − limbDarkeningU × (1 − μ) (미러와 동일 식)', () => {
+    expect(SUN_FRAGMENT_SHADER).toContain('vec3(1.0) - limbDarkeningU * (1.0 - mu)');
+  });
+});
+
+describe('#774 sun-shader — noise 텍스트 planet 동일성 (fbmMirror 재사용 계약)', () => {
+  // JS 미러는 procedural-planet-shader 의 fbmMirror 를 재사용한다 (volt #21 중복 구현 금지).
+  // 전제: sun GLSL 의 hash33/valueNoise/fbm 이 planet GLSL 과 동일 텍스트. 갈라지면 미러가
+  // 한쪽과 어긋난다 (조용한 drift) — 핵심 식 라인 동일성을 정적 계약으로 가드.
+
+  const NOISE_CONTRACT_LINES = [
+    'p = fract(p * vec3(0.1031, 0.1030, 0.0973));', // hash33 시드
+    'p += dot(p, p.yxz + 33.33);', // hash33 mix
+    'vec3 u = f * f * (3.0 - 2.0 * f);', // valueNoise smoothstep 보간
+    '0.55 * valueNoise(p) + 0.30 * valueNoise(p * 2.3) + 0.15 * valueNoise(p * 4.7)', // fbm 3-옥타브
+  ];
+
+  for (const line of NOISE_CONTRACT_LINES) {
+    it(`핵심 식 동일 존재 — ${line.slice(0, 40)}…`, () => {
+      expect(SUN_FRAGMENT_SHADER).toContain(line);
+      expect(PLANET_FRAGMENT_SHADER).toContain(line);
+    });
+  }
+});
+
+describe('#774 sun-shader — SURFACE_TYPE_BY_BODY sun 미등록 유지 (ADR §결정 1)', () => {
+  it('planet 테이블에 sun 부재 — 테이블은 "외부광 반사 표면" 전용 (procedural-planet 변경 0)', () => {
+    expect(SURFACE_TYPE_BY_BODY.sun).toBeUndefined();
+  });
+});

--- a/packages/core/src/scene/sun-shader.ts
+++ b/packages/core/src/scene/sun-shader.ts
@@ -1,0 +1,384 @@
+/**
+ * #774 — 태양 emissive 절차 표면 셰이더 (granulation + limb darkening + 색온도 그라데이션).
+ *
+ * **목적**: 단색 emissive disk (`StandardMaterial.emissiveColor + disableLighting`) 로만 렌더되는
+ * 태양에 사실적 표면 디테일을 부여한다 (방향성 기획 트랙 A — `principles.md §1 Visual Fidelity`,
+ * #756 절차적 행성 표면의 직접 후속). 외부 텍스처 에셋 / 신규 라이브러리 0. ring/starfield/
+ * procedural-planet 의 절차적 ShaderMaterial 구조를 답습한 **4번째 절차 셰이더 모듈**이다.
+ *
+ * **설계 근거**: ADR `docs/decisions/20260703-774-sun-emissive-shader.md`
+ *   - §결정 1 — 신규 독립 모듈. `SURFACE_TYPE_BY_BODY` 에 sun **미등록 유지** (테이블은 "외부광
+ *     반사 표면" 전용 — `procedural-planet-shader.ts` 변경 0). 호출부 star 분기가 직접 본 팩토리 호출.
+ *   - §결정 2 — granulation (fbm) + limb darkening (Eddington 근사 `I(μ) = 1 − u(1−μ)`) + 색온도
+ *     그라데이션 (채널별 u 계수로 자동 도출 — 실물리에서 u 는 파장 함수, blue 가 더 감광 →
+ *     가장자리가 자동으로 주황). sunspot / 시간 변동 / 코로나는 후속 (§재검토 조건 2·3·5).
+ *   - §결정 3 — granulation 은 **painted-on 정적** (vLocalPos local — #782 규약). sun 은
+ *     `rotationPeriodHours` 데이터 부재로 self-rotation 비대상 (데이터 0 유지). 단 vNormal 은
+ *     #782 옵션 e (world normal) 규약 답습 — limb darkening viewDir(world) dot 정합 + 미래
+ *     자전 데이터 추가 시 셰이더 무수정 안전.
+ *   - §결정 4 — **emissive 전용**: ShaderMaterial 은 광원 uniform 을 선언하지 않으면 fragment
+ *     출력이 곧 최종색 (`disableLighting` 개념 자체가 불필요 — 자동 무광). planet 셰이더가 광원
+ *     재현을 위해 9 uniform 을 일부러 주입한 것의 정확한 역방향. 알파 1 고정 (OPAQUE — 기존
+ *     star StandardMaterial 과 동일 블렌딩 특성, 렌더 순서 무회귀). 태양 중심 PointLight
+ *     (`sun-light`) 는 본 셰이더가 참조하지 않으므로 간섭 0.
+ *   - §결정 6 — high/mid 동일 셰이더 공유 (팝핑 0 — #756 실증), low (billboard) + tier-c
+ *     (`forceOverride:'low'`) 는 현행 star full emissive 유지 (별도 코드 0 — glow-marker 정합 §결정 5).
+ *   - §결정 7 — log-depth 정합: ring (#641) / planet (#756) 2회 실증 패턴 복제 (`gl_FragDepth`
+ *     로그 공간 기록). 누락 시 태양이 수성/금성 통과 시 항상 위로 그려지는 가림 버그.
+ *   - §결정 8 — 상수 SSoT 는 본 모듈 소유 (rendering-only 미학 상수 — 데이터 SSoT 무관).
+ *     baseColor 는 `colorHint.hex` read-only uniform (#756 결정 5 동형).
+ *
+ * **viewDir 배선 (`cameraPosition`)**: Babylon ShaderMaterial 표준 auto-bind uniform — uniforms
+ *   배열에 'cameraPosition' 선언 시 bind 단계에서 `scene.activeCamera.globalPosition` 자동 설정
+ *   (shaderMaterial.js `_options.uniforms.indexOf("cameraPosition")` — v8.56/v9.2 동일 확인).
+ *   런타임 확증은 limb darkening radial 프로파일 실측 (미동작이면 프로파일이 평탄해져 즉시 노출).
+ *
+ * ⚠️ **noise 미러 계약 (drift 가드)**: 본 GLSL 의 hash33/valueNoise/fbm 은
+ *   `procedural-planet-shader.ts` GLSL 과 **동일 텍스트**여야 한다 — JS 미러는 그쪽의
+ *   `fbmMirror` 를 재사용하므로 (volt #21 중복 구현 금지), GLSL 텍스트가 갈라지면 미러가
+ *   양쪽 중 한쪽과 어긋난다. sun-shader.test.ts 가 핵심 식 동일성을 정적 계약으로 가드.
+ *
+ * **WebGPU↔WebGL parity**: GLSL 은 양 백엔드 동작 (Babylon GLSL→WGSL 변환 — ring/starfield/
+ *   planet 선례). **switch-case 금지** (WGSL 변환 깨짐 — #756 이견 수용 1), if-else 만 사용.
+ */
+
+import { Color3, Effect, ShaderMaterial, Vector3, type Scene } from '@babylonjs/core';
+import type { LoadedCelestialBody } from '../ephemeris/solar-system-loader.js';
+import { fbmMirror } from './procedural-planet-shader.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rendering-only 미학 상수 SSoT (#69 숨은 상수 drift 차단 — sun-shader.test.ts 가드 대상).
+// 데이터 SSoT 아님 (`solar-system.json` 무관). 출발값은 물리 근사, 최종값은 measurement-first
+// 화면 실측 튜닝으로 박제 (ADR §결정 8 — developer 재량).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 채널별 limb darkening 계수 u(λ) — Eddington 근사 `I(μ) = 1 − u(1−μ)` 의 u 를 RGB 로 분리.
+ *
+ * 실물리에서 u 는 파장 함수다 (Allen's Astrophysical Quantities 근사 — 700nm ~0.5 / 550nm ~0.6 /
+ * 400nm ~0.85–0.9). blue 가 더 어두워지므로 **감광 + 가장자리 주황 (색온도 그라데이션) 을 상수
+ * 1묶음으로 동시 달성** (ADR §결정 2 — 별도 색 mix 불요). u_R < u_G < u_B 순서가 warm 색역
+ * (가장자리 B/R 비 감소) 의 구조적 전제 — 테스트가 순서를 가드.
+ */
+export const LIMB_DARKENING_U_RGB = [0.5, 0.6, 0.9] as const;
+
+/**
+ * granulation fbm 입력 배율 — 쌀알(granule) 크기. 클수록 촘촘.
+ * 단위 구면 좌표 × SCALE 이 fbm 격자 입력 — 48 이면 disk 지름 방향 ~96 셀 (실제 태양 광구의
+ * "쌀알" 인상 재현, 화면 실측 튜닝 결과 출발값 유지 — PR 본문 근거 박제).
+ */
+export const GRANULATION_SCALE = 48;
+
+/**
+ * granulation 변조 진폭 (±). 실제 granule 명암 대비는 낮다 (~수 %) — base 색 (colorHint.hex
+ * #FFE9A8 실측) 보존 우선 (#756 상수 철학 동형). 0 이면 단색과 동일, 과도하면 base 가 묻힘.
+ */
+export const GRANULATION_CONTRAST = 0.12;
+
+/** shader 이름 prefix — ShadersStore key 충돌 방지 (ring/starfield/planet 패턴 답습). */
+const SHADER_NAME = 'sunSurface';
+
+/**
+ * GLSL vertex shader — local position (granulation 기준) + world normal / world position
+ * (limb darkening 기준) 을 fragment 로 전달.
+ *
+ * **vLocalPos = local 구면 좌표** — granulation 패턴의 기준 (painted-on — ADR §결정 3).
+ * tier scale / floating-origin shift 에 표면 패턴이 mesh 와 함께 움직인다. world 변환 금지.
+ *
+ * **vNormal = world normal (#782 옵션 e 규약 답습)** — `normalize((world * vec4(normal,0)).xyz)`.
+ * limb darkening 의 viewDir(world) 와 dot 정합에 필요. sun 은 현재 회전 identity 지만 미래
+ * 자전 데이터 추가 시 셰이더 무수정 안전. uniform scale 전제라 world 곱 후 normalize 로 충분
+ * (normalMatrix inverse-transpose 불요 — planet Amendment 2 cross-validate Q2 합의 동형).
+ *
+ * **vWorldPos** — viewDir = normalize(cameraPosition − vWorldPos) 용 (per-fragment 정확 시선각.
+ * floating-origin 으로 sun 이 원점 근처지만 focus=sun 근접 시 disk 가 대면적이라 per-vertex
+ * 근사 대신 per-fragment 로 μ 프로파일 정확도 확보).
+ *
+ * log-depth 를 위해 clip-space w 도 전달 (ring #641 / planet #756 선례 — ADR §결정 7).
+ */
+const VERTEX_SHADER = /* glsl */ `
+precision highp float;
+
+attribute vec3 position;
+attribute vec3 normal;
+
+uniform mat4 worldViewProjection;
+// #782 옵션 e 규약 답습 — world matrix (Babylon auto-bind). vNormal 을 world 공간으로 변환해
+// viewDir(world) 와 dot 정합 (limb darkening μ). uniform scale + 순수 회전이라 world 곱 후
+// normalize 로 충분. ⚠️ jd/큰 수 uniform 은 넘기지 않는다 (float32 jitter 차단 — #782 규약).
+uniform mat4 world;
+
+varying vec3 vLocalPos;
+varying vec3 vNormal;
+varying vec3 vWorldPos;
+// ADR §결정 7 — 로그 depth: scene 이 enableLogarithmicDepth 로 StandardMaterial(다른 body)을
+// 로그 depth 공간에 기록하는데, 커스텀 ShaderMaterial 이 표준 z 를 쓰면 depth 비교 공간이
+// 불일치 → 태양이 수성/금성 통과 시 항상 위로 그려진다. fragment 에서 gl_FragDepth 를 로그
+// 공간으로 기록한다 (ring #641 / planet #756 실증 패턴 복제).
+varying float vFragmentDepth;
+
+void main(void) {
+  // local 구면 좌표 — granulation 패턴의 기준 (painted-on, ADR §결정 3 — world 변환 금지).
+  vLocalPos = normalize(position);
+  // #782 옵션 e — world normal (limb darkening viewDir 와 동일 world 좌표계 dot 정합). w=0 으로
+  // 변환해 translation 무시 (방향 벡터), uniform scale 이므로 normalize 로 스케일 정규화.
+  vNormal = normalize((world * vec4(normal, 0.0)).xyz);
+  // world position — per-fragment viewDir 계산 기준 (cameraPosition − vWorldPos).
+  vWorldPos = (world * vec4(position, 1.0)).xyz;
+  vec4 clip = worldViewProjection * vec4(position, 1.0);
+  gl_Position = clip;
+  vFragmentDepth = 1.0 + clip.w;
+}
+`;
+
+/**
+ * GLSL fragment shader — emissive 전용: base 발광색 × granulation × limb darkening.
+ *
+ * **광원 uniform 0 (ADR §결정 4)** — 씬 광원을 참조하지 않으므로 fragment 출력이 곧 발광색
+ * (자동 무광). planet 셰이더의 shade(외부광 재현) 합성이 **의도적으로 없다** — 태양은
+ * self-luminous 라 외부광 명암이 무의미 (태양 자신이 그 PointLight 의 광원).
+ *
+ * uniforms:
+ *   - baseColor: 실측 색 (colorHint.hex #FFE9A8) — 발광의 기준 (데이터 SSoT, read-only).
+ *   - limbDarkeningU: 채널별 u 계수 (감광 + 색온도 동시 — LIMB_DARKENING_U_RGB SSoT).
+ *   - granulationScale / granulationContrast: 쌀알 크기/진폭 (rendering-only 미학 상수 SSoT).
+ *   - cameraPosition: Babylon 표준 auto-bind (viewDir 용 — scene.activeCamera.globalPosition).
+ *   - logDepthConstant: Babylon logDepth 정합 상수 (ADR §결정 7).
+ *
+ * **switch-case 금지** (WGSL 변환 깨짐 — #756 이견 수용 1). 분기 자체가 없는 단일 경로 셰이더.
+ */
+const FRAGMENT_SHADER = /* glsl */ `
+precision highp float;
+
+varying vec3 vLocalPos;
+varying vec3 vNormal;
+varying vec3 vWorldPos;
+varying float vFragmentDepth;
+
+uniform vec3 baseColor;
+uniform vec3 limbDarkeningU;
+uniform float granulationScale;
+uniform float granulationContrast;
+uniform vec3 cameraPosition;
+uniform float logDepthConstant;
+
+// 3D hash — sin-free fract-mix (procedural-planet-shader.ts 와 동일 텍스트 — JS 미러 fbmMirror
+// 재사용 계약. 한쪽 수정 시 양쪽 + 미러 동기화 의무, sun-shader.test.ts 정적 가드).
+vec3 hash33(vec3 p) {
+  p = fract(p * vec3(0.1031, 0.1030, 0.0973));
+  p += dot(p, p.yxz + 33.33);
+  return fract((p.xxy + p.yxx) * p.zyx);
+}
+
+float hash13(vec3 p) {
+  return hash33(p).x;
+}
+
+// 3D value noise — trilinear smoothstep 보간 (planet/starfield 와 동일 텍스트).
+float valueNoise(vec3 p) {
+  vec3 i = floor(p);
+  vec3 f = fract(p);
+  vec3 u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(
+      mix(hash13(i + vec3(0.0, 0.0, 0.0)), hash13(i + vec3(1.0, 0.0, 0.0)), u.x),
+      mix(hash13(i + vec3(0.0, 1.0, 0.0)), hash13(i + vec3(1.0, 1.0, 0.0)), u.x),
+      u.y
+    ),
+    mix(
+      mix(hash13(i + vec3(0.0, 0.0, 1.0)), hash13(i + vec3(1.0, 0.0, 1.0)), u.x),
+      mix(hash13(i + vec3(0.0, 1.0, 1.0)), hash13(i + vec3(1.0, 1.0, 1.0)), u.x),
+      u.y
+    ),
+    u.z
+  );
+}
+
+// 3-옥타브 fbm — granulation 결 (planet 셰이더와 동일 텍스트 — fbmMirror 계약).
+float fbm(vec3 p) {
+  return 0.55 * valueNoise(p) + 0.30 * valueNoise(p * 2.3) + 0.15 * valueNoise(p * 4.7);
+}
+
+void main(void) {
+  vec3 p = normalize(vLocalPos);
+  vec3 N = normalize(vNormal);
+
+  // ── limb darkening (ADR §결정 2) — Eddington 근사 I(μ) = 1 − u(1−μ) ──────────
+  // μ = dot(N, viewDir): disk 중심 1 → 가장자리 0. 채널별 u (u_R < u_G < u_B) 로 blue 가
+  // 더 감광 → 가장자리가 자동으로 주황 (색온도 그라데이션 — 별도 색 mix 불요).
+  vec3 viewDir = normalize(cameraPosition - vWorldPos);
+  float mu = clamp(dot(N, viewDir), 0.0, 1.0);
+  vec3 limb = vec3(1.0) - limbDarkeningU * (1.0 - mu);
+
+  // ── granulation (ADR §결정 2·3) — painted-on 정적 fbm 변조 (vLocalPos 기준) ──
+  // (fbm − 0.5) × 2 × contrast — 평균 0 근처 변조로 base 발광색 보존 (#756 상수 철학).
+  float granule = fbm(p * granulationScale);
+  float granulation = 1.0 + (granule - 0.5) * 2.0 * granulationContrast;
+
+  // emissive 합성 — 광원 shade 없음 (ADR §결정 4). 출력이 곧 발광색.
+  vec3 col = baseColor * granulation * limb;
+  // 안전 clamp — u ≤ 1 이라 limb ≥ 0 구조 보장이지만 granulation 상향 변조 (>1) 의 [0,1]
+  // 이탈만 보정 (흰색 saturate — warm 색역 유지, 테스트 가드).
+  col = clamp(col, 0.0, 1.0);
+
+  gl_FragColor = vec4(col, 1.0);
+
+  // ADR §결정 7 — 본체(StandardMaterial useLogarithmicDepth)와 동일한 로그 depth 공간 기록.
+  gl_FragDepth = log2(max(vFragmentDepth, 1e-6)) * logDepthConstant * 0.5;
+}
+`;
+
+let shaderRegistered = false;
+
+/**
+ * GLSL shader 를 Babylon `Effect.ShadersStore` 에 1회 등록 (ring/starfield/planet 패턴 답습).
+ * high/mid variant 가 단일 셰이더 공유 (ShadersStore 1회, 컴파일 1회).
+ */
+function registerSunShader(): void {
+  if (shaderRegistered) return;
+  Effect.ShadersStore[`${SHADER_NAME}VertexShader`] = VERTEX_SHADER;
+  Effect.ShadersStore[`${SHADER_NAME}FragmentShader`] = FRAGMENT_SHADER;
+  shaderRegistered = true;
+}
+
+/**
+ * #774 — 태양 emissive 절차 표면 ShaderMaterial 생성 (high/mid 공유).
+ *
+ * star 전용 팩토리 — planet 팩토리와 달리 테이블 조회가 없다 (**무조건 생성, null 반환 없음** —
+ * 호출부 `createBodyMesh`/`createBodyMeshMid` 의 star 분기가 `surfaceDetail=true` 일 때만 호출.
+ * ADR §결정 1 — `SURFACE_TYPE_BY_BODY` 는 "외부광 반사 표면" 전용으로 sun 미등록 유지).
+ *
+ * 광원 인자 (`surfaceLighting`) 를 받지 않는다 — emissive 전용 (ADR §결정 4). base color 는
+ * `body.colorHint.hex` (실측 #FFE9A8) 를 read-only uniform 으로 전달 (데이터 SSoT 불변).
+ *
+ * @param scene Babylon 씬 (logDepthConstant 용 activeCamera.maxZ 참조)
+ * @param body 대상 body (colorHint.hex 사용 — sun)
+ * @param name 머티리얼 이름 (high/mid 구분용)
+ * @returns ShaderMaterial (emissive 전용 — 씬 광원과 무간섭)
+ */
+export function createSunSurfaceMaterial(
+  scene: Scene,
+  body: LoadedCelestialBody,
+  name: string,
+): ShaderMaterial {
+  registerSunShader();
+
+  const material = new ShaderMaterial(
+    name,
+    scene,
+    { vertex: SHADER_NAME, fragment: SHADER_NAME },
+    {
+      attributes: ['position', 'normal'],
+      uniforms: [
+        'worldViewProjection',
+        // #782 옵션 e 규약 — world matrix auto-bind (vNormal world 변환 + vWorldPos).
+        'world',
+        // Babylon 표준 auto-bind — uniforms 배열 선언 시 bind 단계에서
+        // scene.activeCamera.globalPosition 자동 설정 (shaderMaterial.js 실측 확인, ADR §결정 8).
+        // 미동작 시 limb darkening radial 프로파일이 평탄해져 브라우저 실측에서 즉시 노출 —
+        // 그 경우 onBind 갱신 폴백 (planet uSunDirection 패턴) 으로 전환.
+        'cameraPosition',
+        'baseColor',
+        'limbDarkeningU',
+        'granulationScale',
+        'granulationContrast',
+        'logDepthConstant',
+      ],
+    },
+  );
+
+  // base color (실측 colorHint.hex #FFE9A8) — 발광의 기준 (데이터 SSoT, read-only).
+  const hex = body.colorHint?.hex ?? '#FFE9A8';
+  material.setColor3('baseColor', hexToRgb01(hex));
+
+  // rendering-only 미학 상수 SSoT 전달 (ADR §결정 8).
+  material.setVector3(
+    'limbDarkeningU',
+    new Vector3(LIMB_DARKENING_U_RGB[0], LIMB_DARKENING_U_RGB[1], LIMB_DARKENING_U_RGB[2]),
+  );
+  material.setFloat('granulationScale', GRANULATION_SCALE);
+  material.setFloat('granulationContrast', GRANULATION_CONTRAST);
+
+  // ADR §결정 7 — 로그 depth 상수 (Babylon logDepth 공식: 2 / log2(maxZ + 1)).
+  // maxZ 는 setupArcRotateCamera 가 1e14 로 고정 (ring/planet 과 동일 선례). 카메라 부재
+  // (테스트 등) 시 1e14 fallback.
+  const maxZ = scene.activeCamera?.maxZ ?? 1e14;
+  material.setFloat('logDepthConstant', 2.0 / (Math.log(maxZ + 1.0) / Math.LN2));
+
+  return material;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GLSL 의 순수 JS 미러 (단위 테스트 SSoT 가드 — #719 교훈 + planet surfaceColorMirror 패턴).
+//
+// fbm 미러는 procedural-planet-shader.ts 의 `fbmMirror` 를 **재사용**한다 (volt #21 — 중복
+// 구현 금지. GLSL 텍스트가 planet 과 동일하므로 미러도 동일해야 한다 — 정적 계약 가드).
+// ⚠️ 이 미러 함수들과 FRAGMENT_SHADER 의 GLSL 은 동일 식이어야 한다 (한쪽 수정 시 양쪽 동기화).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * limb darkening GLSL (`vec3(1.0) − limbDarkeningU × (1 − μ)`) 의 JS 미러.
+ *
+ * @param mu 시선각 cos (dot(N, viewDir)) — [0,1] 밖 입력은 GLSL clamp 와 동일하게 clamp.
+ * @returns 채널별 limb 감광 계수 RGB (중심 μ=1 → [1,1,1], 가장자리 μ=0 → 1−u)
+ */
+export function limbDarkeningMirror(mu: number): readonly [number, number, number] {
+  const m = Math.min(Math.max(mu, 0), 1);
+  return [
+    1 - LIMB_DARKENING_U_RGB[0] * (1 - m),
+    1 - LIMB_DARKENING_U_RGB[1] * (1 - m),
+    1 - LIMB_DARKENING_U_RGB[2] * (1 - m),
+  ];
+}
+
+/**
+ * #774 — FRAGMENT_SHADER 합성식 (`baseColor × granulation × limb`) 의 **순수 JS 미러**.
+ *
+ * 주어진 구면 좌표 + 시선각 μ 에 대해 최종 발광 RGB 를 반환한다. GLSL 과 동일 식 —
+ * 결정성 / limb 단조성 / warm 색역 (R ≥ B — 보라·마젠타 부재) / 상수 SSoT 를 결정적으로
+ * 검증한다 (planet surfaceColorMirror 패턴).
+ *
+ * ⚠️ FRAGMENT_SHADER 의 GLSL 과 동일 식이어야 한다 (SSoT — 한쪽 수정 시 양쪽 동기화).
+ *
+ * @param baseColor 실측 base 발광색 RGB ∈ [0,1]³ (colorHint.hex)
+ * @param p 정규화 구면 좌표 [x,y,z] (단위 벡터 가정 — granulation 기준)
+ * @param mu 시선각 cos (disk 중심 1 → 가장자리 0)
+ * @returns 발광 RGB ∈ [0,1]³ (clamp 적용)
+ */
+export function sunColorMirror(
+  baseColor: readonly [number, number, number],
+  p: readonly [number, number, number],
+  mu: number,
+): readonly [number, number, number] {
+  const granule = fbmMirror(
+    p[0] * GRANULATION_SCALE,
+    p[1] * GRANULATION_SCALE,
+    p[2] * GRANULATION_SCALE,
+  );
+  const granulation = 1 + (granule - 0.5) * 2 * GRANULATION_CONTRAST;
+  const limb = limbDarkeningMirror(mu);
+  const clamp01 = (n: number): number => Math.min(Math.max(n, 0), 1);
+  return [
+    clamp01(baseColor[0] * granulation * limb[0]),
+    clamp01(baseColor[1] * granulation * limb[1]),
+    clamp01(baseColor[2] * granulation * limb[2]),
+  ];
+}
+
+/** hex → RGB tuple ∈ [0,1]³ (Color3 인스턴스 — planet hexToColor3 동형, 팩토리 내부용). */
+function hexToRgb01(hex: string): Color3 {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  return new Color3(r, g, b);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 테스트/검증용 re-export (sun-shader.test.ts SSoT 가드 — #69 drift 차단).
+// ─────────────────────────────────────────────────────────────────────────────
+export {
+  // GLSL 소스 (테스트가 switch 부재 / log-depth / world normal 배선 / noise 텍스트 동일성 정적 검증).
+  VERTEX_SHADER as SUN_VERTEX_SHADER,
+  FRAGMENT_SHADER as SUN_FRAGMENT_SHADER,
+};


### PR DESCRIPTION
## [#774] 태양 emissive 절차 표면 셰이더 — granulation + limb darkening + 색온도

### 변경 사항

- **신규 `packages/core/src/scene/sun-shader.ts`** (384줄) — emissive 전용 4번째 절차 셰이더 모듈 (ring/starfield/procedural-planet 구조 답습). ADR [`20260703-774-sun-emissive-shader.md`](docs/decisions/20260703-774-sun-emissive-shader.md) §결정 1~8 구현:
  - **granulation**: fbm 3-옥타브 painted-on 정적 변조 (`vLocalPos` local — §결정 3, #782 규약)
  - **limb darkening**: Eddington 근사 `I(μ) = 1 − u(1−μ)`, μ = dot(N, viewDir) (§결정 2)
  - **색온도 그라데이션**: 채널별 u 계수 (`u_R < u_G < u_B`) 로 감광 + 가장자리 주황 자동 도출 — 별도 색 mix 상수 0
  - vNormal 은 #782 옵션 e (world normal) 규약 답습, `cameraPosition` 은 Babylon 표준 auto-bind (shaderMaterial.js L845 정적 확인 + 실측 radial 프로파일로 배선 확증)
  - log-depth `gl_FragDepth` 정합 (ring #641 / planet #756 실증 패턴 복제 — §결정 7)
  - **광원 uniform 0** — 씬 광원 미참조로 자동 무광 (emissive — §결정 4), 알파 1 OPAQUE
  - JS 미러는 planet 의 `fbmMirror` **재사용** (volt #21 중복 구현 금지) — sun GLSL noise 텍스트가 planet GLSL 과 동일함을 테스트가 정적 계약으로 가드
- **`solar-system-scene.ts`** (+19/−8) — `createBodyMesh`/`createBodyMeshMid` star 분기 2곳에서 `surfaceDetail=true` 시 `createSunSurfaceMaterial` 호출 (high/mid 공유 — §결정 6). `?surface=off` 시 기존 star 단색 emissive 100% 복귀 (§결정 8)
- **신규 `sun-shader.test.ts`** (269줄, 29 tests) — 미러 결정성 / limb 단조성 / warm 색역 (R ≥ B) / 상수 SSoT / GLSL 정적 계약 (switch 부재·gl_FragDepth·world normal 배선·광원 uniform 부재) / noise 텍스트 planet 동일성 / `SURFACE_TYPE_BY_BODY` sun 미등록 유지

### Behavior Changes

- `?focus=sun` (surface 기본 ON) 에서 태양이 granulation + limb darkening + 색온도 그라데이션의 사실적 표면으로 렌더 (high/mid LOD)
- `?surface=off` 시 현행 단색 emissive disk 100% 복귀 (신규 URL 파라미터 0)
- low (billboard) / tier-c / glow-marker / picking / camera / orbit / tier 전환 — 무변경 (실측 무회귀 확인)

### 상수 최종값 (measurement-first — ADR §결정 8)

| 상수 | 최종값 | 근거 |
| --- | --- | --- |
| `LIMB_DARKENING_U_RGB` | `[0.5, 0.6, 0.9]` (출발값 유지) | Allen's Astrophysical Quantities u(λ) 근사. 실측 edge/center 휘도비 0.1996 < 0.85 (DoD 2 마진 충분) + 시각 인상 사실적 (중심 흰노랑 → 가장자리 주황) |
| `GRANULATION_SCALE` | `48` (출발값 유지) | disk ~470px 에서 쌀알 결 시인 적절 (실측 스크린샷 육안 + hf 엔트로피 3.855) |
| `GRANULATION_CONTRAST` | `0.12` (출발값 유지) | base 색 (#FFE9A8) 보존하면서 결 시인 (#756 상수 철학 동형) |

### 실측 결과 (실 Chrome GUI, Playwright composited screenshot + pngjs — #728/#756 WebGPU readback 금지)

| DoD | 기준 | 실측 | 판정 |
| --- | --- | --- | --- |
| 1 | granulation hf 엔트로피 ON > OFF | ON **3.855** vs OFF **0.449** | PASS |
| 2 | radial 휘도 단조 감소 + edge(r≈0.9R)/center < 0.85 | 단조 위반 0 (239.85 → 47.87), 비 **0.1996** | PASS |
| 3 | 가장자리 B/R < 중심 B/R | 중심 **0.6824** → 가장자리 **0.4993** | PASS |
| 4 | `?surface=off` 단색 복귀 + planet 4종 ON 유지 | OFF hf 엔트로피 0.449 (radial 평탄 232.98) / earth 1.343·mars 2.097·jupiter 2.18·moon 2.237 | PASS |
| 5 | glow-marker 무회귀 | `browser-verify-glow-marker.mjs` 전 시나리오 PASS (32 body 발동 유지) | PASS |
| 7 | 단위 테스트 5축 | `sun-shader.test.ts` 29/29 | PASS |
| 8 | core typecheck 0 (#719) + 전체 테스트 | typecheck 0 / core 710 passed / web 479 passed / 신규 lint 워닝 0 | PASS |
| 9 | rotationStates sun 미포함 | 기존 #782 테스트 무회귀 (core 710 포함) | PASS |

- DoD 6 (fps-baseline-guard) / r1-guard 는 CI 에서 판정 (push 완료)
- 측정 방법 정정 1건 (CRITICAL #6.10): granulation 판정 지표를 hfEnergy(RMS) → **hf 엔트로피** 로 정정 — OFF 단색 disk 의 경계 antialiasing 급락 (232→0) 이 소수 픽셀 대형 라플라시안으로 hfEnergy 를 오염 (ON 16.99 < OFF 27.90 false-FAIL). ADR §DoD 1 명시 지표도 엔트로피 — 식/구현이 아닌 판정 지표 선택 오류였음
- console error 0 (ON/OFF 전 시나리오)

### Concrete Prediction 실측 대조 (ADR §Concrete Prediction)

| 영역 | 예측 | 실측 (`git diff --stat`) | 판정 |
| --- | --- | --- | --- |
| `sun-shader.ts` 신규 | ~220–320 | **384** | 초과 +64 — Amendment 1 (아래) |
| `solar-system-scene.ts` | ~10–25 변경 | +19/−8 | 적중 |
| `sun-shader.test.ts` 신규 | ~100–170 | **269** | 초과 +99 — Amendment 1 |
| `procedural-planet-shader.ts` | **0** | **0** | **적중 (핵심 예측)** |
| web 레이어 (`parse-surface-mode.ts`/`sim-canvas.tsx`) | **0** | **0** | **적중 (핵심 예측)** |
| `solar-system.json` | **0** | **0** | **적중 (핵심 예측)** |
| 무침범 모듈 (picking/camera/orbit/tier/LOD pass/glow-marker/billboard) | 0 | 0 | 적중 |

**Amendment 1 — 라인수만 초과 (#756 과 동형 패턴)**: 구조 예측 (파일 2 + 신규 테스트 1, 무침범 0) 은 전부 적중. 초과분은 (a) 헤더/GLSL 주석 밀도 (ADR 결정 근거 역참조 박제), (b) 테스트 검증 축 세분화 (ADR 5축 → noise 텍스트 동일성 + SURFACE_TYPE 미등록 계약 추가 7축). 관심사 혼입 (LOD/광원 레이어 침범) 은 0 — 재검토 불요.

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 — ADR `20260703-774-sun-emissive-shader.md` §DoD 9항목 (Accepted, cross-validate 2026-07-03)
- [x] 모든 완료 기준 충족 — dev 검증 가능 항목 전수 PASS (위 실측 표. DoD 6 fps / r1-guard 는 CI 판정)

### 테스트 (Test plan)
- [x] 단위 테스트 추가/수정 — `sun-shader.test.ts` 29 tests 신규
- [x] 기존 테스트 통과 확인 — core 710 passed (49 files) / web 479 passed / `pnpm --filter @astro-simulator/core typecheck` 0 (#719)
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인 — 신규 워크스페이스 없음, core 기존 `scripts.test` 유지

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [ ] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [x] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR: `docs/decisions/20260703-774-sun-emissive-shader.md` (신규 — architect 커밋 dea82d3 + cross-validate Accepted 전이 ee27e43 포함)
  - 검증 결과: **호환** — 신규 ADR (기존 ADR 폐기/Supersedes 0). #756 ADR (`SURFACE_TYPE_BY_BODY` "외부광 반사 표면" 전용 의미 보존 — sun 미등록 유지) / #782 ADR (옵션 e world normal 규약 답습, jd 미전달 계약 유지) 과 참조 정합만 존재. §재검토 조건 6항목은 후속 재도입 경로 박제 (구현이 조건 발동 없이 1차 범위 준수)

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [x] **[1/3] 정적**: 렌더링 OK, 콘솔 에러 0 — 스크린샷 경로: `docs/reports/774-sun/sun-on.png` (granulation+limb 육안 확인) / `sun-off.png` (단색 복귀) — 로컬 캡처 (untracked 관례, #756/#762 동형)
- [x] **[2/3] 인터랙션**: `?surface=off` URL 플래그 토글 → 단색 복귀 실측 (radial 평탄 232.98 상수)
- [x] **[3/3] 흐름**: `?focus=sun` → focus tween → disk 대면적 렌더 → planet 4종 focus 이동 무회귀 (earth/mars/jupiter/moon hf 엔트로피 유지)
- [x] verify 스크립트(있는 경우) 경로: `apps/web/scripts/browser-verify-774-sun.mjs` (로컬 실행, radial 프로파일 + hf 엔트로피 판정 — CI 통합은 #759 와 동일 트랙 후속)

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님 (단일 feature)

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 feature PR

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 feature PR

### 체크리스트
- [x] 커밋 컨벤션 준수 — `feat(core): #774 ...` + docs(adr) 2건
- [x] 불필요한 변경 없음 — 이슈 범위만 (scope creep 0, 비-범위 sunspot/코로나/시간변동 미구현 — ADR §재검토 조건으로 경로 박제)
- [x] 보안 취약점 없음 — 렌더링 전용 (외부 입력/네트워크/저장소 접근 0)
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145) — 해당 없음 (스키마 미수정)
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드) — ADR 신규 포함: cross-validate 완료 (agy 2026-07-03), outcome 은 ADR §교차검증 반영 사항 (합의 3 / 부분 수용 1 / 기각 3 / YAGNI 기각 1 → §재검토 조건 6 신설) 에 박제

### 관련 이슈
Closes #774
