### PR TITLE
[#783] 지구 디테일 — 극관 + biome 위도 색 변화

### DIFF
--- a/apps/web/scripts/browser-verify-783-earth-detail.mjs
+++ b/apps/web/scripts/browser-verify-783-earth-detail.mjs
@@ -49,7 +49,7 @@ const MODE = process.env.MODE ?? 'dod';
 const T_JD = 2451626.0;
 const NEAR_WHITE_MIN = 140; // DoD 1 — min(R,G,B) 하한 (/255)
 const NEAR_WHITE_SPREAD = 40; // DoD 1 — 채널 max−min 상한
-const POLAR_BAND = 0.12; // disk 세로 극단 — |dy| ≥ (1−0.12)R (sin-space 0.88 = 극관 전이 시작과 일치)
+const POLAR_BAND = 0.12; // disk 세로 극단 — |dy| ≥ (1−0.12)R (sin-space 0.88 — ICE ramp 0.84~0.92 완료 구간 포함, #783 measurement-first 하향 후 기준)
 const MAGENTA_TAU = 15; // DoD 3 — R>G+τ && B>G+τ
 // disk 픽셀 멤버십 임계 — 성운 배경 (lum ~8–15) 배제, 밤면 ambient (~30) 포함 (실측 보정).
 const DISK_LUM_MIN = 20;

--- a/apps/web/scripts/browser-verify-783-earth-detail.mjs
+++ b/apps/web/scripts/browser-verify-783-earth-detail.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+/**
+ * #783 — 지구 디테일 (극관 + biome 위도 색 변화) 동적 검증 (Amendment 3 §A3.5 DoD 1~3 산식).
+ *
+ * 실 Chrome GUI (headless:false, channel:chrome) — WebGPU swiftshader freeze 회피 (#663/#756).
+ * 픽셀 측정 = composited canvas.screenshot() → 페이지 내 Image 디코드 → 2D getImageData
+ * (WebGPU drawImage readback 빈버퍼 함정 회피 — #728 SSoT).
+ *
+ * 결정적 프레임 레시피 (실측 근거 — PR 본문 박제):
+ *   1. `?focus=earth&rotate=off&orbits=off` 로 로드 — identity rotation → local Y = world Y
+ *      = 화면 세로축 (tilt 오염 제거, ADR §A3.2-5). ⚠️ `?speed=0` 를 로드 쿼리에 넣으면
+ *      focus 정착(LOD/광원 per-frame 갱신)이 완주하지 않아 disk 가 렌더되지 않는다 (실측)
+ *      — 로드는 기본 speed 로 진행.
+ *   2. 정착 후 런타임 `__simCore.command(jumpToJulianDate T_JD)` + `command(pause)` 동기 연속
+ *      호출 — 프레임 고정 (재현 결정적).
+ *   3. T_JD = 2451626.0 (2000-03-22, 춘분 근방) — 지구 공전 방위 ~182° 에서 태양 방향이
+ *      world +X (⊥ 패턴 극축 world Y) → terminator 세로 = 남북 극 밴드 양쪽에 낮면 존재
+ *      (§A3.5 DoD 1 "남북 모두 낮면" 측정 가능 조건. dataset epoch J2000 은 태양이 −Y 로
+ *      남극만 낮면이라 측정 불능 — 실측).
+ *
+ * disk 기하: 중심 = mesh 위치 화면 투영, 반경 = boundingSphere.radiusWorld/√3 (실 구 반경) 의
+ * edge 점 화면 투영 (bbox cube 모서리 투영은 ~1.2x 과대, 마스크 count 는 밤면 limb 탈락으로
+ * ~7% 과소 — 실측 보정 이력, 둘 다 밴드를 캡 밖으로 어긋나게 함).
+ *
+ * 측정 축 (§A3.5):
+ *  - DoD 1 극관: disk 세로 양극단 12% (낮면 측, 남북 각각) near-white (min(R,G,B)≥140 &&
+ *    max−min≤40) 비율 ≥ 50% + OFF(&surface=off) 대비 유의 증가.
+ *  - DoD 2 biome: 적도 밴드 (|dy|≤0.15R) land 픽셀 평균 G-share > 중위도 밴드 (0.4–0.65R).
+ *  - DoD 3 마젠타 0: disk 픽셀 중 R>G+15 && B>G+15 개수 0.
+ *  - DoD 4: 밤면 극 휘도 < 낮면 극 휘도 × 1/3 (#773 무회귀 — 극관도 shade 곱 아래).
+ *
+ * 모드:
+ *   node browser-verify-783-earth-detail.mjs                     # DoD 측정 (earth ON vs OFF)
+ *   MODE=others CAPTURE_DIR=/abs node ...                        # mars/jupiter/moon 결정적 캡처 (분기 격리 diff 용)
+ *   MODE=diff node ... <dirA> <dirB>                             # 캡처 dir 픽셀 diff (Concrete Prediction: ≈0)
+ */
+
+import { chromium } from 'playwright';
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { PNG } from 'pngjs';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? null;
+const HEADFUL = process.env.HEADFUL !== '0';
+const MODE = process.env.MODE ?? 'dod';
+
+/** 결정적 프레임 고정 JD — 2000-03-22 (춘분 근방, 태양 ⊥ 패턴 극축 — 헤더 주석 3). */
+const T_JD = 2451626.0;
+const NEAR_WHITE_MIN = 140; // DoD 1 — min(R,G,B) 하한 (/255)
+const NEAR_WHITE_SPREAD = 40; // DoD 1 — 채널 max−min 상한
+const POLAR_BAND = 0.12; // disk 세로 극단 — |dy| ≥ (1−0.12)R (sin-space 0.88 = 극관 전이 시작과 일치)
+const MAGENTA_TAU = 15; // DoD 3 — R>G+τ && B>G+τ
+// disk 픽셀 멤버십 임계 — 성운 배경 (lum ~8–15) 배제, 밤면 ambient (~30) 포함 (실측 보정).
+const DISK_LUM_MIN = 20;
+
+async function launch() {
+  const opts = HEADFUL ? { headless: false, channel: 'chrome' } : { headless: true };
+  try {
+    const b = await chromium.launch(opts);
+    console.log(`[browser] ${HEADFUL ? '실 Chrome GUI' : 'headless chromium'}`);
+    return b;
+  } catch (e) {
+    console.error(`[launch] chrome channel 부재 (${e.message}) — chromium 폴백`);
+    return chromium.launch({ headless: !HEADFUL });
+  }
+}
+
+async function setupPage(browser, query) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on('console', (m) => m.type() === 'error' && consoleErrors.push(m.text()));
+  page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
+  await page.goto(`${BASE_URL}${query}`, { waitUntil: 'networkidle', timeout: 45_000 });
+  await page.waitForFunction(
+    () => typeof window.__simCore !== 'undefined' && typeof window.__solarScene !== 'undefined',
+    { timeout: 20_000 },
+  );
+  await page.waitForTimeout(2800); // mesh 생성 + focus tween + LOD 정착
+  // 결정적 프레임: 고정 JD 점프 + pause (동기 연속 — 사이 tick 0). 헤더 주석 레시피 2.
+  await page.evaluate((jd) => {
+    window.__simCore.command({ type: 'jumpToJulianDate', julianDate: jd });
+    window.__simCore.command({ type: 'pause' });
+  }, T_JD);
+  await page.waitForTimeout(1000); // 점프 반영 프레임 정착
+  return { context, page, consoleErrors };
+}
+
+async function captureBody(page, bodyId, captureName) {
+  const canvas = page.locator('canvas').first();
+  const buf = await canvas.screenshot();
+  if (CAPTURE_DIR && captureName) {
+    await mkdir(CAPTURE_DIR, { recursive: true });
+    await writeFile(path.join(CAPTURE_DIR, `${captureName}.png`), buf);
+  }
+  return buf;
+}
+
+/** earth disk 픽셀 측정 — DoD 산식 (파일 헤더 주석 참조). */
+async function measureEarth(page, buf) {
+  const b64 = buf.toString('base64');
+  return page.evaluate(
+    async ({ b64, NEAR_WHITE_MIN, NEAR_WHITE_SPREAD, POLAR_BAND, MAGENTA_TAU, DISK_LUM_MIN }) => {
+      const scene = window.__simCore?.scene;
+      const mesh = window.__solarScene?.meshes?.get('earth');
+      if (!scene || !mesh) return { error: 'earth mesh/scene 부재' };
+      const engine = scene.getEngine();
+      const rw = engine.getRenderWidth();
+      const rh = engine.getRenderHeight();
+      const cam = scene.activeCamera;
+      const vp = cam.viewport.toGlobal(rw, rh);
+      const transform = scene.getTransformMatrix();
+      const Vector3 = mesh.getAbsolutePosition().constructor;
+      const idMat = mesh.getWorldMatrix().constructor.Identity();
+
+      const meshPos = mesh.getAbsolutePosition();
+      const bb = mesh.getBoundingInfo().boundingBox;
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
+      for (const c of bb.vectorsWorld) {
+        const p = Vector3.Project(c, idMat, transform, vp);
+        minX = Math.min(minX, p.x);
+        minY = Math.min(minY, p.y);
+        maxX = Math.max(maxX, p.x);
+        maxY = Math.max(maxY, p.y);
+      }
+      const centerScreen = Vector3.Project(meshPos, idMat, transform, vp);
+
+      // sunDir 화면 투영 (낮/밤 분할 — #773 스크립트 방법 답습).
+      let sunPos = null;
+      for (const l of scene.lights) {
+        if (l.position && (l.name === 'sun-light' || l.getClassName?.() === 'PointLight')) {
+          sunPos = l.position;
+          break;
+        }
+      }
+      if (!sunPos) return { error: 'sunLight 부재' };
+      const sunDirN = sunPos.subtract(meshPos).normalize();
+      const meshRadius = bb.maximum.subtract(bb.minimum).length() * 0.5 || 1;
+      const tipScreen = Vector3.Project(
+        meshPos.add(sunDirN.scale(meshRadius * 4)),
+        idMat,
+        transform,
+        vp,
+      );
+      let sdx = tipScreen.x - centerScreen.x;
+      let sdy = tipScreen.y - centerScreen.y;
+      const sdLen = Math.hypot(sdx, sdy) || 1;
+      sdx /= sdLen;
+      sdy /= sdLen;
+
+      const img = new Image();
+      await new Promise((res, rej) => {
+        img.onload = res;
+        img.onerror = rej;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+      const off = document.createElement('canvas');
+      off.width = img.width;
+      off.height = img.height;
+      const ctx = off.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const sx = img.width / rw,
+        sy = img.height / rh;
+      const bx = Math.max(0, Math.round(minX * sx)),
+        by = Math.max(0, Math.round(minY * sy));
+      const bw = Math.min(img.width - bx, Math.max(1, Math.round((maxX - minX) * sx)));
+      const bh = Math.min(img.height - by, Math.max(1, Math.round((maxY - minY) * sy)));
+      if (bw < 8 || bh < 8) return { error: `disk bbox 너무 작음 ${bw}x${bh}` };
+      const data = ctx.getImageData(bx, by, bw, bh).data;
+      const cx = centerScreen.x * sx - bx;
+      const cy = centerScreen.y * sy - by;
+
+      // disk 반경 — 투영 기반 (정확): boundingSphere.radiusWorld 는 bounding cube half-diagonal
+      // (구 반경 × √3) 이므로 √3 으로 나눠 실 world 반경 복원 → 카메라 right 방향 edge 점을
+      // 화면 투영해 px 반경 산출. (마스크 count 기반은 밤면 limb 저휘도 픽셀 탈락으로 ~7%
+      // 과소, bbox 투영은 cube 모서리로 ~1.2x 과대 — 실측 보정 이력.)
+      const rWorld = mesh.getBoundingInfo().boundingSphere.radiusWorld / Math.sqrt(3);
+      const camRight = cam.getDirection(new Vector3(1, 0, 0));
+      const edgeScreen = Vector3.Project(meshPos.add(camRight.scale(rWorld)), idMat, transform, vp);
+      const R = Math.hypot(
+        (edgeScreen.x - centerScreen.x) * sx,
+        (edgeScreen.y - centerScreen.y) * sy,
+      );
+      if (R < 20) return { error: `disk 투영 반경 너무 작음 ${R.toFixed(1)}` };
+
+      // pass 2 — 밴드 집계. north = 화면 위 (dy<0) = local +Y, south = 화면 아래.
+      const mkSide = () => ({ nDay: 0, whiteDay: 0 });
+      const acc = {
+        north: mkSide(),
+        south: mkSide(),
+        eq: { n: 0, gShareSum: 0 },
+        mid: { n: 0, gShareSum: 0 },
+        magenta: 0,
+        disk: 0,
+        dayPolarLum: [],
+        nightPolarLum: [],
+      };
+      for (let y = 0; y < bh; y++) {
+        for (let x = 0; x < bw; x++) {
+          const i = (y * bw + x) * 4;
+          const r = data[i],
+            g = data[i + 1],
+            b = data[i + 2];
+          const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+          if (lum < DISK_LUM_MIN) continue; // 우주 배경 + 성운 배제 (disk 멤버십 = R 추정과 동일 임계)
+          acc.disk++;
+          if (r > g + MAGENTA_TAU && b > g + MAGENTA_TAU) acc.magenta++; // DoD 3
+          const dy = (y - cy) / R; // 화면 아래 = +dy (화면 좌표 y 하향) = 남쪽
+          const dotSun = (x - cx) * sdx + (y - cy) * sdy;
+          const isDay = dotSun > 0;
+          const absDy = Math.abs(dy);
+          const mn = Math.min(r, g, b),
+            mx = Math.max(r, g, b);
+          if (absDy >= 1 - POLAR_BAND && absDy <= 1.05) {
+            (isDay ? acc.dayPolarLum : acc.nightPolarLum).push(lum);
+            if (isDay) {
+              const side = dy < 0 ? acc.north : acc.south;
+              side.nDay++;
+              if (mn >= NEAR_WHITE_MIN && mx - mn <= NEAR_WHITE_SPREAD) side.whiteDay++;
+            }
+          }
+          if (isDay && lum > 40) {
+            // land 픽셀 분류 — ocean(B≥G 청록) / near-white(극관 포화) 제외.
+            const isLand = b < g && !(mn >= NEAR_WHITE_MIN && mx - mn <= NEAR_WHITE_SPREAD);
+            if (isLand) {
+              const gShare = g / Math.max(r + g + b, 1);
+              if (absDy <= 0.15) {
+                acc.eq.n++;
+                acc.eq.gShareSum += gShare;
+              } else if (absDy >= 0.4 && absDy <= 0.65) {
+                acc.mid.n++;
+                acc.mid.gShareSum += gShare;
+              }
+            }
+          }
+        }
+      }
+      const mean = (a) => (a.length ? a.reduce((s, v) => s + v, 0) / a.length : 0);
+      const sideOut = (s) => ({
+        nDay: s.nDay,
+        whiteDayPct: s.nDay ? Number(((s.whiteDay / s.nDay) * 100).toFixed(1)) : null,
+      });
+      return {
+        diskPx: acc.disk,
+        R: Number(R.toFixed(1)),
+        north: sideOut(acc.north),
+        south: sideOut(acc.south),
+        eqGShare: acc.eq.n ? Number((acc.eq.gShareSum / acc.eq.n).toFixed(4)) : null,
+        midGShare: acc.mid.n ? Number((acc.mid.gShareSum / acc.mid.n).toFixed(4)) : null,
+        eqN: acc.eq.n,
+        midN: acc.mid.n,
+        magenta: acc.magenta,
+        dayPolarLum: Number(mean(acc.dayPolarLum).toFixed(1)),
+        nightPolarLum: Number(mean(acc.nightPolarLum).toFixed(1)),
+        screenSunDir: { x: Number(sdx.toFixed(3)), y: Number(sdy.toFixed(3)) },
+      };
+    },
+    { b64, NEAR_WHITE_MIN, NEAR_WHITE_SPREAD, POLAR_BAND, MAGENTA_TAU, DISK_LUM_MIN },
+  );
+}
+
+/** MODE=diff — 두 캡처 dir 의 동명 PNG 픽셀 diff (Concrete Prediction: mars/jupiter/moon ≈ 0). */
+async function diffDirs(dirA, dirB, names) {
+  for (const name of names) {
+    const a = PNG.sync.read(await readFile(path.join(dirA, `${name}.png`)));
+    const b = PNG.sync.read(await readFile(path.join(dirB, `${name}.png`)));
+    if (a.width !== b.width || a.height !== b.height) {
+      console.log(`  ${name}: 크기 불일치 ${a.width}x${a.height} vs ${b.width}x${b.height} — FAIL`);
+      continue;
+    }
+    let diffPx = 0,
+      maxDelta = 0;
+    for (let i = 0; i < a.data.length; i += 4) {
+      const d = Math.max(
+        Math.abs(a.data[i] - b.data[i]),
+        Math.abs(a.data[i + 1] - b.data[i + 1]),
+        Math.abs(a.data[i + 2] - b.data[i + 2]),
+      );
+      if (d > 2) diffPx++; // 압축/AA 미세 노이즈 허용 (±2/255)
+      if (d > maxDelta) maxDelta = d;
+    }
+    const total = a.data.length / 4;
+    const pct = ((diffPx / total) * 100).toFixed(4);
+    console.log(
+      `  ${name}: diffPx=${diffPx}/${total} (${pct}%) maxDelta=${maxDelta} → ${diffPx / total < 0.001 ? 'PASS (≈0)' : 'CHECK'}`,
+    );
+  }
+}
+
+const OTHER_BODIES = ['mars', 'jupiter', 'moon'];
+
+(async () => {
+  if (MODE === 'diff') {
+    const [dirA, dirB] = process.argv.slice(2);
+    if (!dirA || !dirB) {
+      console.error('usage: MODE=diff node ... <dirA> <dirB>');
+      process.exit(2);
+    }
+    console.log(`=== 분기 격리 diff (${dirA} vs ${dirB}) — Concrete Prediction ≈0 ===`);
+    await diffDirs(
+      dirA,
+      dirB,
+      OTHER_BODIES.map((id) => `qa-783-${id}`),
+    );
+    return;
+  }
+
+  const browser = await launch();
+  try {
+    if (MODE === 'others') {
+      console.log('=== mars/jupiter/moon 결정적 캡처 (분기 격리 diff 용) ===');
+      for (const id of OTHER_BODIES) {
+        const { context, page, consoleErrors } = await setupPage(
+          browser,
+          `?gpu=a&focus=${id}&lod=auto&rotate=off&orbits=off`,
+        );
+        await captureBody(page, id, `qa-783-${id}`);
+        console.log(`  ${id} 캡처 완료 (err=${consoleErrors.length})`);
+        await context.close();
+      }
+      return;
+    }
+
+    // MODE=dod — DoD 측정 (ON vs OFF).
+    const out = {};
+    for (const [label, extra] of [
+      ['on', ''],
+      ['off', '&surface=off'],
+    ]) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=earth&lod=auto&rotate=off&orbits=off${extra}`,
+      );
+      // 적도면 시점 (beta=π/2) — 기본 beta 1.2566 (북쪽 18° 상방) 은 남극이 실루엣 뒤로 숨어
+      // 남측 밴드가 저위도를 비춘다 (실측 남측 whiteness 1.6% vs 북측 72.7%). 적도면 시점에서
+      // 양극이 실루엣 상/하단에 위치 → 화면 dy/R = sin(위도) 정확 매핑 (§A3.2-5 결정적 측정).
+      await page.evaluate(() => {
+        window.__simCore.scene.activeCamera.beta = Math.PI / 2;
+      });
+      await page.waitForTimeout(600);
+      const buf = await captureBody(page, 'earth', `qa-783-earth-${label}`);
+      const m = await measureEarth(page, buf);
+      out[label] = { ...m, consoleErrors: consoleErrors.length };
+      console.log(`\n=== earth surface=${label} ===`);
+      console.log(JSON.stringify(m, null, 2));
+      if (consoleErrors.length) console.log(`  ↳ console errors: ${consoleErrors.length}`);
+      await context.close();
+    }
+
+    // 판정 (§A3.5 산식).
+    const on = out.on,
+      off = out.off;
+    const capPass = (side) =>
+      on[side].whiteDayPct !== null &&
+      on[side].whiteDayPct >= 50 &&
+      (off[side].whiteDayPct === null || on[side].whiteDayPct > off[side].whiteDayPct);
+    const dod1 = capPass('north') && capPass('south');
+    const dod2 = on.eqGShare !== null && on.midGShare !== null && on.eqGShare > on.midGShare;
+    const dod3 = on.magenta === 0;
+    const dod4 = on.nightPolarLum < on.dayPolarLum / 3;
+    console.log('\n=== 판정 (§A3.5) ===');
+    console.log(
+      `DoD 1 극관(낮면 남북): N ${on.north.whiteDayPct}% / S ${on.south.whiteDayPct}% (≥50, OFF N ${off.north.whiteDayPct}% / S ${off.south.whiteDayPct}%) → ${dod1 ? 'PASS' : 'FAIL'}`,
+    );
+    console.log(
+      `DoD 2 biome: 적도 G-share ${on.eqGShare} (n=${on.eqN}) > 중위도 ${on.midGShare} (n=${on.midN}) → ${dod2 ? 'PASS' : 'FAIL'}`,
+    );
+    console.log(`DoD 3 마젠타: ${on.magenta} px → ${dod3 ? 'PASS' : 'FAIL'}`);
+    console.log(
+      `DoD 4 극 휘도: 밤면 ${on.nightPolarLum} < 낮면 ${on.dayPolarLum}/3=${(on.dayPolarLum / 3).toFixed(1)} → ${dod4 ? 'PASS' : 'FAIL'}`,
+    );
+    if (!(dod1 && dod2 && dod3 && dod4)) process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/docs/decisions/20260628-756-procedural-planet-surface.md
+++ b/docs/decisions/20260628-756-procedural-planet-surface.md
@@ -782,7 +782,7 @@ col = mix(col, iceColor, iceMask);
 5. **다른 rocky body 확장** — mars 등 을 Rocky 로 재분류하거나 위성 rocky 추가 시 biome 파라미터가 earth 전용 상수라 body 별 파라미터화 필요 (§A1.8 재검토 조건 4 연장).
 6. **극관 land/ocean 차등 디테일** (cross-validate 고유 발견) — 현재 iceMask 는 latJ (continents jitter 포함) 기반이라 경계가 지형 장을 따라 요동하지만, land 빙상 vs ocean 해빙의 분포 차이 (열용량) 는 미표현. qa 실측에서 "위도로만 잘린 흰 모자" 로 부자연하면 iceMask 에 landMask 미세 가중 검토.
 
-### A3.8 교차검증 반영 사항 (cross-validate 대기 — Provisional)
+### A3.8 교차검증 반영 사항 (agy 2026-07-04 — 통합 완료)
 
 **호출 전 Claude 편향 셀프 체크** (4종):
 

--- a/docs/decisions/20260628-756-procedural-planet-surface.md
+++ b/docs/decisions/20260628-756-procedural-planet-surface.md
@@ -1,6 +1,6 @@
 # ADR 20260628-756 — 절차적 행성 표면 셰이더 (1차: 인프라 + 대표 4개)
 
-- **상태**: Accepted (cross-validate 2026-06-28) — **Amendment 1 (#773/#775): Accepted (cross-validate 2026-06-30)** — **Amendment 2 (#782): Accepted (cross-validate 2026-07-01)** — **Amendment 3 (#783): Provisional (cross-validate 대기)**
+- **상태**: Accepted (cross-validate 2026-06-28) — **Amendment 1 (#773/#775): Accepted (cross-validate 2026-06-30)** — **Amendment 2 (#782): Accepted (cross-validate 2026-07-01)** — **Amendment 3 (#783): Accepted (cross-validate 2026-07-04)**
 - **날짜**: 2026-06-28 (Amendment 1: 2026-06-30, Amendment 2: 2026-07-01, Amendment 3: 2026-07-04)
 - **이슈**: [#756](https://github.com/coseo12/astro-simulator/issues/756) / Amendment 1: [#773](https://github.com/coseo12/astro-simulator/issues/773) (광원 일관성 회귀, high) + [#775](https://github.com/coseo12/astro-simulator/issues/775) (지구 대륙 mix, low) / Amendment 2: [#782](https://github.com/coseo12/astro-simulator/issues/782) (self-rotation 자전 + 광원 world normal 옵션 e 전환, medium) / Amendment 3: [#783](https://github.com/coseo12/astro-simulator/issues/783) (지구 디테일 — 극관 + biome 위도 색 변화, medium)
 - **관련**: [#738 절차적 별 배경](20260624-738-procedural-starfield.md) (트랙 A 선행), [`docs/architecture/principles.md` §1 Visual Fidelity](../architecture/principles.md)
@@ -634,7 +634,7 @@ self-rotation 도입 후 회전 non-zero 가 **정상**이 되므로 Amendment 1
 
 ## Amendment 3 (2026-07-04) — 지구 디테일: 극관 + biome 위도 색 변화 (#783)
 
-- **상태**: Provisional (cross-validate 대기 — 메인 오케스트레이터가 수행 후 §A3.8 통합 → Accepted 전이)
+- **상태**: Accepted (cross-validate 2026-07-04 — §A3.8 통합 완료)
 - **이슈**: [#783](https://github.com/coseo12/astro-simulator/issues/783) (type:feat, medium, group:B-render, #775 후속 — 사용자 관찰 2026-07-01 "지구가 지구 같지 않음")
 - **형식**: **Amendment** (신규 ADR 기각) — 판단 근거는 §A3.3 결정 1. 일반 Amendment (forensic 비대상 — 회귀가 아닌 신규 시각 기능, runtime 측정으로 결정이 갈리는 가설 경합 없음).
 
@@ -778,8 +778,9 @@ col = mix(col, iceColor, iceMask);
 1. **바다 깊이 색 (Tier 2-3) 요구** — 설계 스케치: `float depth = smoothstep(landThresholdLo, 0.0, continents)` (continents 재활용 — landMask 하위 구간을 깊이로 역해석, noise +0) + `DEEP_OCEAN_RGB` 상수 1개, `oceanCol = mix(baseColor, deepOcean, depth)` 를 첫 mix 의 baseColor 자리에 대입. ocean = colorHint read-only 규약과의 관계 (deep 색이 baseColor 변조인지 독립 상수인지) 재론 필요.
 2. **대기 fresnel rim (Tier 2-4) 요구** — #774 cameraPosition auto-bind 실증으로 uniform 비용 하락. 단 공유 셰이더 varying 혼입 vs 별도 대기 레이어 (§A1.8 재검토 조건 5) 비교 선행 — 구름 도입 시점과 합류 권장.
 3. **구름 / 야간 도시 불빛 (Tier 3)** — 별도 mesh/레이어 트랙 (§A1.8 재검토 조건 5 그대로). 구름은 #782 자전과 차등 offset 필요.
-4. **biome 경계 상관 아티팩트** — continents 재사용 jitter (결정 3-c) 가 해안선-biome 경계 쏠림 등 부자연 발견 시 독립 fbm 샘플 (B) 승격 (fbm +1 비용 재평가 동반).
+4. **biome 경계 상관 아티팩트** — continents 재사용 jitter (결정 3-c) 가 해안선-biome 경계 쏠림 (contour-following) 등 부자연 발견 시 **좌표 스위즐링 fbm (`fbm(p.zyx * 2.4)`)** 으로 승격 (cross-validate 고유 발견 — landMask 와의 상관을 완전 해제하면서 신규 noise 함수 불요. 단 agy 의 "비용 0" 주장은 오류 — 이미 계산된 값 재사용이 아니라 fbm 신규 호출 = hash 24회 추가로 독립 샘플 (B) 와 동일 비용. 가치는 탈상관이지 무비용이 아님).
 5. **다른 rocky body 확장** — mars 등 을 Rocky 로 재분류하거나 위성 rocky 추가 시 biome 파라미터가 earth 전용 상수라 body 별 파라미터화 필요 (§A1.8 재검토 조건 4 연장).
+6. **극관 land/ocean 차등 디테일** (cross-validate 고유 발견) — 현재 iceMask 는 latJ (continents jitter 포함) 기반이라 경계가 지형 장을 따라 요동하지만, land 빙상 vs ocean 해빙의 분포 차이 (열용량) 는 미표현. qa 실측에서 "위도로만 잘린 흰 모자" 로 부자연하면 iceMask 에 landMask 미세 가중 검토.
 
 ### A3.8 교차검증 반영 사항 (cross-validate 대기 — Provisional)
 
@@ -796,4 +797,22 @@ col = mix(col, iceColor, iceMask);
 2. 극관을 ocean/land mix **이후 최종 mix** 로 얹는 순서 (결정 4 B) 가 툰드라→극관 연속성 / #775 해안선 전이와 충돌하지 않는가.
 3. `LAND_COLOR_RGB` 재사용 (temperate 의미 재문서화 + 값 튜닝) vs biome 3색 전부 신규 상수 — 기존 #775 상수/uniform/테스트 계약과의 drift 리스크 비교.
 
-_(cross-validate 수행 결과 — 메인 오케스트레이터가 4축 분류 (합의 / 이견 수용 / 기각 / 고유 발견) 로 본 섹션에 통합 후 Provisional → Accepted 전이)_
+**수행 결과 (agy, 2026-07-04 — 로그 `.claude/logs/cross-validate-architecture-783.log`, 최종 판정 "Accepted 권장")**:
+
+**합의 (설계 유지)**:
+
+1. **Q2 극관 최종 mix 순서** — 충돌 없음 확인. 툰드라 (0.72–0.88) → 극관 (0.88–0.96) 순차 임계로 연속 전이, 중·저위도 iceMask=0 이라 #775 해안선 전이 100% 보존, 고위도에서 빙권이 해안선을 덮는 것은 실제 물리 정합 ("의도적이고 올바른 시각적 수렴"). 결정 4 유지.
+2. **Q3 `LAND_COLOR_RGB` 재사용 (A)** — 신규 3색 전면 교체 (B) 는 #775 uniform 배선/테스트 계약 파괴로 drift 리스크 큼. (A) 채택 유지 + **의미 재문서화 주석 가드 상세화** (temperate 밴드 색으로 동적 사용됨을 상수 선언부와 바인딩 계층 양쪽에 명시) 를 developer 지시에 반영.
+3. **Q1 continents 재사용 우선 채택 타당** — 성능 우위 압도적. 단 상관 아티팩트 리스크 High 평가 (해안선 굴곡과 biome 경계 평행 동조 가능) → qa DoD 실측 관찰 항목 유지.
+
+**고유 발견 (수용 — 사실 정정 포함)**:
+
+4. **스위즐링 백업 플랜** — 아티팩트 발현 시 독립 fbm 대신 `fbm(p.zyx * 2.4)` 좌표 스위즐링으로 탈상관 → §A3.7 재검토 조건 4 에 구체화 박제. **단 "추가 연산 비용 0" 주장은 사실 오류로 정정** — 스위즐링도 fbm 신규 호출 (hash 24회) 로 독립 샘플과 동일 비용. 채택 근거는 탈상관 + 신규 noise 함수 불요.
+5. **극관 land/ocean 차등 부재** — 실제 극빙은 지형별 분포가 다름 ("위도로만 잘린 흰 원형 모자" 우려). iceMask 가 latJ (jitter 포함) 기반이라 경계 요동은 이미 있음 — 1차 수용 범위 밖, qa 실측 관찰 + §A3.7 재검토 조건 6 신설.
+
+**부분 수용**:
+
+6. **uniform +10 인터페이스 복잡도** — struct 바인딩은 Babylon ShaderMaterial 개별 uniform 패턴 (기존 4중 SSoT) 과 이질적이라 기각, **바인딩 계층 그룹화 주석** (biome 상수 블록 명시) 으로 절충 — developer 지시 반영.
+7. **body 별 파라미터화 탈출구** — §A3.7 재검토 조건 5 에 이미 박제됨 (합의 재확인).
+
+**Claude 편향 셀프 체크 결과**: 결합 간과 (미통과 의심 축이었던 continents 이중 재사용) — agy 도 리스크 High 로 동의하나 채택 자체는 타당 판정. jitter 진폭이 작고 (위도 ±0.06) 백업 플랜이 구체화되어 실측 판정 (DoD) 으로 이관. 나머지 3종 통과 유지.

--- a/docs/decisions/20260628-756-procedural-planet-surface.md
+++ b/docs/decisions/20260628-756-procedural-planet-surface.md
@@ -1,8 +1,8 @@
 # ADR 20260628-756 — 절차적 행성 표면 셰이더 (1차: 인프라 + 대표 4개)
 
-- **상태**: Accepted (cross-validate 2026-06-28) — **Amendment 1 (#773/#775): Accepted (cross-validate 2026-06-30)** — **Amendment 2 (#782): Accepted (cross-validate 2026-07-01)**
-- **날짜**: 2026-06-28 (Amendment 1: 2026-06-30, Amendment 2: 2026-07-01)
-- **이슈**: [#756](https://github.com/coseo12/astro-simulator/issues/756) / Amendment 1: [#773](https://github.com/coseo12/astro-simulator/issues/773) (광원 일관성 회귀, high) + [#775](https://github.com/coseo12/astro-simulator/issues/775) (지구 대륙 mix, low) / Amendment 2: [#782](https://github.com/coseo12/astro-simulator/issues/782) (self-rotation 자전 + 광원 world normal 옵션 e 전환, medium)
+- **상태**: Accepted (cross-validate 2026-06-28) — **Amendment 1 (#773/#775): Accepted (cross-validate 2026-06-30)** — **Amendment 2 (#782): Accepted (cross-validate 2026-07-01)** — **Amendment 3 (#783): Provisional (cross-validate 대기)**
+- **날짜**: 2026-06-28 (Amendment 1: 2026-06-30, Amendment 2: 2026-07-01, Amendment 3: 2026-07-04)
+- **이슈**: [#756](https://github.com/coseo12/astro-simulator/issues/756) / Amendment 1: [#773](https://github.com/coseo12/astro-simulator/issues/773) (광원 일관성 회귀, high) + [#775](https://github.com/coseo12/astro-simulator/issues/775) (지구 대륙 mix, low) / Amendment 2: [#782](https://github.com/coseo12/astro-simulator/issues/782) (self-rotation 자전 + 광원 world normal 옵션 e 전환, medium) / Amendment 3: [#783](https://github.com/coseo12/astro-simulator/issues/783) (지구 디테일 — 극관 + biome 위도 색 변화, medium)
 - **관련**: [#738 절차적 별 배경](20260624-738-procedural-starfield.md) (트랙 A 선행), [`docs/architecture/principles.md` §1 Visual Fidelity](../architecture/principles.md)
 - **용어**: [Tier](../glossary.md#tier-t1--t2--t3), [R-Phase](../glossary.md#r-phase-roadmap-v3-phase), [LOD](../glossary.md) (high/mid/low variant)
 
@@ -629,3 +629,171 @@ self-rotation 도입 후 회전 non-zero 가 **정상**이 되므로 Amendment 1
 **호출 전 Claude 편향 셀프 체크 통과 여부** (1줄): 낙관적 일정 축은 **미통과** (Q1 ring 계층 비용을 b-ii 저비용으로 과소평가 → agy 이견 수용으로 pivot 계층 + 비용 상향 정정). 결합 간과 축은 **부분 통과** (ring 결합 실측했으나 격리 구조는 agy 권고로 확정). 순수주의/폐기 프레이밍 축 통과.
 
 **→ 상태 전이: Provisional → Accepted (cross-validate 2026-07-01)**. §A2.3 결정 1 을 pivot 계층 확정으로 갱신 (위 이견 수용 1).
+
+---
+
+## Amendment 3 (2026-07-04) — 지구 디테일: 극관 + biome 위도 색 변화 (#783)
+
+- **상태**: Provisional (cross-validate 대기 — 메인 오케스트레이터가 수행 후 §A3.8 통합 → Accepted 전이)
+- **이슈**: [#783](https://github.com/coseo12/astro-simulator/issues/783) (type:feat, medium, group:B-render, #775 후속 — 사용자 관찰 2026-07-01 "지구가 지구 같지 않음")
+- **형식**: **Amendment** (신규 ADR 기각) — 판단 근거는 §A3.3 결정 1. 일반 Amendment (forensic 비대상 — 회귀가 아닌 신규 시각 기능, runtime 측정으로 결정이 갈리는 가설 경합 없음).
+
+### A3.1 배경 — #775 가 남긴 "1차 비목표" 의 실현
+
+Amendment 1 §A1.3 결정 4 의 rocky 분기 (`col = mix(baseColor, landColor, landMask)`) 는 ocean↔land **2색뿐** 이며, 결정 4 GLSL 스케치에 `// (선택, 후속 가능) 해안선 대비 / 극관 — 1차 비목표` 로 극관을 명시 예비했다. 본 Amendment 3 은 그 예비된 후속의 실현이다 (Amendment 2 가 A1 의 "옵션 e 전환" 예비를 실현한 것과 동형 관계).
+
+사용자 관찰 (#783): 실제 지구의 시각 상징 (흰 극관 / 다양한 대륙색) 부재로 사실감 부족. 제약 (이슈 계약): 단일 ShaderMaterial high/mid 공유 / 에셋 0 절차적 / if-else / 데이터 SSoT 보존 (rendering-only 코드 상수) / 보라·마젠타 anti-pattern 회피 / #773 광원 shade 최종 곱 유지.
+
+### A3.2 코드베이스 실측 (설계 결정의 근거 — 재조사 불필요)
+
+1. **`p.y` = sin(위도) — "정규화된 위도" 가 아니다 (이슈 판단 요청 4-c 실측)**. body sphere 는 `MeshBuilder.CreateSphere` (`solar-system-scene.ts:2116/:2169`) — Babylon 구는 pole 이 **local ±Y**. fragment 의 `p = normalize(vLocalPos)` 는 단위 구면 좌표이므로 `p.y ∈ [−1,1] = sin(latitude)` (선형 위도 아님 — 60° 에서 0.866, 75° 에서 0.966). **위도 임계 상수는 전부 sin-space 로 박제** 하며 상수 주석에 대응 각도를 병기한다. gas-bands 분기가 이미 `float latitude = p.y` 로 동일 좌표를 사용 (#782 Amendment 2 에서 "local Y = 실제 자전축(pole) 정렬" 확정 — 선례).
+2. **자전 불변 (#782 정합)**: spin quaternion 은 local Y 축 회전 → local 정점 좌표 `vLocalPos` 는 불변이고 패턴이 mesh 와 함께 돈다 (painted-on). `abs(p.y)` 위도 밴드/극관은 **자전축 대칭이라 자전해도 위도가 변하지 않는다** — 극관이 흔들리거나 미끄러질 구조 자체가 없음. tilt 도 mesh rotation 이라 local 불변.
+3. **rocky 분기는 earth 전용** (현재 `SURFACE_TYPE_BY_BODY` 에서 Rocky = earth 1개) — rocky 분기 수정은 mars(desert)/jupiter(gas-bands)/moon(cratered) 분기 식에 영향 0 (같은 fragment 소스가 재컴파일되지만 타 분기 식 불변 → 픽셀 불변).
+4. **`continents = fbm(p * 2.4)` 가 rocky 분기에서 이미 계산됨** — biome 경계 jitter 소스로 재사용 가능 (추가 noise 샘플 0, §A3.3 결정 3).
+5. **결정적 측정 수단 존재**: `?rotate=off` (parse-rotate-mode.ts, #782) 로 selfRotation=false → rotationStates 빈 Map → mesh rotation identity → **local Y = world Y = 화면 세로축** (tilt 23.44° 오염 제거) + `&speed=0&t=<jd>` 프레임 고정. 극관/biome 밴드가 disk 세로축을 따라 결정적으로 샘플링 가능.
+
+### A3.3 결정
+
+#### 결정 1 — 형식: #756 Amendment 3 (신규 ADR 기각)
+
+| 축               | (A) 본 ADR Amendment 3                                                                                                    | (B) 신규 ADR (`20260704-783-earth-detail.md`)                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 선례 정합        | ✓ #775 (rocky 분기 확장) 가 Amendment 1 로 처리된 직접 선례. A1 결정 4 가 "극관 — 1차 비목표" 로 본 건을 예비             | ✗ #774 가 신규 ADR 인 이유 (신규 모듈 `sun-shader.ts` + 광원 모델 정반대) 가 본 건에 부재 |
+| 모듈/아키텍처    | ✓ 신규 모듈 0 — 기존 rocky 분기 내부 식 + rendering-only 미학 상수 확장 (아키텍처 결정 없음)                              | △ 결정 대상이 색 체계 상수 설계라 ADR 4섹션 (배경/후보/결정/재검토) 독립 파일 밀도 미달   |
+| 결정 이력 연속성 | ✓ rocky 분기의 전 결정 이력 (§결정 5 → A1 결정 4 → A3) 이 한 파일에 수렴 — 미래 rocky 수정자가 단일 문서로 전체 맥락 회수 | ✗ rocky 분기 이력이 2 파일로 분산                                                         |
+| 파일 비대        | △ 632 → ~800 줄 (수용 가능 — 셰이더 .ts 자체가 824줄)                                                                     | ✓ 분리                                                                                    |
+
+→ **(A) Amendment 3 채택**. "범위/색 체계 결정이 크다" (이슈 판단 요청 1) 는 신규 ADR 근거로 불충분 — 크기가 아니라 **결정의 종류** (신규 모듈/광원 모델 = 신규 ADR, 기존 분기 확장 = Amendment) 가 분기 기준이다 (#774 vs #775 선례 대조).
+
+#### 결정 2 — 범위: Tier 1 한정 (극관 + biome), Tier 2 후속
+
+| 항목                                 | 포함        | 근거                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Tier 1-1 극관 (polar ice caps)       | ✓           | 이슈 핵심. `smoothstep` mask 1개 + 색 상수 1개 — 저비용                                                                                                                                                                                                                                                                                                                                    |
+| Tier 1-2 biome 위도 색 (3밴드)       | ✓           | 이슈 핵심. 기존 continents fbm 재사용으로 noise 샘플 +0 (결정 3)                                                                                                                                                                                                                                                                                                                           |
+| Tier 2-3 바다 깊이 색 (deep/shallow) | ✗ 후속      | 저비용임은 인정 (§A3.7 재검토 조건 1 에 설계 스케치 박제 — continents 값 재활용). 단 (i) DoD 측정 축 +1 (deep/shallow 픽셀 판별 방법 별도 설계 필요), (ii) ocean = baseColor (데이터 SSoT read-only) 규약에 shallow 신규 상수가 얹히는 색 체계 논의 확장, (iii) Tier 1 만으로 "지구가 지구처럼 보인다" 완결 Behavior Change 집합 성립. scope 절제 우선 (CRITICAL #6)                       |
+| Tier 2-4 대기 fresnel rim            | ✗ 후속      | #774 가 `cameraPosition` auto-bind 를 실증해 viewDir 비용은 하락 (이슈 판단 요청 2 의 재평가 반영). 그러나 (i) 4 타입 공유 셰이더에 rocky 전용 varying (vWorldPos) 혼입 — #774 결정 1 이 "무의미한 uniform 동거" 를 분리 근거로 쓴 논리의 역방향 침범, (ii) 대기 표현은 구름 (Tier 3) 과 묶어 별도 레이어로 설계하는 것이 자연 (§A1.8 재검토 조건 5 대기/구름 mesh 박제와 합류). 후속 유지 |
+| Tier 3 구름 / 야간 불빛              | ✗ 별도 트랙 | 별도 mesh/레이어 — §A1.8 재검토 조건 5 그대로                                                                                                                                                                                                                                                                                                                                              |
+
+#### 결정 3 — biome 색 구조: 3밴드 연쇄 mix + continents 재사용 jitter
+
+**위도 파라미터** (sin-space, §A3.2-1):
+
+```glsl
+// rocky 분기 (uSurfaceType == 0) — 기존 continents/landMask 계산 직후
+float latRaw = abs(p.y);                                        // |sin(위도)| — 남북 대칭
+float latJ = latRaw + (continents - 0.5) * biomeLatJitter;      // 경계 자연화 — 기존 fbm 재사용 (추가 noise 0)
+// 대륙색: 적도 녹색 → 중위도 황토·갈색 → 고위도 툰드라 회백 (2 smoothstep 연쇄 mix)
+vec3 landCol = mix(biomeTropicalColor, landColor, smoothstep(biomeTemperateLo, biomeTemperateHi, latJ));
+landCol = mix(landCol, biomeTundraColor, smoothstep(biomeTundraLo, biomeTundraHi, latJ));
+col = mix(baseColor, landCol, landMask);                        // #775 해안선 전이 유지 (ocean = baseColor 불변)
+// 극관 — continents 무관 (결정 4), ocean/land 공통 최종 mix
+float iceMask = smoothstep(iceLatLo, iceLatHi, latJ);
+col = mix(col, iceColor, iceMask);
+```
+
+**하위 결정 3-a — 밴드 수 = 3 (+ 극관)**: 이슈 명세 그대로 (적도 열대 / 중위도 사막·평원 / 고위도 툰드라). 밴드 4+ (예: 아열대 분리) 는 smoothstep/상수 표면만 늘리고 px 단위 시각 구분 불가 (earth disk 는 focus 시에도 수백 px — 밴드당 수십 px). 밴드 2 는 "다양한 대륙색" 요구 미달.
+
+**하위 결정 3-b — 색 상수 (신규 3 + 기존 1 재사용)**: 전부 `procedural-planet-shader.ts` rendering-only 미학 상수 SSoT (starfield/#775 패턴 — export + 단위 테스트 가드). 출발값은 물리/자연색 근사, **최종값은 developer measurement-first 시각 튜닝 재량** (#774 결정 8 동형):
+
+| 상수                           | 출발값                                                                     | 근거·제약                                                                                                                                                                    |
+| ------------------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BIOME_TROPICAL_RGB` (신규)    | `(0.20, 0.38, 0.16)`                                                       | 열대 녹 — G 우세. **제약: G-share (G/(R+G+B)) 가 temperate 보다 커야 함** (DoD 2 밴드 구분 측정 가능성)                                                                      |
+| `LAND_COLOR_RGB` (기존 재사용) | 현행 `(0.34, 0.40, 0.24)` → 황토 방향 튜닝 재량 (예: `(0.44, 0.38, 0.23)`) | **중위도 temperate 밴드 색으로 의미 재문서화** — #775 상수/uniform (`landColor`) 배선 그대로 유지 (drift 0). 값 갱신 시 기존 박제값 테스트 동반 갱신 (SSoT 갱신 — 정상 경로) |
+| `BIOME_TUNDRA_RGB` (신규)      | `(0.55, 0.56, 0.52)`                                                       | 고위도 툰드라 회백 — 극관과의 연속 전이 (이슈 "툰드라→극관 연결")                                                                                                            |
+| `ICE_COLOR_RGB` (신규)         | `(0.93, 0.95, 0.96)`                                                       | 근중성 백 — G ≥ min(R,B) 유지 (anti-pattern 가드 자동 충족, B 단독 우세 아님)                                                                                                |
+
+| 위도 임계 (신규, sin-space) | 출발값      | 대응 위도                                                     |
+| --------------------------- | ----------- | ------------------------------------------------------------- |
+| `BIOME_TEMPERATE_LO/HI`     | 0.30 / 0.55 | ~17°–33° (열대→온대 전이)                                     |
+| `BIOME_TUNDRA_LO/HI`        | 0.72 / 0.88 | ~46°–62° (온대→툰드라 전이)                                   |
+| `ICE_LAT_LO/HI`             | 0.88 / 0.96 | ~62°–74° (극관 전이 — 실제 빙권 위도대 근사)                  |
+| `BIOME_LAT_JITTER`          | 0.12        | 경계 요동 진폭 (continents fbm ±0.5 × 0.12 = 위도 ±0.06 요동) |
+
+**하위 결정 3-c — 경계 자연화 = 기존 `continents` fbm 재사용 (독립 noise 샘플 기각)**:
+
+| 축            | (A) `continents` 값 재사용 jitter                                                                | (B) 독립 `fbm(p * K)` 신규 샘플                       |
+| ------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| fragment 비용 | ✓ **noise +0** (smoothstep 3 + mix 4 만 추가 — value noise 8 hash × 3 옥타브 회피)               | ✗ fbm 1회 = hash 24회 추가 (fill-rate, tier-b 실 GPU) |
+| 시각 유기성   | ✓ biome 경계가 대륙 패턴과 동일 저주파 장(場)을 따라 요동 — 지형 연동처럼 보임                   | △ 독립 요동 (지형 무관)                               |
+| 결합 리스크   | △ landMask 임계 (0.48–0.62) 와 jitter 소스가 동일 값 — 상관 자체는 의도, 아티팩트 여부는 qa 실측 | ✓ 독립                                                |
+
+→ **(A) 채택**. 비용 우위 (표면 셰이더는 earth focus 대면적 fill — #756 결정 6 fill-rate 철학) + 유기성. 상관 아티팩트 (예: 해안선 부근 biome 경계 쏠림) 가 qa 실측에서 부자연하면 (B) 승격 (§A3.7 재검토 조건 4) — cross-validate 명시 질문 1 대상.
+
+**uniform 배선**: 신규 색 3 (vec3) + 위도 임계 6 + jitter 1 = **uniform +10 (전부 rocky 전용)** — 기존 landColor/landThreshold 패턴 그대로 (uniforms 배열 + setColor3/setFloat + GLSL 선언 + JS 미러 동기 4중 SSoT).
+
+#### 결정 4 — 극관 mask: continents 무관 + ocean/land 공통 최종 mix
+
+| 축        | (A) 극관 = land 위에만 (`landMask` 곱)                                | (B) **continents 무관 — ocean/land 공통 최종 mix**                                 |
+| --------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 물리 정합 | ✗ 북극은 해빙 (ocean 위 얼음) — land 한정이면 북극이 파란 바다로 남음 | ✓ 북극 해빙 + 남극 대륙 빙상 — 둘 다 흰색 (이슈 판단 요청 4-b 의 물리 근거 그대로) |
+| 시각 상징 | ✗ 극이 얼룩덜룩 (대륙 패턴 노출)                                      | ✓ 흰 극관 — 지구 시각 상징                                                         |
+| 식 비용   | 동일                                                                  | 동일 (mix 1)                                                                       |
+
+→ **(B) 채택**. `iceMask` 는 ocean↔land mix **이후 최종 mix** 로 적용 — 극관이 해안선 전이 위를 덮는 것은 고위도 (sin-lat ≥ 0.88) 한정이라 #775 의 중·저위도 해안선 전이는 불변 (규약 (b) 정합). 극관도 albedo 단계 (`col`) 에서 결정되고 `col *= shade` 최종 곱은 무변경 — 밤면 극관은 어둡다 (#773 규약 (a) 정합, 낮/밤 대비 유지).
+
+### A3.4 Concrete Prediction (구현 후 `git diff --stat` 실측 재현)
+
+| 영역                     | 파일                                                                         | 예측 라인         | 근거                                                                                                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **셰이더 rocky 확장**    | `procedural-planet-shader.ts`                                                | ~90–150 변경/신규 | GLSL rocky 분기 +8–14 줄 + 상수 4 색 + 7 float (주석 포함) + uniforms 배열 +10 + setColor3/setFloat +10 + JS 미러 rocky +20–35 + 헤더 주석 갱신                        |
+| **단위 테스트**          | `procedural-planet-shader.test.ts`                                           | ~70–130 신규/변경 | 극 위도 → ice 수렴 (landMask 양극단 모두) / 적도 vs 중위도 G-share 순서 / 신규 색 anti-pattern / 상수 SSoT drift (uniform 선언 + 배선) / 기존 rocky 박제값 테스트 갱신 |
+| **browser verify**       | `apps/web/scripts/browser-verify-783-earth-detail.mjs` (신규)                | ~130–190 신규     | `?focus=earth&rotate=off&speed=0` 결정적 프레임 — 극관 whiteness / 밴드 G-share / 마젠타 0 픽셀 측정                                                                   |
+| **scene / web / 데이터** | `solar-system-scene.ts` / `sim-canvas.tsx` / `parse-*` / `solar-system.json` | **0**             | 미학 상수는 셰이더 모듈 내부 SSoT (scene 주입 불필요 — #775 landColor 동형). 데이터 0 (rendering-only)                                                                 |
+| **타 셰이더**            | `sun-shader.ts` / `ring-shader.ts` / `starfield.ts`                          | **0**             | 무관 모듈                                                                                                                                                              |
+
+**핵심 예측** (reviewer/qa 실측 대상):
+
+- **rocky 외 3종 (mars/jupiter/moon) 픽셀 불변** — rocky 분기 식만 수정, desert/gas-bands/cratered 분기 무변경 (공유 소스 재컴파일되나 식 불변). 스크린샷 diff ≈ 0 예측. 실패 시 = 분기 격리 위반 신호.
+- **noise 샘플 +0** — fbm 호출 수 불변 (continents 재사용). fbm 신규 호출 발견 시 = 결정 3-c 위반.
+- **picking / camera / orbit / tier / LOD / r1-guard 변경 0** — fragment albedo 식 + uniform 만. mesh 기하/metadata/rotation 불변. r1-guard 는 canvas 미측정 (A2 결정 7) 이라 baseline 재생성 불요 예상 (qa 실측 확인).
+
+### A3.5 DoD (측정 가능 — 실 Chrome GUI 필수, CRITICAL #3 + WebGPU readback 금지 #756/#728)
+
+| #   | 기준                                                                                                                                                                                   | 측정 방법                                                                                                                                        |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **극관 실재**: earth disk 세로 양극단 12% 영역 (낮면 측, 남북 모두) 의 near-white 픽셀 (min(R,G,B) ≥ 140/255 && max−min 채널 ≤ 40/255) 비율 ≥ 50%, OFF (`&surface=off`) 대비 유의 증가 | `?focus=earth&rotate=off&speed=0` (identity rotation → local Y = 화면 세로, §A3.2-5) — Playwright composited screenshot + pngjs (#756 qa 방법론) |
+| 2   | **biome 위도 색 변화**: 적도 밴드 (disk 중심 ±0.15R) land 픽셀 평균 G-share > 중위도 밴드 (0.4–0.65R) land 픽셀 평균 G-share (낮면 측 통계)                                            | 동일 스크린샷 위도 밴드별 샘플링 (browser-verify-783)                                                                                            |
+| 3   | **보라/마젠타 0**: 미러 전 샘플 G ≥ min(R,B) 위배 0 (단위 테스트) + GUI earth disk 에 R>G+τ && B>G+τ 픽셀 0 (τ=15/255)                                                                 | `procedural-planet-shader.test.ts` + verify 스크립트                                                                                             |
+| 4   | **#773 광원 무회귀**: 낮/밤 휘도 대비비 ≥ 5x 유지 (A1.5 DoD 1 재현) + terminator 태양 추종 + 밤면 극관도 어두움 (밤면 극 휘도 < 낮면 극 휘도 × 1/3)                                    | 기존 browser-verify-773 + 신규 극 휘도 비교                                                                                                      |
+| 5   | **#775 무회귀**: 중·저위도 land/ocean 색조 구분 유지 (해안선 전이 불변)                                                                                                                | 기존 #775 검증 축 재현                                                                                                                           |
+| 6   | **#756 무회귀**: earth 라플라시안 고주파 엔트로피 ON > OFF 유지 + **mars/jupiter/moon 스크린샷 diff ≈ 0** (분기 격리)                                                                  | browser-verify-756 + 3종 diff                                                                                                                    |
+| 7   | **fps 회귀 0**: fps-baseline-guard PASS (CI swiftshader tier-c 포함 — tier-c 는 forceOverride 자동 우회, noise +0 이라 tier-a/b 예산 내)                                               | CI workflow                                                                                                                                      |
+| 8   | **데이터 0**: `git diff --stat` 에 `solar-system.json` 부재                                                                                                                            | reviewer 실측                                                                                                                                    |
+| 9   | **core typecheck 0** (#719 — dev/메인/reviewer 3중) + 기존 procedural-planet 테스트 전체 PASS                                                                                          | `pnpm --filter core typecheck` + vitest                                                                                                          |
+
+### A3.6 §Visual Fidelity 의무 체크리스트 4항목 (principles.md §1)
+
+- [x] **데이터 SSoT 보존** — biome/극관 색·위도 임계는 전부 `procedural-planet-shader.ts` rendering-only 미학 상수. `solar-system.json` 직접 수정 0 (DoD 8). ocean = `colorHint.hex` read-only 유지.
+- [x] **rendering 시점 분리** — fragment albedo 식 단독. physics 엔진 (Rust+wasm) 무의존, P11-A 좌표 계약 위반 0.
+- [x] **사용자 D-T2 가이드** — 극관/biome 은 순수 시각 표현 (위도 밴드는 실제 기후대의 근사 왜곡). Info/focus 패널 실측값 표기 불변.
+- [x] **점유율 / 사실 비율 baseline** — mesh 크기/위치/rotation 불변 (albedo 만) → px diameter / 점유율 / 분리 마진 / #762 단조성 영향 0. r1-guard canvas 미측정 (재생성 불요 예상 — qa 실측 판정).
+
+### A3.7 결과 · 재검토 조건
+
+**기대 결과**: `?focus=earth` 에서 흰 극관 (남북) + 적도 녹 → 중위도 황토 → 고위도 회백 대륙색 + 파란 바다 (실 Chrome GUI). 자전 시 극관/밴드가 표면과 함께 회전 (painted-on, 위도 불변). mars/jupiter/moon + 단색 22 + sun 무회귀. `?surface=off` 100% 복귀.
+
+**재검토 조건**:
+
+1. **바다 깊이 색 (Tier 2-3) 요구** — 설계 스케치: `float depth = smoothstep(landThresholdLo, 0.0, continents)` (continents 재활용 — landMask 하위 구간을 깊이로 역해석, noise +0) + `DEEP_OCEAN_RGB` 상수 1개, `oceanCol = mix(baseColor, deepOcean, depth)` 를 첫 mix 의 baseColor 자리에 대입. ocean = colorHint read-only 규약과의 관계 (deep 색이 baseColor 변조인지 독립 상수인지) 재론 필요.
+2. **대기 fresnel rim (Tier 2-4) 요구** — #774 cameraPosition auto-bind 실증으로 uniform 비용 하락. 단 공유 셰이더 varying 혼입 vs 별도 대기 레이어 (§A1.8 재검토 조건 5) 비교 선행 — 구름 도입 시점과 합류 권장.
+3. **구름 / 야간 도시 불빛 (Tier 3)** — 별도 mesh/레이어 트랙 (§A1.8 재검토 조건 5 그대로). 구름은 #782 자전과 차등 offset 필요.
+4. **biome 경계 상관 아티팩트** — continents 재사용 jitter (결정 3-c) 가 해안선-biome 경계 쏠림 등 부자연 발견 시 독립 fbm 샘플 (B) 승격 (fbm +1 비용 재평가 동반).
+5. **다른 rocky body 확장** — mars 등 을 Rocky 로 재분류하거나 위성 rocky 추가 시 biome 파라미터가 earth 전용 상수라 body 별 파라미터화 필요 (§A1.8 재검토 조건 4 연장).
+
+### A3.8 교차검증 반영 사항 (cross-validate 대기 — Provisional)
+
+**호출 전 Claude 편향 셀프 체크** (4종):
+
+- **낙관적 일정** (셰이더 +10 uniform 4중 SSoT 배선 비용 — Concrete Prediction 을 미러/테스트 포함 폭넓게 잡아 통과 예상).
+- **결합 간과** (continents fbm 을 landMask 임계와 biome jitter 양쪽에 재사용 — 동일 noise 장 상관이 의도된 유기성인지 아티팩트원인지 단정 못 함) — **미통과 의심** → 명시 질문 1.
+- **폐기 프레이밍** (단일 land 색을 "단조" 로 폐기 — 사용자 관찰 #783 실측 근거라 통과).
+- **순수주의** (sin-space 임계 직접 박제가 도 단위 대비 가독성 손해 — 상수 주석에 대응 각도 병기로 완화, fragment 비용 0 이 우선. 통과 예상).
+
+**cross-validate 명시 질문** (메인 수행 시 프롬프트 삽입):
+
+1. (결합 간과) biome 경계 jitter 소스로 기존 `continents` fbm 을 재사용 (noise +0) 하는 것 vs 독립 fbm 샘플 — 동일 noise 장 상관의 시각 아티팩트 리스크 평가.
+2. 극관을 ocean/land mix **이후 최종 mix** 로 얹는 순서 (결정 4 B) 가 툰드라→극관 연속성 / #775 해안선 전이와 충돌하지 않는가.
+3. `LAND_COLOR_RGB` 재사용 (temperate 의미 재문서화 + 값 튜닝) vs biome 3색 전부 신규 상수 — 기존 #775 상수/uniform/테스트 계약과의 drift 리스크 비교.
+
+_(cross-validate 수행 결과 — 메인 오케스트레이터가 4축 분류 (합의 / 이견 수용 / 기각 / 고유 발견) 로 본 섹션에 통합 후 Provisional → Accepted 전이)_

--- a/packages/core/src/scene/procedural-planet-shader.test.ts
+++ b/packages/core/src/scene/procedural-planet-shader.test.ts
@@ -528,8 +528,8 @@ describe('#783 극관 — 극 위도 ice 수렴 (landMask 양극단 — continen
     Math.min(...rgb) >= NEAR_WHITE_MIN && Math.max(...rgb) - Math.min(...rgb) <= NEAR_WHITE_SPREAD;
 
   it('정확한 남북극 (p = [0,±1,0]) 에서 near-white 수렴 — jitter 최악 경우 포함', () => {
-    // 극점 latRaw=1, latJ = 1 + (continents−0.5)×0.12 ∈ [0.94, 1.06] — iceMask ≥ smoothstep(0.88,0.96,0.94)
-    // ≈ 0.84 로 어느 continents 값이든 (ocean/land 무관) near-white 에 수렴한다.
+    // 극점 latRaw=1, latJ = 1 + (continents−0.5)×0.12 ∈ [0.94, 1.06] — iceMask ≥ smoothstep(0.84,0.92,0.94)
+    // = 1.0 (포화) 로 어느 continents 값이든 (ocean/land 무관) near-white 에 수렴한다.
     for (const pole of [1, -1] as const) {
       const out = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, [0, pole, 0]);
       expect(isNearWhite(out)).toBe(true);

--- a/packages/core/src/scene/procedural-planet-shader.test.ts
+++ b/packages/core/src/scene/procedural-planet-shader.test.ts
@@ -28,6 +28,16 @@ import {
   LAND_COLOR_RGB,
   LAND_THRESHOLD_LO,
   LAND_THRESHOLD_HI,
+  BIOME_TROPICAL_RGB,
+  BIOME_TUNDRA_RGB,
+  ICE_COLOR_RGB,
+  BIOME_TEMPERATE_LO,
+  BIOME_TEMPERATE_HI,
+  BIOME_TUNDRA_LO,
+  BIOME_TUNDRA_HI,
+  ICE_LAT_LO,
+  ICE_LAT_HI,
+  BIOME_LAT_JITTER,
   fbmMirror,
   surfaceColorMirror,
   lightingShadeMirror,
@@ -35,6 +45,25 @@ import {
   PLANET_VERTEX_SHADER,
   PLANET_FRAGMENT_SHADER,
 } from './procedural-planet-shader.js';
+
+/** 구면 골든앵글 샘플 (결정적) — 위도/경도 고른 커버리지 (#783 밴드 테스트 공용). */
+function spherePoints(n: number): Array<[number, number, number]> {
+  const pts: Array<[number, number, number]> = [];
+  const ga = Math.PI * (3 - Math.sqrt(5));
+  for (let i = 0; i < n; i++) {
+    const y = 1 - (2 * (i + 0.5)) / n;
+    const r = Math.sqrt(Math.max(1 - y * y, 0));
+    const th = ga * i;
+    pts.push([r * Math.cos(th), y, r * Math.sin(th)]);
+  }
+  return pts;
+}
+
+/** #783 검증용 — GLSL 과 동일 smoothstep (테스트 로컬 미러). */
+function smoothstepMirror(e0: number, e1: number, x: number): number {
+  const t = Math.min(Math.max((x - e0) / Math.max(e1 - e0, 1e-6), 0), 1);
+  return t * t * (3 - 2 * t);
+}
 
 describe('#756 procedural-planet — surfaceType enum ↔ uniform int 매핑 SSoT (ADR §교차검증 이견 수용 2)', () => {
   // #719 교훈 + cross-validate 이견 수용 2 — JS enum 정수가 곧 GLSL `uniform int surfaceType` 값.
@@ -354,37 +383,44 @@ describe('#775 지구 대륙 mix — ocean ↔ land 색 분리 (ADR §A1.5 DoD 4
   // earth base = 청록 (ocean), land = 올리브-브라운. landMask 로 색조(hue) mix → "바다만" 회귀 해소.
   const EARTH_OCEAN: [number, number, number] = [0.23, 0.45, 0.6];
 
-  it('rocky 대륙 mix — ocean(landMask=0) + land(landMask=1) 색 둘 다 존재', () => {
-    // continents 가 LO 미만이 되는 표면점을 찾아 ocean 색 유지 확인 — 다수 샘플 중 ocean/land 둘 다 존재.
+  it('rocky 대륙 mix — ocean(landMask=0) + land(landMask=1) 색 둘 다 존재 (#783 밴드 조건 반영)', () => {
+    // Amendment 3 (#783) 후 land 색은 위도 의존 (biome 3밴드) + 고위도는 극관이 덮는다.
+    // 따라서 박제값 대조는 밴드가 확정되는 latJ 구간으로 조건화한다:
+    //  - ocean: continents ≤ LO && latJ ≤ ICE_LAT_LO → baseColor 그대로 (#775 read-only 규약 유지)
+    //  - land(tropical): continents ≥ HI && latJ ≤ TEMPERATE_LO → BIOME_TROPICAL_RGB
+    //  - land(temperate): continents ≥ HI && TEMPERATE_HI ≤ latJ ≤ TUNDRA_LO → LAND_COLOR_RGB
     let foundOcean = false;
-    let foundLand = false;
-    for (let i = 0; i < 400; i++) {
-      const t = i * 0.0157;
-      const x = Math.sin(t * 1.3) * Math.cos(t * 0.7);
-      const y = Math.cos(t * 1.1);
-      const z = Math.sin(t * 0.9) * Math.sin(t * 0.6);
-      const len = Math.hypot(x, y, z) || 1;
-      const p: [number, number, number] = [x / len, y / len, z / len];
+    let foundTropical = false;
+    let foundTemperate = false;
+    for (const p of spherePoints(4000)) {
       const continents = fbmMirror(p[0] * 2.4, p[1] * 2.4, p[2] * 2.4);
+      const latJ = Math.abs(p[1]) + (continents - 0.5) * BIOME_LAT_JITTER;
       const [r, g, b] = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, p);
-      if (continents <= LAND_THRESHOLD_LO) {
-        // ocean 색 (baseColor) 에 근접.
+      if (continents <= LAND_THRESHOLD_LO && latJ <= ICE_LAT_LO) {
+        // ocean 색 (baseColor) 그대로 — 중·저위도 해안선/바다 불변 (#775 무회귀, §A3.5 DoD 5).
         expect(r).toBeCloseTo(EARTH_OCEAN[0], 4);
         expect(g).toBeCloseTo(EARTH_OCEAN[1], 4);
         expect(b).toBeCloseTo(EARTH_OCEAN[2], 4);
         foundOcean = true;
       }
       if (continents >= LAND_THRESHOLD_HI) {
-        // land 색 (LAND_COLOR_RGB) 에 근접.
-        expect(r).toBeCloseTo(LAND_COLOR_RGB.r, 4);
-        expect(g).toBeCloseTo(LAND_COLOR_RGB.g, 4);
-        expect(b).toBeCloseTo(LAND_COLOR_RGB.b, 4);
-        foundLand = true;
+        if (latJ <= BIOME_TEMPERATE_LO) {
+          expect(r).toBeCloseTo(BIOME_TROPICAL_RGB.r, 4);
+          expect(g).toBeCloseTo(BIOME_TROPICAL_RGB.g, 4);
+          expect(b).toBeCloseTo(BIOME_TROPICAL_RGB.b, 4);
+          foundTropical = true;
+        } else if (latJ >= BIOME_TEMPERATE_HI && latJ <= BIOME_TUNDRA_LO) {
+          expect(r).toBeCloseTo(LAND_COLOR_RGB.r, 4);
+          expect(g).toBeCloseTo(LAND_COLOR_RGB.g, 4);
+          expect(b).toBeCloseTo(LAND_COLOR_RGB.b, 4);
+          foundTemperate = true;
+        }
       }
     }
-    // 지구 표면에 대륙과 바다가 둘 다 존재해야 (mix 가 의미 있음).
+    // 지구 표면에 바다 + 열대 대륙 + 온대 대륙이 모두 존재해야 (mix/밴드가 의미 있음).
     expect(foundOcean).toBe(true);
-    expect(foundLand).toBe(true);
+    expect(foundTropical).toBe(true);
+    expect(foundTemperate).toBe(true);
   });
 
   it('ocean 과 land 가 색조(hue) 다름 — "바다만 밝기 변조" 회귀 해소', () => {
@@ -398,8 +434,9 @@ describe('#775 지구 대륙 mix — ocean ↔ land 색 분리 (ADR §A1.5 DoD 4
     expect(LAND_COLOR_RGB.g).toBeGreaterThanOrEqual(Math.min(LAND_COLOR_RGB.r, LAND_COLOR_RGB.b));
   });
 
-  it('GLSL rocky 분기가 mix(baseColor, landColor, landMask) 사용 (밝기 변조 → 색 mix)', () => {
-    expect(PLANET_FRAGMENT_SHADER).toContain('mix(baseColor, landColor, landMask)');
+  it('GLSL rocky 분기가 mix(baseColor, landCol, landMask) 사용 (밝기 변조 → 색 mix — #783 landCol 밴드)', () => {
+    // Amendment 3 (#783): 단일 landColor → 위도 밴드 합성 landCol 로 확장 (ocean=baseColor 불변).
+    expect(PLANET_FRAGMENT_SHADER).toContain('mix(baseColor, landCol, landMask)');
     expect(PLANET_FRAGMENT_SHADER).toContain('smoothstep(landThresholdLo, landThresholdHi');
     expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 landColor');
   });
@@ -408,7 +445,9 @@ describe('#775 지구 대륙 mix — ocean ↔ land 색 분리 (ADR §A1.5 DoD 4
 describe('Amendment 1 — 신규 미학 상수 SSoT (#69 drift 가드)', () => {
   it('soft terminator / 육지색 / 임계 박제값 (drift 시 시각 회귀)', () => {
     expect(SOFT_TERMINATOR_WIDTH).toBe(0.12);
-    expect(LAND_COLOR_RGB).toEqual({ r: 0.34, g: 0.4, b: 0.24 });
+    // #783 튜닝: 올리브 (0.34,0.40,0.24) → 황토 (temperate 밴드 재문서화 — §A3.3 결정 3-b,
+    // DoD 2 적도>중위도 G-share 분리 마진 확보. SSoT 갱신 = 정상 경로).
+    expect(LAND_COLOR_RGB).toEqual({ r: 0.44, g: 0.38, b: 0.23 });
     expect(LAND_THRESHOLD_LO).toBe(0.48);
     expect(LAND_THRESHOLD_HI).toBe(0.62);
   });
@@ -473,5 +512,167 @@ describe('Amendment 2 (#782) — JS 미러 world normal 계약 (미러 식 불�
     const nightLum = luminance709(lightingShadeMirror(nightN, sunDir));
     expect(dayLum).toBeGreaterThan(termLum);
     expect(termLum).toBeGreaterThanOrEqual(nightLum);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Amendment 3 (#783) — 지구 극관 + biome 위도 색 변화 (ADR §A3.3 결정 3·4 + §A3.5).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('#783 극관 — 극 위도 ice 수렴 (landMask 양극단 — continents 무관, §A3.3 결정 4 B)', () => {
+  const EARTH_OCEAN: [number, number, number] = [0.23, 0.45, 0.6];
+  // §A3.5 DoD 1 near-white 산식 (/255 → [0,1] 정규화): min(R,G,B) ≥ 140/255 && max−min ≤ 40/255.
+  const NEAR_WHITE_MIN = 140 / 255;
+  const NEAR_WHITE_SPREAD = 40 / 255;
+  const isNearWhite = (rgb: readonly [number, number, number]): boolean =>
+    Math.min(...rgb) >= NEAR_WHITE_MIN && Math.max(...rgb) - Math.min(...rgb) <= NEAR_WHITE_SPREAD;
+
+  it('정확한 남북극 (p = [0,±1,0]) 에서 near-white 수렴 — jitter 최악 경우 포함', () => {
+    // 극점 latRaw=1, latJ = 1 + (continents−0.5)×0.12 ∈ [0.94, 1.06] — iceMask ≥ smoothstep(0.88,0.96,0.94)
+    // ≈ 0.84 로 어느 continents 값이든 (ocean/land 무관) near-white 에 수렴한다.
+    for (const pole of [1, -1] as const) {
+      const out = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, [0, pole, 0]);
+      expect(isNearWhite(out)).toBe(true);
+    }
+  });
+
+  it('근극 위도 (|sin lat| ≥ 0.995) 전 샘플 near-white — ocean/land(landMask 양극단) 모두', () => {
+    // 남북 각각 경도 스캔 — continents 값과 무관하게 (landMask 0/1 어느 쪽이든) 극관이 덮는다.
+    let north = 0;
+    let south = 0;
+    for (let i = 0; i < 64; i++) {
+      const th = (i / 64) * Math.PI * 2;
+      const rho = Math.sqrt(1 - 0.995 * 0.995);
+      for (const sign of [1, -1] as const) {
+        const p: [number, number, number] = [rho * Math.cos(th), sign * 0.995, rho * Math.sin(th)];
+        const out = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, p);
+        expect(isNearWhite(out)).toBe(true);
+        if (sign > 0) north++;
+        else south++;
+      }
+    }
+    expect(north).toBeGreaterThan(0);
+    expect(south).toBeGreaterThan(0);
+  });
+
+  it('중·저위도 (latJ ≤ ICE_LAT_LO) 는 iceMask = 0 — 극관이 해안선 전이를 침범하지 않음 (Q2 합의)', () => {
+    for (const p of spherePoints(2000)) {
+      const continents = fbmMirror(p[0] * 2.4, p[1] * 2.4, p[2] * 2.4);
+      const latJ = Math.abs(p[1]) + (continents - 0.5) * BIOME_LAT_JITTER;
+      if (latJ > ICE_LAT_LO) continue;
+      expect(smoothstepMirror(ICE_LAT_LO, ICE_LAT_HI, latJ)).toBe(0);
+    }
+  });
+});
+
+describe('#783 biome — 적도 vs 중위도 G-share 순서 (§A3.5 DoD 2 단위축)', () => {
+  const EARTH_OCEAN: [number, number, number] = [0.23, 0.45, 0.6];
+  const gShare = (rgb: readonly [number, number, number]): number =>
+    rgb[1] / Math.max(rgb[0] + rgb[1] + rgb[2], 1e-6);
+
+  it('full-land 픽셀: 적도 밴드 (|sin lat| ≤ 0.15) 평균 G-share > 중위도 밴드 (0.4–0.65)', () => {
+    const eq: number[] = [];
+    const mid: number[] = [];
+    for (const p of spherePoints(6000)) {
+      const continents = fbmMirror(p[0] * 2.4, p[1] * 2.4, p[2] * 2.4);
+      if (continents < LAND_THRESHOLD_HI) continue; // full land 만 (해안 전이 배제)
+      const absY = Math.abs(p[1]);
+      const out = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, p);
+      if (absY <= 0.15) eq.push(gShare(out));
+      else if (absY >= 0.4 && absY <= 0.65) mid.push(gShare(out));
+    }
+    // 통계 유의성 — 밴드당 표본 최소 확보 (스캔 커버리지 가드).
+    expect(eq.length).toBeGreaterThan(20);
+    expect(mid.length).toBeGreaterThan(20);
+    const mean = (a: number[]): number => a.reduce((s, v) => s + v, 0) / a.length;
+    expect(mean(eq)).toBeGreaterThan(mean(mid));
+  });
+
+  it('색 상수 제약: G-share(BIOME_TROPICAL) > G-share(LAND_COLOR=temperate) (§A3.3 결정 3-b)', () => {
+    const gs = (c: { r: number; g: number; b: number }): number => c.g / (c.r + c.g + c.b);
+    expect(gs(BIOME_TROPICAL_RGB)).toBeGreaterThan(gs(LAND_COLOR_RGB));
+  });
+});
+
+describe('#783 anti-pattern — 신규 색 G ≥ min(R,B) (보라/마젠타 구조 회피, §A3.5 DoD 3)', () => {
+  it('biome/극관 색 4종 전부 G ≥ min(R,B)', () => {
+    for (const c of [BIOME_TROPICAL_RGB, BIOME_TUNDRA_RGB, ICE_COLOR_RGB, LAND_COLOR_RGB]) {
+      expect(c.g).toBeGreaterThanOrEqual(Math.min(c.r, c.b));
+    }
+  });
+
+  it('rocky 미러 전 표면 샘플 G ≥ min(R,B) 위배 0 (mix 결과 포함 — DoD 3 미러축)', () => {
+    const EARTH_OCEAN: [number, number, number] = [0.23, 0.45, 0.6];
+    let violations = 0;
+    for (const p of spherePoints(4000)) {
+      const [r, g, b] = surfaceColorMirror(EARTH_OCEAN, SurfaceType.Rocky, p);
+      if (g < Math.min(r, b) - 1e-6) violations++;
+    }
+    expect(violations).toBe(0);
+  });
+});
+
+describe('#783 상수 SSoT drift 가드 (#69 — 4중 SSoT: 상수/uniforms/바인딩/GLSL + 미러)', () => {
+  it('박제값 (sin-space 위도 임계 — 주석 각도 병기, drift 시 시각 회귀)', () => {
+    expect(BIOME_TROPICAL_RGB).toEqual({ r: 0.2, g: 0.38, b: 0.16 });
+    expect(BIOME_TUNDRA_RGB).toEqual({ r: 0.55, g: 0.56, b: 0.52 });
+    expect(ICE_COLOR_RGB).toEqual({ r: 0.93, g: 0.95, b: 0.96 });
+    expect(BIOME_TEMPERATE_LO).toBe(0.3);
+    expect(BIOME_TEMPERATE_HI).toBe(0.55);
+    expect(BIOME_TUNDRA_LO).toBe(0.72);
+    // #783 measurement-first 튜닝: 출발값 (TUNDRA_HI 0.88 / ICE 0.88·0.96) 은 ice ramp 가
+    // DoD 1 측정 밴드 (≥0.88) 전체와 겹쳐 실측 10.2% 미달 → 0.84/0.84·0.92 하향 (상수 주석 참조).
+    expect(BIOME_TUNDRA_HI).toBe(0.84);
+    expect(ICE_LAT_LO).toBe(0.84);
+    expect(ICE_LAT_HI).toBe(0.92);
+    expect(BIOME_LAT_JITTER).toBe(0.12);
+  });
+
+  it('위도 임계 순서 — 밴드 겹침 없이 순차 (tropical → temperate → tundra → ice, Q2 합의)', () => {
+    expect(BIOME_TEMPERATE_LO).toBeGreaterThan(0);
+    expect(BIOME_TEMPERATE_LO).toBeLessThan(BIOME_TEMPERATE_HI);
+    expect(BIOME_TEMPERATE_HI).toBeLessThanOrEqual(BIOME_TUNDRA_LO);
+    expect(BIOME_TUNDRA_LO).toBeLessThan(BIOME_TUNDRA_HI);
+    // 툰드라→극관 연속 전이 (이슈 "툰드라→극관 연결") — TUNDRA_HI 가 ICE_LAT_LO 와 맞닿음.
+    expect(BIOME_TUNDRA_HI).toBeLessThanOrEqual(ICE_LAT_LO);
+    expect(ICE_LAT_LO).toBeLessThan(ICE_LAT_HI);
+    expect(ICE_LAT_HI).toBeLessThanOrEqual(1);
+    // jitter 진폭 (±0.06 요동) 이 밴드 폭을 넘지 않는 합리 범위.
+    expect(BIOME_LAT_JITTER).toBeGreaterThan(0);
+    expect(BIOME_LAT_JITTER).toBeLessThan(0.25);
+  });
+
+  it('GLSL fragment 에 biome/극관 uniform 10종 선언 존재 (미러와 동기)', () => {
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 biomeTropicalColor');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 biomeTundraColor');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform vec3 iceColor');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float biomeTemperateLo');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float biomeTemperateHi');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float biomeTundraLo');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float biomeTundraHi');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float iceLatLo');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float iceLatHi');
+    expect(PLANET_FRAGMENT_SHADER).toContain('uniform float biomeLatJitter');
+  });
+
+  it('GLSL rocky 분기 식 계약 — §A3.3 결정 3 스케치 그대로 (fbm 신규 호출 0)', () => {
+    // 위도 파라미터 (sin-space) + 기존 continents 재사용 jitter.
+    expect(PLANET_FRAGMENT_SHADER).toContain('float latRaw = abs(p.y)');
+    expect(PLANET_FRAGMENT_SHADER).toContain('(continents - 0.5) * biomeLatJitter');
+    // 2 smoothstep 연쇄 biome mix → landMask mix → iceMask 최종 mix (합성 순서 계약).
+    expect(PLANET_FRAGMENT_SHADER).toContain(
+      'mix(biomeTropicalColor, landColor, smoothstep(biomeTemperateLo, biomeTemperateHi, latJ))',
+    );
+    expect(PLANET_FRAGMENT_SHADER).toContain(
+      'mix(landCol, biomeTundraColor, smoothstep(biomeTundraLo, biomeTundraHi, latJ))',
+    );
+    expect(PLANET_FRAGMENT_SHADER).toContain('smoothstep(iceLatLo, iceLatHi, latJ)');
+    expect(PLANET_FRAGMENT_SHADER).toContain('mix(col, iceColor, iceMask)');
+    // 핵심 예측 "noise +0" — rocky 분기의 fbm 호출은 continents 1회뿐 (결정 3-c 위반 가드).
+    const rockyBranch = PLANET_FRAGMENT_SHADER.slice(
+      PLANET_FRAGMENT_SHADER.indexOf('uSurfaceType == 0'),
+      PLANET_FRAGMENT_SHADER.indexOf('uSurfaceType == 1'),
+    );
+    expect((rockyBranch.match(/fbm\(/g) ?? []).length).toBe(1);
   });
 });

--- a/packages/core/src/scene/procedural-planet-shader.ts
+++ b/packages/core/src/scene/procedural-planet-shader.ts
@@ -39,6 +39,15 @@
  *     (StandardMaterial + PointLight 2.5 + HemisphericLight ambient) 과 시각 일치 (밤면/terminator/극).
  *   - §A1.3 결정 4 (#775) — rocky 분기를 `mix(oceanColor, landColor, landMask)` 로 교체 (대륙 색 구분).
  *
+ * **Amendment 3 (#783) — 지구 극관 + biome 위도 색 변화** (ADR §Amendment 3):
+ *   - §A3.3 결정 3 — rocky 분기에 biome 3밴드 (적도 녹 → 중위도 황토 → 고위도 툰드라, 2 smoothstep
+ *     연쇄 mix) + 극관 (continents 무관 최종 mix — 결정 4 B). 위도 임계는 전부 **sin-space**
+ *     (`p.y = sin(위도)`, §A3.2-1). 경계 자연화 = 기존 `continents` fbm 재사용 (**추가 noise 샘플 0**
+ *     — 결정 3-c, fill-rate 보호). `landColor` 는 temperate 밴드 색으로 의미 재문서화 (Q3 합의).
+ *   - 극관도 albedo 단계에서만 — `col *= shade` 최종 곱 불변 (#773 규약, 밤면 극관은 어둡다).
+ *   - 자전 불변 (§A3.2-2): spin 은 local Y 축 회전이라 `abs(p.y)` 위도 밴드/극관은 자전해도 불변
+ *     (painted-on 정합 — 극관이 흔들릴 구조 자체가 없음).
+ *
  * ⚠️ **옵션 e 배선 계약 (drift 가드, Amendment 2)**: 본 광원 모델은 "vNormal = world normal (world
  *   matrix 변환) + uniform scaling" 에 의존한다. `world` uniform 이 uniforms 배열에서 빠지거나 VERTEX
  *   가 vNormal 을 local 로 되돌리면, 자전 시 명암이 표면과 함께 돌아버린다. onBind 의 dev-only 어서션이
@@ -163,17 +172,83 @@ export const SOFT_TERMINATOR_WIDTH = 0.12;
 /**
  * #775 — rocky 육지색 RGB (rendering-only 미학 상수, 데이터 SSoT 무관 — ADR §A1.3 결정 4 A).
  *
- * ocean 색 = base color (colorHint.hex, 데이터 SSoT read-only). land 색 = 본 상수. 올리브-브라운
+ * ocean 색 = base color (colorHint.hex, 데이터 SSoT read-only). land 색 = 본 상수. 황토-브라운
  * 자연 톤 (R/G 우세, B 결핍 — 보라/마젠타 anti-pattern 구조적 회피, #756 가드 정합). landMask 로
  * ocean↔land 색조(hue) mix → "바다만" 회귀 (밝기 변조만) 해소.
+ *
+ * ⚠️ **Amendment 3 (#783) 의미 재문서화 — temperate(중위도 황토·갈색) 밴드 색으로 사용됨**
+ * (cross-validate Q3 합의 — 신규 상수 대신 기존 landColor uniform 배선 재사용, drift 0). biome
+ * 3밴드 (BIOME_TROPICAL → 본 상수 → BIOME_TUNDRA) 의 중간 밴드다. 값도 #775 올리브
+ * (0.34, 0.40, 0.24) 에서 황토 방향으로 튜닝 (§A3.3 결정 3-b measurement-first — DoD 2 의
+ * 적도>중위도 G-share 분리 마진 확보). 제약: G-share 가 BIOME_TROPICAL_RGB 보다 작아야 한다
+ * (테스트 가드).
  */
-export const LAND_COLOR_RGB = { r: 0.34, g: 0.4, b: 0.24 } as const;
+export const LAND_COLOR_RGB = { r: 0.44, g: 0.38, b: 0.23 } as const;
 
 /** #775 — 대륙 mask smoothstep 하한 (continents fbm < LO → 100% ocean). */
 export const LAND_THRESHOLD_LO = 0.48;
 
 /** #775 — 대륙 mask smoothstep 상한 (continents fbm > HI → 100% land). LO~HI 사이 해안선 전이. */
 export const LAND_THRESHOLD_HI = 0.62;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Amendment 3 (#783) — 지구 극관 + biome 위도 색 rendering-only 미학 상수 SSoT (§A3.3 결정 3).
+//
+// 위도 임계는 전부 **sin-space** (fragment 의 p.y = sin(위도) — §A3.2-1, 정규화 위도 아님.
+// CreateSphere pole = local ±Y, 선형 위도가 아니라 60° 에서 0.866). 각 상수 주석에 대응 각도 병기.
+// 전 색상 G ≥ min(R,B) (보라/마젠타 anti-pattern 구조 회피 — 테스트 가드). 데이터 SSoT 무관
+// (solar-system.json 0 — rendering-only). 출발값은 ADR §A3.3 결정 3-b, 최종값 measurement-first.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * #783 — 적도 열대 밴드 색 (녹 우세 — 열대 숲).
+ * 제약: G-share (G/(R+G+B)) 가 temperate(LAND_COLOR_RGB) 보다 커야 한다 (§A3.5 DoD 2
+ * 밴드 구분 측정 가능성 — 테스트 가드).
+ */
+export const BIOME_TROPICAL_RGB = { r: 0.2, g: 0.38, b: 0.16 } as const;
+
+/**
+ * #783 — 고위도 툰드라 밴드 색 (회백). 극관과의 연속 전이를 위해 BIOME_TUNDRA_HI 가
+ * ICE_LAT_LO 와 맞닿는다 (이슈 "툰드라→극관 연결" — cross-validate Q2 합의 순차 임계).
+ */
+export const BIOME_TUNDRA_RGB = { r: 0.55, g: 0.56, b: 0.52 } as const;
+
+/** #783 — 극관 색 (근중성 백 — G ≥ min(R,B) 유지, B 단독 우세 아님). */
+export const ICE_COLOR_RGB = { r: 0.93, g: 0.95, b: 0.96 } as const;
+
+/** #783 — 열대→온대 전이 시작 (sin-space 0.30 ≈ 위도 17°). */
+export const BIOME_TEMPERATE_LO = 0.3;
+
+/** #783 — 열대→온대 전이 완료 (sin-space 0.55 ≈ 위도 33°). */
+export const BIOME_TEMPERATE_HI = 0.55;
+
+/** #783 — 온대→툰드라 전이 시작 (sin-space 0.72 ≈ 위도 46°). */
+export const BIOME_TUNDRA_LO = 0.72;
+
+/**
+ * #783 — 온대→툰드라 전이 완료 (sin-space 0.84 ≈ 위도 57° — ICE_LAT_LO 와 맞닿음).
+ * 출발값 0.88 → 0.84 하향 (measurement-first — 아래 ICE_LAT_LO 튜닝과 동조).
+ */
+export const BIOME_TUNDRA_HI = 0.84;
+
+/**
+ * #783 — 극관 전이 시작 (sin-space 0.84 ≈ 위도 57°).
+ * 출발값 0.88 → 0.84 하향 튜닝 (measurement-first, §A3.3 결정 3-b 재량): 출발값에서는 ice ramp
+ * (0.88→0.96) 가 DoD 1 측정 밴드 (|sin lat| ≥ 0.88) 전체와 겹쳐 밴드 대부분이 iceMask < 0.6
+ * (ocean cyan 혼합, near-white 스펙트럼 밖) — 실측 near-white 비율 10.2% 로 미달. 하향으로
+ * 밴드 안에서 ice 가 완성돼 흰 극관 시인 + DoD 1 충족. 실제 지구 빙설선 (~55–60°) 근사 유지.
+ */
+export const ICE_LAT_LO = 0.84;
+
+/** #783 — 극관 전이 완료 (sin-space 0.92 ≈ 위도 67°). 출발값 0.96 → 0.92 (동조 튜닝 — 위 참조). */
+export const ICE_LAT_HI = 0.92;
+
+/**
+ * #783 — biome 경계 요동 진폭. 기존 `continents` fbm 재사용 (§A3.3 결정 3-c — 추가 noise 샘플 0,
+ * fill-rate 보호). (fbm − 0.5) × 0.12 = 위도 ±0.06 요동. 상관 아티팩트 발현 시 좌표 스위즐링
+ * fbm(p.zyx) 승격 (§A3.7 재검토 조건 4 — 단 fbm 신규 호출 = hash 24회 추가 비용).
+ */
+export const BIOME_LAT_JITTER = 0.12;
 
 /** shader 이름 prefix — ShadersStore key 충돌 방지 (ring/starfield 패턴 답습). */
 const SHADER_NAME = 'proceduralPlanet';
@@ -274,11 +349,29 @@ uniform vec3 ambientUp;
 uniform float softTerminatorWidth;
 
 // Amendment 1 (#775) — 지구 대륙 mix uniform (rendering-only 미학 상수, scene 무관).
-//   landColor: 육지색 (올리브-브라운, R/G 우세 — 보라/마젠타 회피).
+//   landColor: 육지색 (황토-브라운, R/G 우세 — 보라/마젠타 회피). ⚠️ Amendment 3 (#783):
+//              temperate(중위도) 밴드 색으로 사용됨 (의미 재문서화 — cross-validate Q3 합의).
 //   landThresholdLo/Hi: continents fbm → landMask smoothstep 임계 (해안선 전이).
 uniform vec3 landColor;
 uniform float landThresholdLo;
 uniform float landThresholdHi;
+
+// Amendment 3 (#783) — 지구 biome/극관 uniform 블록 (rocky 전용, rendering-only 미학 상수 —
+// biome 상수 블록 그룹화, cross-validate 부분 수용 6). 위도 임계는 전부 sin-space (§A3.2-1
+// — p.y = sin(위도), 주석 각도는 상수 선언부 참조).
+//   biomeTropicalColor: 적도 열대 녹. biomeTundraColor: 고위도 툰드라 회백. iceColor: 극관 백.
+//   biomeTemperateLo/Hi · biomeTundraLo/Hi · iceLatLo/Hi: 위도 밴드 smoothstep 임계.
+//   biomeLatJitter: 경계 요동 진폭 (기존 continents fbm 재사용 — 추가 noise 0, §A3.3 결정 3-c).
+uniform vec3 biomeTropicalColor;
+uniform vec3 biomeTundraColor;
+uniform vec3 iceColor;
+uniform float biomeTemperateLo;
+uniform float biomeTemperateHi;
+uniform float biomeTundraLo;
+uniform float biomeTundraHi;
+uniform float iceLatLo;
+uniform float iceLatHi;
+uniform float biomeLatJitter;
 
 // 3D hash — sin-free fract-mix (starfield.ts hash33 답습 — swiftshader/tier-c fps 보호).
 vec3 hash33(vec3 p) {
@@ -340,12 +433,21 @@ void main(void) {
 
   // #756 §결정 2 — 표면 타입별 절차 변조 (if-else 분기만). 같은 draw = 같은 타입 (divergence 0).
   if (uSurfaceType == 0) {
-    // ── rocky (지구) — 대륙↔해양 색 mix (Amendment 1 #775) ──────────────────
-    // continents fbm → landMask. ocean = baseColor (실측 청록), land = landColor (올리브-브라운).
-    // 밝기 변조만 (col=base*(1+mod)) 하던 #756 → 색조(hue) mix 로 "바다만" 회귀 해소.
+    // ── rocky (지구) — 대륙↔해양 mix (#775) + biome 위도 색 + 극관 (Amendment 3 #783) ──
+    // continents fbm → landMask. ocean = baseColor (실측 청록, read-only 규약).
     float continents = fbm(p * 2.4);
     float landMask = smoothstep(landThresholdLo, landThresholdHi, continents);
-    col = mix(baseColor, landColor, landMask);
+    // Amendment 3 (#783) §A3.3 결정 3 — 위도 파라미터 (sin-space: p.y = sin(위도), §A3.2-1).
+    float latRaw = abs(p.y);                                        // |sin(위도)| — 남북 대칭
+    float latJ = latRaw + (continents - 0.5) * biomeLatJitter;      // 경계 자연화 — 기존 fbm 재사용 (추가 noise 0)
+    // 대륙색: 적도 녹색 → 중위도 황토·갈색 (landColor=temperate) → 고위도 툰드라 회백 (2 smoothstep 연쇄 mix)
+    vec3 landCol = mix(biomeTropicalColor, landColor, smoothstep(biomeTemperateLo, biomeTemperateHi, latJ));
+    landCol = mix(landCol, biomeTundraColor, smoothstep(biomeTundraLo, biomeTundraHi, latJ));
+    col = mix(baseColor, landCol, landMask);                        // #775 해안선 전이 유지 (ocean = baseColor 불변)
+    // 극관 — continents 무관 (§A3.3 결정 4 B: 북극 해빙 + 남극 빙상 둘 다 흰색), ocean/land 공통
+    // 최종 mix. albedo 단계에서만 결정 — 아래 col *= shade 최종 곱 불변 (#773 규약, 밤면 극관은 어둡다).
+    float iceMask = smoothstep(iceLatLo, iceLatHi, latJ);
+    col = mix(col, iceColor, iceMask);
   } else if (uSurfaceType == 1) {
     // ── desert (화성) — dust/협곡 결 (fbm) + 산화철 톤 ─────────────────────
     float detail = fbm(p * 3.6);
@@ -527,6 +629,17 @@ export function createProceduralPlanetMaterial(
         'landColor',
         'landThresholdLo',
         'landThresholdHi',
+        // Amendment 3 (#783) — 지구 biome/극관 uniform 블록 (rocky 전용, +10 — vec3 3 + float 7).
+        'biomeTropicalColor',
+        'biomeTundraColor',
+        'iceColor',
+        'biomeTemperateLo',
+        'biomeTemperateHi',
+        'biomeTundraLo',
+        'biomeTundraHi',
+        'iceLatLo',
+        'iceLatHi',
+        'biomeLatJitter',
       ],
     },
   );
@@ -562,9 +675,31 @@ export function createProceduralPlanetMaterial(
   material.setFloat('softTerminatorWidth', SOFT_TERMINATOR_WIDTH);
 
   // Amendment 1 (#775) — 대륙 mix 미학 상수 uniform (rendering-only).
+  // ⚠️ Amendment 3 (#783): landColor 는 temperate(중위도 황토·갈색) 밴드 색으로 사용된다
+  // (의미 재문서화 — 상수 선언부와 본 바인딩 계층 양쪽 주석 가드, cross-validate Q3 합의).
   material.setColor3('landColor', new Color3(LAND_COLOR_RGB.r, LAND_COLOR_RGB.g, LAND_COLOR_RGB.b));
   material.setFloat('landThresholdLo', LAND_THRESHOLD_LO);
   material.setFloat('landThresholdHi', LAND_THRESHOLD_HI);
+
+  // Amendment 3 (#783) — 지구 biome/극관 미학 상수 uniform 블록 (rocky 전용, rendering-only —
+  // biome 상수 블록 그룹화, cross-validate 부분 수용 6). 4중 SSoT: 상수 → uniforms 배열 →
+  // 본 바인딩 → GLSL 선언 (+ JS 미러 동기 — 한쪽 수정 시 전부 동기화 의무, 테스트 가드).
+  material.setColor3(
+    'biomeTropicalColor',
+    new Color3(BIOME_TROPICAL_RGB.r, BIOME_TROPICAL_RGB.g, BIOME_TROPICAL_RGB.b),
+  );
+  material.setColor3(
+    'biomeTundraColor',
+    new Color3(BIOME_TUNDRA_RGB.r, BIOME_TUNDRA_RGB.g, BIOME_TUNDRA_RGB.b),
+  );
+  material.setColor3('iceColor', new Color3(ICE_COLOR_RGB.r, ICE_COLOR_RGB.g, ICE_COLOR_RGB.b));
+  material.setFloat('biomeTemperateLo', BIOME_TEMPERATE_LO);
+  material.setFloat('biomeTemperateHi', BIOME_TEMPERATE_HI);
+  material.setFloat('biomeTundraLo', BIOME_TUNDRA_LO);
+  material.setFloat('biomeTundraHi', BIOME_TUNDRA_HI);
+  material.setFloat('iceLatLo', ICE_LAT_LO);
+  material.setFloat('iceLatHi', ICE_LAT_HI);
+  material.setFloat('biomeLatJitter', BIOME_LAT_JITTER);
 
   // Amendment 1 (#773) §A1.3 결정 1 — 태양 방향 uniform.
   //   기본 +X (provider 미전달 시 테스트 fallback). provider 가 있으면 onBind 에서 매 draw 갱신.
@@ -701,17 +836,35 @@ export function surfaceColorMirror(
   const [px, py, pz] = p;
 
   if (surfaceType === SurfaceType.Rocky) {
-    // Amendment 1 (#775) — 대륙↔해양 색 mix (밝기 변조 → 색조 mix). GLSL rocky 분기와 동일 식.
+    // Amendment 1 (#775) 대륙↔해양 mix + Amendment 3 (#783) biome 위도 색·극관.
+    // GLSL rocky 분기와 동일 식 (§A3.3 결정 3 — 한쪽 수정 시 양쪽 동기화 의무).
+    const sm = (e0: number, e1: number, x: number): number => {
+      const t = Math.min(Math.max((x - e0) / Math.max(e1 - e0, 1e-6), 0), 1);
+      return t * t * (3 - 2 * t);
+    };
+    const mix = (a: number, b2: number, t: number): number => a + (b2 - a) * t;
     const continents = fbmMirror(px * 2.4, py * 2.4, pz * 2.4);
-    const t =
-      (continents - LAND_THRESHOLD_LO) / Math.max(LAND_THRESHOLD_HI - LAND_THRESHOLD_LO, 1e-6);
-    const landMask = (() => {
-      const c = Math.min(Math.max(t, 0), 1);
-      return c * c * (3 - 2 * c);
-    })();
-    r = bx + (LAND_COLOR_RGB.r - bx) * landMask;
-    g = by + (LAND_COLOR_RGB.g - by) * landMask;
-    b = bz + (LAND_COLOR_RGB.b - bz) * landMask;
+    const landMask = sm(LAND_THRESHOLD_LO, LAND_THRESHOLD_HI, continents);
+    // 위도 파라미터 (sin-space) — 경계 자연화는 기존 continents fbm 재사용 (추가 noise 0).
+    const latRaw = Math.abs(py);
+    const latJ = latRaw + (continents - 0.5) * BIOME_LAT_JITTER;
+    // 대륙색: 적도 녹 → 중위도 황토 (LAND_COLOR_RGB=temperate) → 고위도 툰드라 (2 smoothstep 연쇄).
+    const temperateMix = sm(BIOME_TEMPERATE_LO, BIOME_TEMPERATE_HI, latJ);
+    const tundraMix = sm(BIOME_TUNDRA_LO, BIOME_TUNDRA_HI, latJ);
+    let lr = mix(BIOME_TROPICAL_RGB.r, LAND_COLOR_RGB.r, temperateMix);
+    let lg = mix(BIOME_TROPICAL_RGB.g, LAND_COLOR_RGB.g, temperateMix);
+    let lb = mix(BIOME_TROPICAL_RGB.b, LAND_COLOR_RGB.b, temperateMix);
+    lr = mix(lr, BIOME_TUNDRA_RGB.r, tundraMix);
+    lg = mix(lg, BIOME_TUNDRA_RGB.g, tundraMix);
+    lb = mix(lb, BIOME_TUNDRA_RGB.b, tundraMix);
+    r = mix(bx, lr, landMask);
+    g = mix(by, lg, landMask);
+    b = mix(bz, lb, landMask);
+    // 극관 — continents 무관, ocean/land 공통 최종 mix (§A3.3 결정 4 B).
+    const iceMask = sm(ICE_LAT_LO, ICE_LAT_HI, latJ);
+    r = mix(r, ICE_COLOR_RGB.r, iceMask);
+    g = mix(g, ICE_COLOR_RGB.g, iceMask);
+    b = mix(b, ICE_COLOR_RGB.b, iceMask);
   } else if (surfaceType === SurfaceType.Desert) {
     const detail = fbmMirror(px * 3.6, py * 3.6, pz * 3.6);
     const mod = (detail - 0.5) * 2 * DESERT_DETAIL;


### PR DESCRIPTION
## [#783] 지구 디테일 — 극관 + biome 위도 색 변화

### 변경 사항
- **`packages/core/src/scene/procedural-planet-shader.ts`** (+168/−19) — rocky 분기 확장 (ADR [`20260628-756-procedural-planet-surface.md` §Amendment 3](docs/decisions/20260628-756-procedural-planet-surface.md) 구현, GLSL 스케치 §A3.3 결정 3 그대로):
  - **biome 3밴드**: 적도 열대 녹 → 중위도 황토 (`landColor` = temperate 의미 재문서화, cross-validate Q3 합의 — 상수 선언부 + 바인딩 계층 양쪽 주석 가드) → 고위도 툰드라 회백 (2 smoothstep 연쇄 mix)
  - **극관**: continents 무관 (§결정 4 B — 북극 해빙 + 남극 빙상), ocean/land mix **이후 최종 mix**. albedo 단계에서만 — `col *= shade` 최종 곱 불변 (#773 규약, 밤면 극관은 어둡다)
  - **위도 임계 전부 sin-space** (`p.y = sin(위도)`, §A3.2-1) + 상수 주석 대응 각도 병기
  - **경계 자연화 = 기존 `continents` fbm 재사용** — 신규 noise 호출 0 (§결정 3-c, fill-rate 보호. rocky 분기 fbm 1회 유지를 테스트가 정적 계약으로 가드)
  - **uniform +10** (rocky 전용, vec3 3 + float 7) — 기존 landColor 4중 SSoT 패턴 (상수 → uniforms 배열 → setColor3/setFloat → GLSL 선언) + JS 미러 동기, 바인딩 계층 biome 블록 그룹화 주석 (cross-validate 부분 수용 6)
- **`procedural-planet-shader.test.ts`** (+232/−13, 11 tests 신규) — 극 위도 ice 수렴 (landMask 양극단 — jitter 최악 경우 포함) / 적도 vs 중위도 G-share 순서 (골든앵글 6000점 스캔) / anti-pattern (신규 색 4종 + 미러 4000점 G ≥ min(R,B) 위배 0) / 상수 SSoT drift (박제값 + 임계 순서 + GLSL uniform 10종 + 식 계약 + fbm 1회 가드) / 기존 #775 박제값 테스트 밴드 조건부 갱신
- **신규 `apps/web/scripts/browser-verify-783-earth-detail.mjs`** (383줄) — 결정적 프레임 DoD 1~4 측정 + `MODE=others/diff` 분기 격리 픽셀 diff
- **`docs/decisions/20260628-756-procedural-planet-surface.md`** (+192/−1) — Amendment 3 설계 + cross-validate Accepted 전이 (architect 단계 커밋 d07fa02 / f92a5f5 포함)

### 상수 최종값 (measurement-first — ADR §A3.3 결정 3-b 재량, 근거 박제)

| 상수 | 출발값 (ADR) | 최종값 | 근거 |
| --- | --- | --- | --- |
| `BIOME_TROPICAL_RGB` | (0.20, 0.38, 0.16) | 유지 | G-share 0.514 > temperate 0.362 — DoD 2 분리 마진 충분 |
| `LAND_COLOR_RGB` | (0.34, 0.40, 0.24) → 황토 재량 | **(0.44, 0.38, 0.23)** | ADR 예시 황토값 채택 — temperate 밴드 색 재문서화 + 적도>중위도 G-share 분리 마진 확보 (기존 박제값 테스트 동반 갱신 = 정상 경로) |
| `BIOME_TUNDRA_RGB` / `ICE_COLOR_RGB` | (0.55,0.56,0.52) / (0.93,0.95,0.96) | 유지 | 실측 극관 순백 클램프 + 툰드라 연속 전이 확인 |
| `BIOME_TEMPERATE_LO/HI` | 0.30 / 0.55 | 유지 | ~17°–33° |
| `BIOME_TUNDRA_LO/**HI**` | 0.72 / 0.88 | 0.72 / **0.84** | ICE_LAT_LO 하향과 동조 (맞닿음 유지 — Q2 순차 임계) |
| `ICE_LAT_LO/HI` | 0.88 / 0.96 | **0.84 / 0.92** (~57°/67°) | **측정 발 튜닝**: 출발값에서는 ice ramp (0.88→0.96) 가 DoD 1 측정 밴드 (\|sin lat\| ≥ 0.88) 전체와 겹쳐 밴드 대부분이 iceMask < 0.6 (ocean cyan 혼합, near-white 스펙트럼 밖) — 실측 10.2% 미달. 하향으로 밴드 내 ice 완성 → 72%/61.5% PASS. 실제 지구 빙설선 (~55–60°) 근사 유지 |
| `BIOME_LAT_JITTER` | 0.12 | 유지 | 위도 ±0.06 요동 — 캡 경계 유기적 요동 시각 확인 |

### 실측 결과 (실 Chrome GUI, Playwright composited + pngjs — WebGPU readback 금지 #728/#756)

| DoD (§A3.5) | 기준 | 실측 | 판정 |
| --- | --- | --- | --- |
| 1 | 극관: 세로 양극단 12% (낮면, 남북 각각) near-white ≥ 50% + OFF 대비 증가 | **N 72.0% / S 61.5%** (OFF 0% / 0%, 변경 전 ON 0~1.1%) | PASS |
| 2 | biome: 적도 land G-share > 중위도 | **0.5057 > 0.4045** (변경 전 0.405 ≈ 0.401) + 단위 6000점 스캔 동일 순서 | PASS |
| 3 | 보라/마젠타 0 | 미러 4000점 위배 0 + GUI disk 0 px | PASS |
| 4 | #773 무회귀: 대비비 + terminator 추종 + 밤면 극 < 낮면 극 × 1/3 | contrastExtreme **22.86** (#773 세션 확립 판정 지표 — 당시 21.4, 동일 범위) / contrastMean 4.67 (세션 3.50 대비 개선) / 밤면 극 **52.4 < 73.4** | PASS |
| 5 | #775 무회귀: land/ocean 색조 구분 + 해안선 전이 | land/ocean 971/3611 공존 + ocean=baseColor 그대로 (중·저위도, 단위 가드) | PASS |
| 6 | #756 무회귀: earth 엔트로피 ON > OFF + **mars/jupiter/moon diff ≈ 0** | hfEnt **2.155 > 1.24** / **mars 0 px · jupiter 0 px** (픽셀 동일) · moon 559 px (0.06%) = **run-to-run 노이즈 플로어 535 px 와 동일** (동일 코드 2회 캡처 실측 — 별/카메라 tween 서브픽셀 지터, cratered 분기 무관) | PASS |
| 7 | fps 회귀 0 (tier-c 포함) | CI fps-baseline-guard 판정 (push 완료). noise +0 이라 예산 내 예상 | CI |
| 8 | 데이터 0 | diff 에 `solar-system.json` 부재 (파일 4개 — shader/test/verify/ADR 만) | PASS |
| 9 | core typecheck 0 (#719) + 테스트 전수 | typecheck 0 / core **721 passed** (+11) / web **479 passed** / 수정 파일 lint 0 | PASS |

- `?surface=off` 100% 복귀 — OFF 측정에서 biome/극관 축 전부 무신호 (eq/mid land 0, whiteness 0)
- console error 0 (ON/OFF/others 전 시나리오)

### 측정 레시피 실측 노트 (verify 스크립트 헤더에 동일 박제)
- **`?speed=0` 로드 함정**: 로드 쿼리에 `speed=0` 포함 시 focus 정착 (LOD/광원 per-frame 갱신) 이 완주하지 않아 disk 미렌더 (실측) → 정상 로드 후 **런타임 `jumpToJulianDate` + `pause` 동기 연속 호출**로 프레임 고정
- **T_JD = 2451626.0 (춘분 근방)**: dataset epoch (J2000) frozen 위치에서는 태양이 world −Y (패턴 극축과 정렬 — 북극 영구 밤) 라 DoD 1 "남북 모두 낮면" 측정 불능 → 지구 공전 방위 ~182° 시점으로 점프해 태양 ⊥ 극축 (terminator 세로) 기하 확보, §A3.5 산식 그대로 측정
- **disk 반경 = boundingSphere.radiusWorld/√3 투영** (bbox cube 모서리 투영 ~1.2x 과대 / 마스크 count 밤면 limb 탈락 ~7% 과소 — 둘 다 밴드를 캡 밖으로 어긋나게 함, 실측 보정)

### qa 관찰 예고 항목 실측 선행 (cross-validate Q1 High / §A3.7 조건 4·6)
- **해안선-biome 경계 동조 아티팩트**: 렌더 스케일 (disk ~195px) 실측에서 contour-following 쏠림 미발현 — biome 전이가 land 패치를 유기적으로 가로지름. **스위즐링 (§A3.7 조건 4) 승격 불요 판단** (qa 재확인 대상)
- **극관 "흰 모자" 부자연 여부**: 캡 경계가 jitter 로 요동 + 툰드라 회백 연속 전이 — "위도로만 잘린 모자" 아님, 자연스러움 (§A3.7 조건 6 발동 불요 판단, qa 재확인 대상)
- 스크린샷: `docs/reports/783-earth/head/qa-783-earth-{on,off,zoom}.png` (로컬 캡처 — untracked 관례 #756/#762/#774 동형)

### Concrete Prediction 실측 대조 (ADR §A3.4)

| 영역 | 예측 | 실측 (`git diff --stat`) | 판정 |
| --- | --- | --- | --- |
| `procedural-planet-shader.ts` | ~90–150 | **187** (+168/−19) | 초과 +37 — Amendment 1 (아래) |
| `procedural-planet-shader.test.ts` | ~70–130 | **245** | 초과 — Amendment 1 |
| `browser-verify-783-earth-detail.mjs` 신규 | ~130–190 | **383** | 초과 — Amendment 1 |
| scene / web 레이어 / `solar-system.json` | **0** | **0** | **적중 (핵심 예측)** |
| `sun-shader.ts` / `ring-shader.ts` / `starfield.ts` | **0** | **0** | **적중 (핵심 예측)** |
| **mars/jupiter/moon 픽셀 불변** (분기 격리) | diff ≈ 0 | mars **0** / jupiter **0** / moon 노이즈 플로어 동치 | **적중 (핵심 예측)** |
| **fbm 호출 수 불변** (noise +0) | 0 | rocky 분기 fbm 1회 유지 (테스트 정적 가드 신설) | **적중 (핵심 예측)** |
| picking / camera / orbit / tier / LOD / r1-guard | 0 | 0 | 적중 |

**Amendment 1 — 라인수만 초과 (#756/#774 와 동형 패턴)**: 구조 예측 (파일 3 + ADR, 무침범 0) 전부 적중. 초과분은 (a) 상수별 결정 근거 주석 밀도 (sin-space 각도 병기 + measurement-first 튜닝 근거 박제), (b) 테스트 축 세분화 (골든앵글 헬퍼 + fbm 1회 정적 가드 추가), (c) verify 스크립트의 측정 기하 강건화 (jump+pause 레시피 + 투영 반경 + 분기 격리 diff/others 모드 — 위 실측 노트의 3개 함정 해소). 관심사 혼입 0 — 재검토 불요.

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 — ADR `20260628-756-procedural-planet-surface.md` §A3.5 DoD 9항목 (Amendment 3 Accepted, cross-validate 2026-07-04)
- [x] 모든 완료 기준 충족 — dev 검증 가능 항목 전수 PASS (위 실측 표. DoD 7 fps 는 CI 판정)

### 테스트 (Test plan)
- [x] 단위 테스트 추가/수정 — `procedural-planet-shader.test.ts` 11 tests 신규 + #775 박제값 밴드 조건부 갱신
- [x] 기존 테스트 통과 확인 — core 721 passed / web 479 passed / `pnpm --filter @astro-simulator/core typecheck` 0 (#719)
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인 — 신규 워크스페이스 없음, core 기존 `scripts.test` 유지

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [ ] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [x] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR: `docs/decisions/20260628-756-procedural-planet-surface.md` **§Amendment 3** (architect 설계 커밋 d07fa02 + cross-validate Accepted 전이 f92a5f5 포함)
  - 검증 결과: **호환** — 기존 ADR 의 Amendment 추가 (폐기/Supersedes 0). #773 (shade 최종 곱 불변) / #775 (ocean=baseColor read-only, 해안선 전이 유지) / #782 (sin-space p.y, painted-on 자전 불변, 옵션 e 무접촉) 규약 전부 준수 — 구현이 §A3.7 재검토 조건 발동 없이 1차 범위 준수 (ICE_LAT/TUNDRA_HI 상수값 튜닝은 §A3.3 결정 3-b 가 위임한 measurement-first 재량 범위)

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [x] **[1/3] 정적**: 렌더링 OK, 콘솔 에러 0 — 스크린샷 경로: `docs/reports/783-earth/head/qa-783-earth-on.png` (흰 극관 + biome 밴드 육안 확인, 로컬 캡처 untracked 관례)
- [x] **[2/3] 인터랙션**: `?surface=off` URL 플래그 토글 → 단색 복귀 실측 (`qa-783-earth-off.png`, biome/극관 축 전부 무신호)
- [x] **[3/3] 흐름**: `?focus=earth` focus tween → disk 대면적 렌더 → mars/jupiter/moon focus 이동 무회귀 (분기 격리 diff 0 px)
- [x] verify 스크립트(있는 경우) 경로: `apps/web/scripts/browser-verify-783-earth-detail.mjs` (로컬 실행 — CI 통합은 #759 트랙 후속)

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님 (단일 feature)

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 feature PR

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 feature PR

### 체크리스트
- [x] 커밋 컨벤션 준수 — `feat(core): #783 ...` (+ architect docs(adr) 2건)
- [x] 불필요한 변경 없음 — 이슈 Tier 1 범위만 (Tier 2 바다 깊이/fresnel, Tier 3 구름/불빛 미구현 — §A3.7 재검토 조건 1~3 경로 박제)
- [x] 보안 취약점 없음 — 렌더링 전용 (외부 입력/네트워크/저장소 접근 0)
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145) — 해당 없음 (스키마 미수정)
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드) — ADR Amendment 포함: cross-validate 완료 (agy 2026-07-04), outcome 은 ADR §A3.8 (합의 3 / 고유 발견 수용 2 — 사실 정정 포함 / 부분 수용 2 / 편향 셀프 체크) 에 박제

### 관련 이슈
Closes #783
