### PR TITLE
[#779] CI flake 자동화 Phase 2/3 — verify:699 step retry + fps fresh-runner escalation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,8 +390,25 @@ jobs:
             if curl -sf http://localhost:3012/ > /dev/null; then break; fi
             sleep 2
           done
-          BASE_URL=http://localhost:3012 node apps/web/scripts/browser-verify-699-freefly-unified.mjs
-          GUARD_EXIT=$?
+          # #779 Phase 2 — S3b deltaTime 타이밍 flake 흡수 (v0.39.0 / v0.43.0 prep 실측 2회 — 가드 9종 중 유일).
+          # dev server 는 유지한 채 guard 호출만 재시도 (#709 동일 패턴). 2연속 fail = step fail (fail-fast 유지).
+          GUARD_EXIT=1
+          for attempt in 1 2; do
+            echo "::group::verify:699 attempt $attempt/2"
+            if BASE_URL=http://localhost:3012 node apps/web/scripts/browser-verify-699-freefly-unified.mjs; then
+              GUARD_EXIT=0
+              echo "::endgroup::"
+              if [[ $attempt -eq 2 ]]; then
+                echo "::warning::verify:699 attempt 1 실패를 attempt 2 가 흡수 — runner 부하 spike flake 추정 (#779 Phase 2)"
+              fi
+              break
+            fi
+            echo "::endgroup::"
+            if [[ $attempt -lt 2 ]]; then
+              echo "::warning::verify:699 attempt $attempt 실패 — 15s 후 재시도 (#779 Phase 2)"
+              sleep 15
+            fi
+          done
           kill $WEB_PID || true
           exit $GUARD_EXIT
 

--- a/.github/workflows/fps-baseline-guard.yml
+++ b/.github/workflows/fps-baseline-guard.yml
@@ -3,6 +3,11 @@ name: fps-baseline-guard
 # 프로젝트 로컬 워크플로 — harness 업데이트 대상 아님.
 # 이슈 #536 / R4 cross-validate Gemini 고유 발견 3 후속.
 # `docs/benchmarks/fps-lowend-baseline.json` 대비 회귀 (>30% 저하 또는 <30 FPS) 감지 시 PR 차단.
+#
+# #779 Phase 3 — 2-job fresh-runner escalation (ADR 20260701-779 §A1 결정 3 개정):
+#   measure (머신 1, guard soft-fail) → guard 실패 시에만 retry-fresh-runner (머신 2, hard-fail).
+#   전역 부하 spike flake 는 새 머신에서 흡수 → workflow conclusion=success → 메일 0.
+#   진짜 회귀는 2 머신 × 2 attempt = 4회 전부 fail → 최종 failure 메일 1통 (은폐 불가, fail-fast 유지).
 
 # 같은 sha 의 push+PR 중복 run 제거 (#779). group 에 github.workflow 포함 →
 # 워크플로 간 교차 취소 방지. PR head sha == 머지 후 push sha 로 수렴 → 같은 sha 묶임.
@@ -40,12 +45,28 @@ on:
         description: 'scenario 당 측정 샘플 수 (진단 모드)'
         type: string
         default: '10'
+      # #779 — escalation 시뮬레이션 test hook (ADR 20260701-779 §A1 부수 결정). 기본 none, 수동 전용.
+      #   flake: measure guard 만 강제 fail → retry-fresh-runner 실측 pass 기대 (recovery 실증, 메일 0)
+      #   regression: 양 job guard 강제 fail → workflow failure 기대 (negative 실증, fail 메일 1통 의도됨)
+      simulate:
+        description: 'escalation 시뮬레이션 (#779 test hook)'
+        type: choice
+        options:
+          - none
+          - flake
+          - regression
+        default: 'none'
 
 jobs:
-  fps-baseline-guard:
+  measure:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    outputs:
+      guard_outcome: ${{ steps.guard.outcome }}
     steps:
+      # ⚠ measure job 과 동기 유지 — 이 setup 구간 (checkout ~ dev server 기동) 은 retry-fresh-runner
+      #   job 에 복제되어 있음. 한쪽 수정 시 반드시 양쪽 동시 수정
+      #   (ADR 20260701-779 §A1 재검토 7 — 첫 drift 발견 시 composite action 추출이 착수 트리거).
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
@@ -121,14 +142,28 @@ jobs:
 
       # #709 — 전역 부하 spike flake 흡수 (measurement-first 결론: best-of-N 으로는 흡수 불가,
       #   docs/benchmarks/fps-variance-diagnosis-20260619.json). 1차 fail 시 1회 자동 재측정
-      #   (sleep 으로 시간차 → transient spike 회피). 2회 연속 fail 이어야 job fail → 일시 spike
-      #   는 메일 미발송 (alert fatigue 완화). 진짜 회귀는 매 시도 fail 하므로 은폐 불가.
+      #   (sleep 으로 시간차 → transient spike 회피). 진짜 회귀는 매 시도 fail 하므로 은폐 불가.
+      # #779 Phase 3 — continue-on-error 는 non-blocking silent skip 이 아니라 필수 blocking
+      #   escalation job (retry-fresh-runner) 으로의 라우팅 (ADR §A1 CRITICAL 정합 — fail-fast 유지).
       - name: FPS baseline 회귀 검증 (1회 자동 재시도)
+        id: guard
+        continue-on-error: true # step-level soft-fail — outcome=failure 보존, escalation job 이 blocking 승계
         if: github.event_name != 'workflow_dispatch' || inputs.diagnose_variance != true
+        env:
+          # #779 test hook — simulate=flake|regression 시 measure guard 강제 fail (측정 스크립트 수정 0)
+          SIMULATE_GUARD_FAIL: ${{ inputs.simulate == 'flake' || inputs.simulate == 'regression' }}
         run: |
+          # simulate 주입은 guard 호출부 단일 함수로 캡슐화 (워크플로 분기 최소화 — agy 권고)
+          run_guard() {
+            if [[ "$SIMULATE_GUARD_FAIL" == "true" ]]; then
+              echo "simulate hook (#779): measure guard 강제 fail"
+              return 1
+            fi
+            BASE_URL=http://localhost:3001 node scripts/verify-fps-baseline.mjs
+          }
           for attempt in 1 2; do
             echo "::group::fps guard attempt $attempt/2"
-            if BASE_URL=http://localhost:3001 node scripts/verify-fps-baseline.mjs; then
+            if run_guard; then
               echo "::endgroup::"
               echo "✓ fps guard passed (attempt $attempt)"
               exit 0
@@ -139,8 +174,12 @@ jobs:
               sleep 15
             fi
           done
-          echo "::error::fps guard 2회 연속 실패 — 진짜 회귀 또는 지속 부하"
+          echo "::error::fps guard 2회 연속 실패 — fresh-runner escalation 으로 이관 (#779 Phase 3)"
           exit 1
+
+      - name: escalation 이관 알림
+        if: steps.guard.outcome == 'failure'
+        run: echo "::warning::fps 측정 실패 — fresh-runner escalation job 으로 이관 (#779 Phase 3)"
 
       # #709 — 진단 분포 보고서 업로드 (로그에도 출력되나 artifact 로 정밀 분석).
       - name: variance 진단 보고서 업로드
@@ -158,11 +197,137 @@ jobs:
             kill $(cat /tmp/next-pid) || true
           fi
 
+      # #779 — guard 가 continue-on-error 라 job-level failure() 는 guard 실패 시 false.
+      #   if 를 steps.guard.outcome 기준으로 교체 (ADR §A1 구조 스케치 — 필수 배선).
+      - name: 회귀 보고서 업로드 (guard 실패 시)
+        if: steps.guard.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fps-baseline-report
+          path: |
+            .verify-screenshots/fps-baseline/
+            docs/benchmarks/fps-lowend-baseline.json
+          retention-days: 7
+
+  # #779 Phase 3 — flake escalation (ADR 20260701-779 §A1 결정 3 개정 (B')).
+  #   measure guard 실패 시에만 fresh VM (GitHub hosted job = job 단위 새 머신) 에서 재측정.
+  #   여기서는 hard-fail (continue-on-error 없음) → 실패 = workflow failure = 메일 (진짜 회귀만).
+  #   무한 rerun 구조적 불가 — job 2개 고정 (상한이 토폴로지에 내장).
+  retry-fresh-runner:
+    needs: measure
+    if: needs.measure.outputs.guard_outcome == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      # ⚠ measure job 과 동기 유지 — 이 setup 구간 (checkout ~ dev server 기동) 은 measure job 의
+      #   복제본 (동작 동일, 상세 배경 주석은 measure job 원본 참조). 한쪽 수정 시 반드시 양쪽 동시 수정
+      #   (ADR 20260701-779 §A1 재검토 7 — 첫 drift 발견 시 composite action 추출이 착수 트리거).
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Rust 툴체인 설정
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Playwright 브라우저 캐시
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Playwright chromium 설치 (캐시 미스 — 다운로드+extract)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Playwright 시스템 deps (캐시 히트 — extract 생략)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: wasm + workspace 빌드
+        run: pnpm build
+
+      - name: next dev server 기동
+        run: |
+          pnpm --filter @astro-simulator/web exec next dev -p 3001 &
+          echo $! > /tmp/next-pid
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3001/ko > /dev/null; then
+              echo "ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "timeout"; exit 1
+
+      - name: FPS baseline 회귀 검증 (fresh runner — hard fail)
+        env:
+          # #779 test hook — simulate=regression 만 여기까지 강제 fail (flake 는 이 job 에서 실측 pass 기대)
+          SIMULATE_GUARD_FAIL: ${{ inputs.simulate == 'regression' }}
+        run: |
+          run_guard() {
+            if [[ "$SIMULATE_GUARD_FAIL" == "true" ]]; then
+              echo "simulate hook (#779): fresh-runner guard 강제 fail (regression 시뮬레이션)"
+              return 1
+            fi
+            BASE_URL=http://localhost:3001 node scripts/verify-fps-baseline.mjs
+          }
+          for attempt in 1 2; do
+            echo "::group::fps guard fresh-runner attempt $attempt/2"
+            if run_guard; then
+              echo "::endgroup::"
+              echo "✓ fps guard passed on fresh runner (attempt $attempt)"
+              # #779 escalation 흡수 기록 (ADR §A1 교차검증 고유 발견 1) —
+              # 경계 회귀 (2차 머신 성능 편차 우연 통과) 추적용 가시화
+              {
+                echo "### ⚠ #779 flake 흡수 — measure fail → fresh-runner pass"
+                echo "- measure job (머신 1) guard 실패 → fresh-runner (머신 2) attempt ${attempt}/2 pass"
+                echo "- 전역 부하 spike flake 판정. 반복 관찰 시 경계 회귀 의심 — ADR 20260701-779 §A1 재검토 6"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [[ $attempt -lt 2 ]]; then
+              echo "::warning::fresh-runner attempt $attempt 실패 — 15s 후 재측정"
+              sleep 15
+            fi
+          done
+          echo "::error::fps guard 2 머신 × 2 attempt 전부 실패 — 진짜 회귀 (최종 failure, 메일 발송)"
+          exit 1
+
+      - name: dev server 정리
+        if: always()
+        run: |
+          if [[ -f /tmp/next-pid ]]; then
+            kill $(cat /tmp/next-pid) || true
+          fi
+
+      # hard-fail job 이므로 failure() 정상 작동. artifact 이름은 measure 와 충돌 방지 위해 구분.
       - name: 회귀 보고서 업로드 (실패 시)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fps-baseline-report
+          name: fps-baseline-report-fresh-runner
           path: |
             .verify-screenshots/fps-baseline/
             docs/benchmarks/fps-lowend-baseline.json

--- a/docs/decisions/20260701-779-ci-alert-fatigue-concurrency.md
+++ b/docs/decisions/20260701-779-ci-alert-fatigue-concurrency.md
@@ -1,6 +1,7 @@
 # ADR 20260701-779 — CI 알림 alert fatigue 완화 (이중 트리거 concurrency + flake 안정화)
 
 - 상태: **Accepted** (cross-validate 2026-07-01 — agy, §교차검증 반영 사항 4축 박제 완료. group 식은 sha 유지 + Phase 1 branch-cross 가드 브랜치 무관성 실측 의무)
+  - **§Amendment 1 (Phase 2/3 구체 설계): Provisional** — cross-validate 대기 (ADR 개정 = 발동 앵커. 통합 후 Accepted 전이)
 - 날짜: 2026-07-01
 - 이슈: [#779](https://github.com/coseo12/astro-simulator/issues/779)
 - 관련: #766 (alert fatigue 개념 — Z 패턴 health), #728 (step retry vs job rerun), #709 (fps retry 도입), #626 (paths-ignore docs skip), ADR [20260421-workflows-responsibility-split](20260421-workflows-responsibility-split.md) (frozen vs user-owned 경계)
@@ -254,3 +255,121 @@ developer 가 run history 로 flake 이력 실측 → flake-prone 가드(verify:
 - **확증 편향**(저비용 1순위 결론 정당화?): run history 15 run 실측 + branch protection 404 실측 기반. agy 이견(matrix)도 §재검토로 반영. **통과**
 
 #### 결론: 조건부 통과 → group 식(sha) 유지 + Phase 1 branch-cross 가드 브랜치 무관성 실측 의무 추가 후 Accepted
+
+---
+
+## Amendment 1 (2026-07-04) — Phase 2/3 구체 설계 확정 (상태: Provisional — cross-validate 대기)
+
+> Phase 1 (concurrency, v0.41.0) 안정화 실측 완료 후 Phase 2/3 착수 설계. 결정 2 는 **선별 결과 정정**, 결정 3 은 **메커니즘 개정** (workflow_run rerun → 동일 워크플로 2-job escalation). 개정이므로 cross-validate 발동 대상 — 통합 전까지 Provisional.
+
+### A1 배경 — Phase 1 이후 flake 반복 비용 실측 (measurement-first)
+
+| 릴리스          | flake 지점                                  | 처리       |
+| --------------- | ------------------------------------------- | ---------- |
+| v0.39.0         | verify:699 deltaTime (detect-and-test)      | 수동 rerun |
+| v0.40.0         | fps 부하 spike                              | 수동 rerun |
+| v0.43.0 prep    | verify:699 deltaTime (**16m 실행 후** fail) | 수동 rerun |
+| v0.43.0 release | fps 부하 spike (5m fail)                    | 수동 rerun |
+| v0.44.0         | flake 0 (한 번에 그린)                      | —          |
+
+거의 매 릴리스 1~2회 수동 개입 고정 비용. #709 진단 확립 사실: 정상 run cv 0~3.8%, fail = **전역 부하 spike** (scenario-내 noise 아님) → same-runner step retry 는 지속 부하에 무력 (설계 시점 예견이 v0.40.0/v0.43.0 에서 재확인).
+
+### A1 결정 2 정정 — Phase 2 retry 대상은 verify:699 단독
+
+원 결정 2 의 후보 "verify:699, r1-guard 등" 을 run history 실측으로 확정:
+
+- **verify:699 — 적용** (flake 2회: v0.39.0 / v0.43.0 prep). S3b 가 100ms vs 200ms hold 이동 비율 ≈2.0 을 단언하는 부하 민감 타이밍 측정.
+- **r1-guard — 미적용**. flake 원천은 #606 Playwright install extract deadlock 이었고 Node 22 핀(#663/#666) + 바이너리 캐시(#684) 로 해소. v0.39.0~v0.44.0 창에서 verify 단계 flake 0 → 결정적 가드로 분류.
+- 나머지 8종 (verify:378/408/627/629/631/675/693/704) — flake 이력 0, retry 미적용 (원 결정 2 "결정적 가드 retry 금지 — 진짜 fail 2배 지연" 유지).
+
+**방식**: `ci.yml` verify:699 step 내부에서 dev server 는 유지한 채 guard 스크립트 호출만 `for attempt in 1 2` + 실패 시 `sleep 15` (#709 동일 패턴). 2연속 fail = step fail (fail-fast). flake 원인이 runner 전역 부하이므로 server 재기동 불요 — 단 §A1 재검토 1 참조.
+
+**agy 고유 발견 (Playwright retries 옵션 대안) 비교 의무 이행**: `browser-verify-699-freefly-unified.mjs` / `verify-fps-baseline.mjs` 모두 `import { chromium } from 'playwright'` 인 plain node 스크립트 (`@playwright/test` runner 아님) → 도구 내부 `retries` 옵션 부재 → shell for-loop 가 유일 경로 (실측 확인).
+
+**기각 재확인**: (b) 분리 job — non-blocking 은 원 ADR 기각 유지 + blocking 분리 job 도 wasm/Playwright/build setup ~10분 중복으로 가드 1종 대비 비용 과잉. (c) S3b 측정 강건화 — verify:699 전용 variance 진단 데이터 부재 상태의 선행 착수는 오진 위험 (CLAUDE.md 스프린트 계약 §10 "측정 방법 검증 우선" — 진단이 먼저). §A1 재검토 1 로 이연.
+
+### A1 결정 3 개정 — fps 새 머신 rerun 은 (B) workflow_run 이 아니라 (B') 동일 워크플로 2-job escalation
+
+| 축              | (B) workflow_run + `gh run rerun --failed`                                                                     | **(B') 2-job fresh-runner escalation (채택)**                                                                               | (C) margin 재검토                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 메일 (핵심)     | attempt 1 이 conclusion=`failure` 로 **확정된 후** 트리거 → **fail 메일 1통 구조적 잔존** (노이즈 0 목표 미달) | flake 시 workflow conclusion=`success` → **메일 0**. 진짜 회귀만 최종 failure 메일                                          | —                                                                                        |
+| 검증 가능 시점  | workflow_run 은 default branch 반영 후에만 발화 — PR 단계 실검증 **불가** (2단계 함정 전면)                    | pull_request run 이 **PR 의 워크플로 파일을 사용** → PR 단계 실검증 가능. dispatch `--ref` 경로도 기존 등록(#663) 활용 가능 | —                                                                                        |
+| 무한 rerun 방지 | `run_attempt` 상한 체크 코드 필요                                                                              | **구조적 불가** (job 2개 고정 — 상한이 토폴로지에 내장)                                                                     | —                                                                                        |
+| 권한/보안       | `GITHUB_TOKEN: actions: write` + Run ID 엄격 한정 (원 §고유 발견 DoD)                                          | 추가 권한 **불필요** — 원 §고유 발견의 보안 DoD 는 대상 소멸 (supersede, cross-validate 라운드에서 재확인 예정)             | —                                                                                        |
+| 새 머신 여부    | rerun = 새 runner ✓                                                                                            | job B = 새 runner ✓ (GitHub hosted job 은 job 단위 fresh VM)                                                                | ✗ (머신 무관)                                                                            |
+| 평가            | **기각** — 메일 잔존이 결정타                                                                                  | **채택**                                                                                                                    | **기각** — cv 0~3.8% 정상 대비 spike 는 35~47% 하락. margin 은 원인과 무관 (silent 약화) |
+
+**구조 스케치** (`fps-baseline-guard.yml`):
+
+```yaml
+jobs:
+  measure: # 기존 job — guard step 만 soft-fail 화
+    timeout-minutes: 25
+    outputs:
+      guard_outcome: ${{ steps.guard.outcome }}
+    steps:
+      # ... 기존 setup 동일 (checkout/pnpm/node/rust/wasm-pack/playwright cache/build/dev server) ...
+      - id: guard
+        continue-on-error: true # step-level — outcome=failure 보존, job 은 success
+        run: | # 기존 #709 for attempt in 1 2 루프 그대로
+      - if: steps.guard.outcome == 'failure'
+        run: echo "::warning::fps 측정 실패 — fresh-runner escalation job 으로 이관"
+      # 회귀 보고서 업로드 step 의 if 를 failure() → steps.guard.outcome == 'failure' 로 교체
+      #   (continue-on-error 로 job failure() 가 false 가 되므로 — 필수 배선)
+  retry-fresh-runner:
+    needs: measure
+    if: needs.measure.outputs.guard_outcome == 'failure'
+    timeout-minutes: 25
+    steps:
+      # measure 와 동일 setup 복제 (⚠ 주석 마커로 동기 유지 — YAML anchor 미지원)
+      # 측정 step 은 hard-fail (continue-on-error 없음) → 여기서 fail = workflow failure = 메일
+```
+
+**동작 매트릭스** (fail-fast 정합 증명):
+
+| 시나리오          | job A (머신 1)            | job B (머신 2)                    | workflow conclusion | 메일                        |
+| ----------------- | ------------------------- | --------------------------------- | ------------------- | --------------------------- |
+| 정상              | guard pass                | skipped (`guard_outcome≠failure`) | success             | 0                           |
+| 부하 spike flake  | guard 2회 fail (soft)     | pass                              | **success**         | **0**                       |
+| 진짜 회귀         | guard 2회 fail (soft)     | **2회 fail (hard)**               | **failure**         | 1 (최종 실패만)             |
+| setup 결정적 실패 | guard 이전 step hard fail | skipped (needs failure)           | failure             | 1 (즉시 — 낭비 재시도 없음) |
+| diagnose dispatch | guard step skipped        | skipped (`outcome=skipped`)       | 진단 결과대로       | —                           |
+
+**continue-on-error 금지 원칙과의 정합 (CRITICAL)**: 원 ADR 이 기각한 것은 _non-blocking_ continue-on-error (= fail 무시, silent skip) 다. (B') 는 step-level soft-fail 을 **필수 blocking escalation job** 으로 라우팅 — fail 은 무시되지 않고 새 머신 재검증으로 승격되며, 진짜 회귀는 2 머신 × 2 attempt = 4회 전부 fail 해야만 그린이 될 수 없다 (은폐 불가). 가드 약화 아님 — [guard-design-principles.md](../lessons/guard-design-principles.md) §3 fail-fast 유지.
+
+**부수 결정 — `simulate` dispatch input (test hook)**: workflow_dispatch 에 `simulate: none|flake|regression` choice input 추가 (기본 none, #709 `diagnose_variance` 선례). `flake` = job A guard 강제 fail + job B 정상 → recovery 실증. `regression` = 양 job 강제 fail → negative 실증. dispatch `--ref feature/*` 가 ref 브랜치 워크플로 정의를 따르므로 (#709 실측 박제) **머지 전 PR 단계에서 3중 시뮬레이션이 결정적으로 가능**. 잔존 위험 (수동 오발사 시 red run 1회) 은 default none + 수동 전용으로 수용.
+
+### A1 축 4 종결 — 알림 정책 별도 조치 불필요 확정
+
+GitHub 메일 = conclusion=`failure` 만 발송. Phase 2 (flake 시 step retry 로 job 성공 유지) + Phase 3 (flake 시 escalation 흡수로 workflow 성공) → **"최종 실패만 메일" 이 워크플로 구조만으로 완성**. 별도 알림 코드/설정 0. — (B) 를 채택했다면 attempt 1 메일이 잔존해 이 축이 미완이었음 (기각 근거와 표리).
+
+### A1 Concrete Prediction (무침범 예측 — `git diff --stat` 실측 재현 의무)
+
+- `.github/workflows/ci.yml` — verify:699 step **내부만** 수정 (+15줄 내외). 다른 가드 step / job 구조 0줄
+- `.github/workflows/fps-baseline-guard.yml` — 1 job → 2 job 재편 (+80~95줄: setup 복제 ~55 + simulate input ~12 + escalation 배선 ~15)
+- **앱/가드 스크립트 무침범**: `apps/**`, `packages/**`, `scripts/verify-fps-baseline.mjs`, `apps/web/scripts/browser-verify-*.mjs` **0줄** (워크플로 지휘부만 변경, 측정 로직 불변 = 가드 본질 보존의 구조적 증거)
+- 예측 실패 (측정 스크립트 수정 필요 발생) 시 = simulate hook 설계 결함 신호 → 본 Amendment 재검토
+
+### A1 DoD — PR 단계 vs 머지 후 실측 분리 (workflow_dispatch 2단계 함정 대응)
+
+**PR 단계 (머지 전 검증 가능)**:
+
+- [ ] Phase 2 retry 루프 3중 시뮬레이션 — 로컬 stub 스크립트로 positive (1회차 pass→즉시 exit 0) / negative (2연속 fail→exit 1) / recovery (1차 fail→2차 pass→exit 0) 결정적 재현 (#709 선례)
+- [ ] PR 자체의 detect-and-test run 이 수정된 verify:699 step 으로 그린 (ci.yml 은 paths filter 없음 → PR 단계 실행 보장)
+- [ ] Phase 3 — `gh workflow run fps-baseline-guard.yml --ref feature/*` dispatch 3회: `simulate=none` (A pass + B skipped) / `flake` (A soft-fail → B pass → conclusion=success, **메일 0**) / `regression` (양 job fail → conclusion=failure, 메일 정확 1통). run link 3개 PR 박제
+  - 주의: fps 워크플로는 `paths-ignore: '.github/**'` 라 워크플로만 바꾼 PR 에서 pull_request 트리거 자체가 발화 안 함 → dispatch `--ref` 가 PR 단계 유일 실검증 경로 (설계에 반영됨)
+- [ ] setup 복제 구간 동기 주석 마커 (`⚠ measure job 과 동기 유지`) 양쪽 박제
+- [ ] 가드 도입 PR DoD 4축 명시 — 축 1(격리 동적)=stub 시뮬레이션+dispatch, 축 2(3중)=simulate 3종, 축 3(5 페르소나 self-consistency)=N/A (판정이 exit code 결정적 — verify-\*.sh 텍스트 매칭 가드 아님) 사유 박제, 축 4(메타 자기 적용)=N/A 사유 박제
+
+**머지 후 실측 의무 (후속 관찰 — 이슈 #779 에 박제 후 종결)**:
+
+- [ ] push 트리거 (develop push) 경로에서 2-job 구조 정상 1회 (PR 단계는 dispatch/pull_request 경로만 실측됨)
+- [ ] 다음 자연 flake 발생 시: verify:699 attempt 2 흡수 warning annotation 또는 fps A-fail→B-pass→메일 0 실측 박제 (현 빈도 릴리스당 1~2회 → 대기 짧음)
+- [ ] 릴리스 2회 창에서 수동 rerun 횟수 0 (baseline: 4/4 릴리스 → 목표 0)
+
+### A1 재검토 조건 (원 §재검토 1~4 에 추가)
+
+5. **verify:699 이 step retry 후에도 2연속 fail flake 재발**: (0) 측정 방법 검증 우선 — verify:699 전용 variance 진단 (fps `--diagnose-variance` 패턴 이식) 으로 S3b ratio 분포 실측 → 그 후에만 측정 강건화 (median-of-N hold 등) 검토. 임계 완화는 여전히 금지
+6. **retry-fresh-runner 도 fail 하는 지속 부하가 반복** (2 머신 연속 spike): GitHub hosted runner 전역 이벤트 가능성 — matrix 분할/시간대 회피가 아니라 발생 빈도 실측 후 판단 (현재 관찰 0건)
+7. **setup 복제 구간 drift 발생** (한쪽만 수정): composite action 추출로 SSoT 화 — 첫 drift 발견 시점이 착수 트리거
+8. **simulate input 오발사로 인한 red run 이 노이즈화**: input 제거 + 검증은 scratch 브랜치 dispatch 로 대체

--- a/docs/decisions/20260701-779-ci-alert-fatigue-concurrency.md
+++ b/docs/decisions/20260701-779-ci-alert-fatigue-concurrency.md
@@ -1,7 +1,7 @@
 # ADR 20260701-779 — CI 알림 alert fatigue 완화 (이중 트리거 concurrency + flake 안정화)
 
 - 상태: **Accepted** (cross-validate 2026-07-01 — agy, §교차검증 반영 사항 4축 박제 완료. group 식은 sha 유지 + Phase 1 branch-cross 가드 브랜치 무관성 실측 의무)
-  - **§Amendment 1 (Phase 2/3 구체 설계): Provisional** — cross-validate 대기 (ADR 개정 = 발동 앵커. 통합 후 Accepted 전이)
+  - **§Amendment 1 (Phase 2/3 구체 설계): Accepted** (cross-validate 2026-07-04 — agy, §A1 교차검증 반영 사항 통합)
 - 날짜: 2026-07-01
 - 이슈: [#779](https://github.com/coseo12/astro-simulator/issues/779)
 - 관련: #766 (alert fatigue 개념 — Z 패턴 health), #728 (step retry vs job rerun), #709 (fps retry 도입), #626 (paths-ignore docs skip), ADR [20260421-workflows-responsibility-split](20260421-workflows-responsibility-split.md) (frozen vs user-owned 경계)
@@ -258,7 +258,7 @@ developer 가 run history 로 flake 이력 실측 → flake-prone 가드(verify:
 
 ---
 
-## Amendment 1 (2026-07-04) — Phase 2/3 구체 설계 확정 (상태: Provisional — cross-validate 대기)
+## Amendment 1 (2026-07-04) — Phase 2/3 구체 설계 확정 (상태: Accepted — cross-validate 2026-07-04)
 
 > Phase 1 (concurrency, v0.41.0) 안정화 실측 완료 후 Phase 2/3 착수 설계. 결정 2 는 **선별 결과 정정**, 결정 3 은 **메커니즘 개정** (workflow_run rerun → 동일 워크플로 2-job escalation). 개정이므로 cross-validate 발동 대상 — 통합 전까지 Provisional.
 
@@ -373,3 +373,12 @@ GitHub 메일 = conclusion=`failure` 만 발송. Phase 2 (flake 시 step retry �
 6. **retry-fresh-runner 도 fail 하는 지속 부하가 반복** (2 머신 연속 spike): GitHub hosted runner 전역 이벤트 가능성 — matrix 분할/시간대 회피가 아니라 발생 빈도 실측 후 판단 (현재 관찰 0건)
 7. **setup 복제 구간 drift 발생** (한쪽만 수정): composite action 추출로 SSoT 화 — 첫 drift 발견 시점이 착수 트리거
 8. **simulate input 오발사로 인한 red run 이 노이즈화**: input 제거 + 검증은 scratch 브랜치 dispatch 로 대체
+9. **branch protection 도입 시** (현재 미설정 — 실측 404): `measure` job 은 soft-fail 구조라 항상 success — required check 로 부적합. 두 job 결과를 취합하는 gatekeeper job (`needs: [measure, retry-fresh-runner]` + `if: always()`) 신설 후 그것만 required 등록 (cross-validate 고유 발견 — 도입 시점이 착수 트리거)
+
+### A1 교차검증 반영 사항 (agy 2026-07-04 — 로그 `.claude/logs/cross-validate-architecture-779-a1.log`)
+
+**합의 (설계 유지)**: Q1 verify:699 단독 한정 — 이력 기반 선별이 fail-fast 정합, 균일 retry 는 진짜 회귀 시 전체 지연 + 오진 확률 확대 (동적 옵트인 = 재검토 조건 5 와 동일 구조). Q3 simulate hook — dispatch 는 write 권한자 전용이라 fork 우회 불가, 분기 검증 가치 > 비용. Q4 workflow_run 보안 DoD supersede 타당 (PR 컨텍스트 read-only 유지로 위험 도메인 소멸 — cache poisoning 잔존은 일반 PR 빌드와 동일 범위, 무조치). **Phase 3 전제 확증**: GitHub hosted runner 는 job 단위 fresh VM 100% 보장 (needs 직렬이어도 별도 머신).
+
+**고유 발견 (수용)**: (1) **escalation 흡수 이력 관찰 가능성** — 2차 job 성공 (= flake 흡수) 시 `$GITHUB_STEP_SUMMARY` 에 "A-fail→B-pass 흡수" 기록 의무 (경계 회귀 — 2차 머신 성능 편차로 우연 통과 — 추적용. 100% 포착 원칙의 수용된 트레이드오프를 가시화). (2) **gatekeeper job** — 재검토 조건 9 로 박제 (현재 branch protection 부재라 즉시 구현은 YAGNI).
+
+**이견 (기각)**: composite action 즉시 추출 (Phase 3 병합 동시) — 재검토 조건 7 의 "첫 drift 발견 시 착수" 유지. 근거: 워크플로 구조 변경 PR 은 검증 창이 좁아 (2단계 함정) 변경 표면 최소화가 우선, 동기 주석 마커 + reviewer 대조가 1차 방어. **기각 (조치 불요)**: 공통 인프라 실패 (레지스트리 다운 등) 시 양 job fail → 메일 발송은 정당한 알림 (구제 대상 아님). escalation 경로의 스케줄링 지연은 실패 경로 한정 트레이드오프.


### PR DESCRIPTION
## [#779] CI flake 자동화 Phase 2/3 — verify:699 step retry + fps fresh-runner escalation

### 변경 사항
ADR `20260701-779-ci-alert-fatigue-concurrency.md` **§Amendment 1** (Accepted — cross-validate agy 2026-07-04, §A1 교차검증 반영 사항 통합) 구현. 구조 스케치·동작 매트릭스·Concrete Prediction·DoD 그대로.

- **Phase 2 (§A1 결정 2 정정)** — `ci.yml` verify:699 step **내부만**: dev server 는 유지한 채 guard 호출만 `for attempt in 1 2` + 실패 시 `sleep 15` (#709 동일 패턴). 2연속 fail = step fail (fail-fast 유지). attempt 2 흡수 시 `::warning::` annotation. 다른 가드 step / job 구조 0줄.
  - 선별 근거 (measurement-first, §A1 배경 표): flake 이력 verify:699 **2회** (v0.39.0 / v0.43.0 prep) — 가드 9종 중 유일. r1-guard 는 #663 Node 22 핀 + #684 바이너리 캐시로 해소 → 결정적 가드 분류 (retry 미적용). 나머지 8종 flake 0 (retry 미적용 — 진짜 fail 2배 지연 회피).
  - Playwright `retries` 옵션 대안 비교 (agy 고유 발견 이행): 두 스크립트 모두 plain node + `import { chromium }` (`@playwright/test` runner 아님) → 내부 retries 부재 → shell for-loop 유일 경로 (§A1 실측 박제).
- **Phase 3 (§A1 결정 3 개정 B′)** — `fps-baseline-guard.yml` 1 job → 2-job fresh-runner escalation:
  - `measure`: guard step `id: guard` + `continue-on-error: true` (step-level soft-fail) + `outputs.guard_outcome` + 실패 시 `::warning::` 이관 알림 + **회귀 보고서 업로드 if 를 `failure()` → `steps.guard.outcome == 'failure'` 로 교체 (필수 배선** — continue-on-error 로 job-level `failure()` 가 false)
  - `retry-fresh-runner`: `needs: measure` + `if: needs.measure.outputs.guard_outcome == 'failure'`, setup 복제 + 동기 주석 마커 `⚠ measure job 과 동기 유지` **양쪽 박제**, 측정 step hard-fail (continue-on-error 없음). 무한 rerun 구조적 불가 (job 2개 고정 — 상한이 토폴로지에 내장)
  - **escalation 흡수 기록** (§A1 교차검증 고유 발견 1): fresh-runner pass 시 `$GITHUB_STEP_SUMMARY` 에 "flake 흡수 — measure fail → fresh-runner pass" 기록 (경계 회귀 우연 통과 추적용 가시화)
  - artifact 이름 충돌 방지: retry job 은 `fps-baseline-report-fresh-runner` (upload-artifact@v4 동일 이름 에러 회피)
- **simulate dispatch input** (§A1 부수 결정): `none|flake|regression` choice (기본 none, 수동 전용). 주입은 guard 호출부 `run_guard()` **단일 함수로 캡슐화** — 워크플로 분기 최소화 (agy 권고) + 측정 스크립트 수정 0 (Concrete Prediction 무침범 원칙과 충돌 없이 env 주입으로 캡슐화).

### Behavior Changes (CI 동작 · 메일 정책 변화)
- **verify:699 (detect-and-test)**: 1회차 fail → 15s 후 재시도. 2회차 pass = step pass + 흡수 warning annotation → **flake 메일 0** (기존: 18분 job 전체 fail + 메일 + 수동 rerun). 2연속 fail 시에만 step fail — 진짜 회귀 경로는 기존과 동일.
- **fps-baseline-guard**: measure (머신 1) guard 실패가 더 이상 즉시 workflow failure 가 아님 — fresh VM (머신 2) escalation 재측정으로 승격.
  - 부하 spike flake: A soft-fail → B pass → workflow conclusion=**success** → **메일 0** (기존: fail 메일 1통 + 수동 rerun)
  - 진짜 회귀: 2 머신 × 2 attempt = **4회 전부 fail** → 최종 failure **메일 정확 1통** (포착 100% 유지)
  - setup 결정적 실패 (빌드 등): measure hard fail → retry skipped (needs) → 즉시 failure 메일 (낭비 재시도 없음)
  - diagnose dispatch (#709): guard skipped → retry skipped (`outcome=skipped ≠ failure`) — 기존 진단 경로 무변화
- **가드 약화 아님 (CRITICAL, §A1 정합)**: continue-on-error 는 non-blocking silent skip 이 아니라 **필수 blocking escalation job 으로의 라우팅**. 진짜 회귀 은폐 경로 0 (동작 매트릭스 5행 = ADR §A1).
- 축 4 종결: "최종 실패만 메일" 이 워크플로 구조만으로 완성 — 별도 알림 코드/설정 0.

### Test plan
1. Local stub 3-scenario simulation of the Phase 2 retry loop (positive / negative / recovery) — deterministic reproduction, results pinned below
2. YAML validation: python3 `yaml.safe_load` on both files (actionlint unavailable locally) + programmatic wiring assertions (outputs.guard_outcome / needs+if / continue-on-error / simulate choice / setup-step functional equality across both jobs)
3. workflow_dispatch real-run verification ×3 on this branch (`gh workflow run fps-baseline-guard.yml --ref feature/779-flake-phase23 -f simulate=…`) — fps workflow has `paths-ignore: '.github/**'`, so dispatch is the **only** pre-merge real-execution path (§A1 DoD 주의 문구 반영). Runs executed sequentially — concurrency group is keyed on the same sha, parallel dispatches would cancel each other
4. This PR's own detect-and-test runs the modified verify:699 step (ci.yml has no paths filter) — must be green

### DoD 결과 — PR 단계 (§A1 DoD 그대로)

**1. Phase 2 retry 루프 3중 시뮬레이션** (로컬 stub — volt #67 임시 스크립트 패턴, 실행 후 즉시 rm. ci.yml retry 루프 그대로 복제, 치환 2건만: guard 호출→stub / sleep 15→0. `set -euo pipefail` GH Actions 기본 shell 정합)

| 케이스 | 기대 | 실측 | 판정 |
|---|---|---|---|
| positive (1회차 pass) | EXIT=0, ATTEMPTS=1 (재시도 없음) | `CASE=positive EXIT=0 ATTEMPTS=1` | ✅ |
| negative (2연속 fail = 진짜 회귀) | EXIT=1, ATTEMPTS=2 (**미은폐**) | `CASE=negative EXIT=1 ATTEMPTS=2` | ✅ |
| recovery (1차 fail → 2차 pass = flake) | EXIT=0, ATTEMPTS=2 + 흡수 warning | `CASE=recovery EXIT=0 ATTEMPTS=2` + `::warning::verify:699 attempt 1 실패를 attempt 2 가 흡수 …` | ✅ |

**2. Phase 3 dispatch 3회 실측** (순차 실행 — 같은 sha concurrency group 교차 취소 방지)

| simulate | 기대 | run link | conclusion | 메일 |
|---|---|---|---|---|
| none | measure pass + retry-fresh-runner skipped | [28699730583](https://github.com/coseo12/astro-simulator/actions/runs/28699730583) | **success** (measure ✓ / retry skipped ✓) | 0 ✓ |
| flake | measure soft-fail → fresh-runner pass → success | [28699841915](https://github.com/coseo12/astro-simulator/actions/runs/28699841915) | **success** (retry job 실행됨 = guard outcome=failure 구조 증명 + escalation 흡수) | 0 ✓ |
| regression | 양 job 강제 fail → failure | [28706842148](https://github.com/coseo12/astro-simulator/actions/runs/28706842148) | **failure** (measure success·soft + retry hard-fail → workflow failure) | 1 ✓ (의도된 fail 메일 — 사전 고지됨) |

**3. Concrete Prediction 실측** (`git diff --stat` vs §A1 예측 — 재현 의무)

| 대상 | 예측 | 실측 | 판정 |
|---|---|---|---|
| `ci.yml` | verify:699 step 내부만, +15줄 내외 | **+19/−2 (net +17)**, verify:699 step 내부만 — 다른 step/job 0줄 | ✅ 부합 |
| `fps-baseline-guard.yml` | 1→2 job 재편, +80~95줄 | **+171/−6 (net +165**, 169→334줄**)** | ⚠ 초과 (사유 하단) |
| `apps/**` / `packages/**` / `scripts/verify-fps-baseline.mjs` / `apps/web/scripts/browser-verify-*.mjs` | **0줄** | **0줄** (diff 파일 목록 = 워크플로 2개 + ADR 1개) | ✅ 무침범 invariant 유지 |

fps 초과 사유: §A1 예측 내역 (setup 복제 ~55 + simulate input ~12 + escalation 배선 ~15 ≈ 82) 이 retry job 의 **측정 실행부** (hard-fail guard 루프 + STEP_SUMMARY 흡수 기록 ~40줄) / cleanup + artifact 업로드 (~16줄) / 주석 (CRITICAL 정합 · 동기 마커 · simulate 설명) / step 간 공백 라인을 미산입. **§A1 예측 실패 트리거 (= 측정 스크립트 수정 필요 발생) 에는 미해당** — 스코프 침범 0, 순수 워크플로 지휘부 확장. Amendment 재검토 불요 판단 (reviewer 재검 환영).

**4. 가드 도입 PR DoD 4축 (§A1 DoD 문구 그대로)**
- 축 1 (격리 동적 테스트) = stub 시뮬레이션 + dispatch ✅
- 축 2 (3중 시뮬레이션) = simulate 3종 (positive=none / negative=regression / recovery=flake) ✅
- 축 3 (5 페르소나 self-consistency) = **N/A — 판정이 exit code 결정적 (verify-\*.sh 텍스트 매칭 가드 아님)**
- 축 4 (메타 측정 도구 자기 적용) = **N/A — 측정 도구 신설 아님. 기존 측정 스크립트 (0줄 무변경) 의 워크플로 지휘부 재편**

**5. yaml lint**: actionlint 로컬 부재 → 계약 대체 경로 (python3 yaml parse) 수행 — 2개 파일 `yaml.safe_load` PASS + 배선 프로그램 검증 (measure.outputs.guard_outcome=`steps.guard.outcome` / retry needs+if / guard continue-on-error=true / simulate choice [none, flake, regression] default none) PASS. setup 복제 구간 기능 필드 (uses/run/with/if/id) **12 step 전수 동일** (name 표시 문자열 1건만 상이 — 기능 무관).

**6. 한글 인코딩**: 변경 파일 U+FFFD 0 hit. **커밋 후 검증**: `git show --stat HEAD` = 의도 파일 2개 정확 반영 (lint-staged FAILED 0).

### 머지 후 실측 의무 (후속 관찰 — 이슈 #779 에 박제 후 종결, §A1 DoD)
- [ ] push 트리거 (develop push) 경로에서 2-job 구조 정상 1회 (PR 단계는 dispatch/pull_request 경로만 실측됨)
- [ ] 다음 자연 flake 발생 시: verify:699 attempt 2 흡수 warning annotation 또는 fps A-fail→B-pass→메일 0 실측 박제 (현 빈도 릴리스당 1~2회 → 대기 짧음)
- [ ] 릴리스 2회 창에서 수동 rerun 횟수 0 (baseline: 4/4 릴리스 → 목표 0)

### 비-범위
- 임계 완화 (margin/ratio) / non-blocking continue-on-error / push 트리거 제거 일절 없음 (가드 약화 금지)
- verify:699 외 8종 가드 retry 미적용 (결정적 가드 — §A1 결정 2 정정 그대로)
- composite action 추출 — §A1 재검토 조건 7 (첫 drift 발견 시 착수). gatekeeper job — §A1 재검토 조건 9 (branch protection 도입 시 착수)
- verify:699 S3b 측정 강건화 — §A1 재검토 조건 5 (재발 시 variance 진단 선행)

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (ADR §Amendment 1 Accepted + 이슈 #779 architect 설계 코멘트 — 구조 스케치·동작 매트릭스·Concrete Prediction·DoD 계약화)
- [x] 모든 완료 기준 충족 (PR 단계 DoD 1~6 위 표, 머지 후 실측 의무 3항은 §A1 설계대로 후속 분리 명시)

### 테스트
- [x] 단위 테스트 추가/수정 — N/A (CI 워크플로 YAML 전용 변경. 대체 검증 = 로컬 stub 3중 시뮬레이션 + dispatch 3회 실측, 위 Test plan/DoD 표)
- [x] 기존 테스트 통과 확인 — 런타임 코드 0줄 (워크플로 지휘부만). PR 의 detect-and-test 가 수정된 verify:699 step 포함 전체 가드로 실검증 (§A1 DoD)
- [x] 모노레포: 신규/변경 워크스페이스 없음 — 해당 없음

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [ ] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [x] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR: `docs/decisions/20260701-779-ci-alert-fatigue-concurrency.md` **§Amendment 1** (a96962b Provisional → b6f4148 Accepted — ADR Status 워크플로 #370 옵션 C 준수, cross-validate agy 2026-07-04 통합)
  - 검증 결과: **호환** — grep 1차: `Amendment` / `§재검토 조건` hit (결정 2 정정 + 결정 3 개정 B′ + 재검토 조건 5~9 추가). LLM 2차: 원 ADR 결정 2 의 후보 "verify:699, r1-guard 등" 을 실측으로 verify:699 단독 확정 (정정), 원 결정 3 의 (B) workflow_run rerun 을 (B′) 2-job escalation 으로 개정 — 원 §고유 발견 workflow_run 보안 DoD 는 대상 소멸로 supersede (§A1 교차검증 Q4 합의 재확인). 본 구현은 §A1 구조 스케치·동작 매트릭스와 1:1 정합.

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
- [x] N/A — UI/렌더 경로 0줄 (CI 워크플로 YAML 전용). 동적 검증은 dispatch 3회 실측 + PR detect-and-test 로 대체 (§A1 DoD).

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님 (#779 는 머지 후 실측 의무 3항 박제 후 종결 — §A1 DoD)

### 체크리스트
- [x] 커밋 컨벤션 준수 (`ci(flake): #779 Phase 2/3 — …` — Phase 1 `ci(concurrency)` 선례 정합, `docs(adr): #779 …`)
- [x] 불필요한 변경 없음 (diff = 워크플로 2개 + ADR Amendment 1 만. prettier 재포맷 drift 0)
- [x] 보안 취약점 없음 (추가 권한 0 — §A1: (B′) 채택으로 `actions: write` 자체가 불필요. simulate dispatch 는 write 권한자 전용, fork 우회 불가 — §A1 교차검증 Q3 합의)
- [x] CLAUDE.md SSoT 코어 필드 미수정 — 해당 없음
- [x] **정책·규약·ADR 박제 변경 포함**: ADR §Amendment 1 박제. cross-validate 박제 직후 1회 루틴 (volt #23) 은 Amendment 커밋 시점에 이미 수행 — b6f4148 에서 Provisional → Accepted 전이 + §A1 교차검증 반영 사항 (합의/고유 발견 2건 수용/이견 기각) 본문 통합 완료 (로그 `.claude/logs/cross-validate-architecture-779-a1.log`). 본 구현 PR 은 §A1 의 코드화로 추가 cross-validate 불요 (Phase 1 PR #780 동일 판단 선례).

### 관련 이슈
Refs #779 (auto-close 미사용 — §A1 머지 후 실측 의무 3항 박제 후 종결. Phase 1 PR #780 동일 패턴)

