### PR TITLE
[#759] 표면 셰이더 verify 6종 CI 상시 가드 — shader-pixel-guard workflow

### DIFF
--- a/.github/workflows/shader-pixel-guard.yml
+++ b/.github/workflows/shader-pixel-guard.yml
@@ -1,0 +1,182 @@
+name: shader-pixel-guard
+
+# 프로젝트 로컬 워크플로 — harness 업데이트 대상 아님.
+# 이슈 #759 / ADR 20260705-759 — 표면 셰이더 verify 6종 CI 상시 가드.
+#
+# 목적: 셰이더 feature 5개 지대 (#756 표면 / #762 비율 단조성 / #773 광원 / #774 태양 /
+#   #782 자전 / #783 지구 디테일) 의 픽셀 회귀 (uniform 배선 절단·분기 오염·광원 붕괴·
+#   자전 정지·극관/biome 소실) 를 PR 단계에서 차단. r1-guard 는 UI 영역 diff 만 담당하고
+#   canvas 픽셀은 baseline 대상이 아니므로 (#756 ADR §A2 결정 7) 본 가드가 canvas 성질을 지킨다.
+#
+# 판정 규약 (ADR 결정 3): per-body 상대 성질 (ON vs OFF) 만 — 절대 임계 금지
+#   (swiftshader ↔ 하드웨어 값 편차). 756 마진은 D1 CI 실측으로 확정 (스크립트 주석 참조).
+#
+# CI 렌더 전제 (ADR §실측 1): ubuntu runner 는 GPU 부재 → headless chromium 이 SwiftShader
+#   (소프트웨어 렌더) 로 WebGL2 렌더. detect-gpu-tier 는 tier-c 로 판정하므로 6 스크립트 전부
+#   `?gpu=a` tier 강제 플래그 (P11-C #290) 로 표면 셰이더에 진입한다.
+#   로컬 재현: SWIFTSHADER=1 HEADFUL=0 BASE_URL=http://localhost:3001 \
+#     pnpm --filter @astro-simulator/web run verify:756-surface   (756/773/783 지원)
+#
+# retry 미포함 시작 (ADR 축 3) — 판정이 시간 비의존 성질 검증 (verify:699 deltaTime 류 아님).
+#   flake 실측 ≥ 1회/주 시 #779 Phase 2 step-retry 패턴 편입. silent 판정 완화 금지 —
+#   의식적 완화는 ADR Amendment 로만 (guard-design-principles §2).
+
+# 같은 sha 의 push+PR 중복 run 제거 (#779). group 에 github.workflow 포함 →
+# 워크플로 간 교차 취소 방지. PR head sha == 머지 후 push sha 로 수렴 → 같은 sha 묶임.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [develop, main]
+    # #626 — docs/ADR/워크플로만 바뀐 PR 은 픽셀 측정이 무의미 (런타임 무관). fps-baseline-guard
+    # 선례 그대로 답습 (자기 자신 .yml 만 변경된 PR 도 skip — fps 동일 정책). paths filter 효과는
+    # base 브랜치 반영 후 후속 PR 부터.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
+  push:
+    branches: [develop, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    # ADR cross-validate 부분 수용 (1) — CI 계수가 로컬 2~3× 추정을 초과할 가능성 완충.
+    # P1 예측 ≤25분은 유지, 30분 초과 실측 시 재검토 트리거 2항 (2-job 분할) 발동.
+    timeout-minutes: 40
+    steps:
+      # ⚠ setup 구간 (checkout ~ dev server 기동) 은 fps-baseline-guard measure job 과 동일 구간의
+      #   3번째 복제 (ci.yml r1-guard / fps-baseline-guard / 본 workflow). 한쪽 수정 시 동시 수정 —
+      #   composite action 추출은 후속 이슈 #802 (rule-of-three 도달, 선행 조건 = 본 건 머지).
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # #663 fix — playwright extract 가 Node 24.16 에서 deadlock. `.node-version` (22.16.0) 핀.
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      # ci.yml R1 가드 패턴 따름 — wasm 빌드 후 next dev 사용 (__solarScene 핸들 의존).
+      - name: Rust 툴체인 설정
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.1'
+          targets: wasm32-unknown-unknown
+
+      - name: Rust 빌드 캐시
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/physics-wasm
+
+      - name: wasm-pack 설치
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀 #663 이 1차).
+      - name: Playwright 브라우저 캐시
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Playwright chromium 설치 (캐시 미스 — 다운로드+extract)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: wasm + workspace 빌드
+        run: pnpm build
+
+      - name: next dev server 기동
+        run: |
+          pnpm --filter @astro-simulator/web exec next dev -p 3001 &
+          echo $! > /tmp/next-pid
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3001/ko > /dev/null; then
+              echo "ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "timeout"; exit 1
+
+      # ── verify 6종 직렬 실행 — 각 step 이 자기 exit code 로 job fail-fast (ADR 결정 1) ──
+      # 호출 규약: HEADFUL=0 (756/773/774/782/783) / --headless (762) — CI 에 chrome channel 이
+      #   없으므로 폴백이 아닌 명시적 headless 로 결정적 실행. BASE_URL 주입 (dev server 3001).
+      # trap: 스크립트 비정상 종료 (playwright timeout/crash) 시 잔존 chromium 정리 —
+      #   스크립트 간 실패 격리 (ADR cross-validate 부분 수용 4). 정상 종료 시 no-op.
+
+      - name: verify:756-surface (절차 표면 hfEntropy ON−OFF 갭 + tier-c)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          HEADFUL=0 BASE_URL=http://localhost:3001 \
+            CAPTURE_DIR="$GITHUB_WORKSPACE/.verify-screenshots/shader-pixel-guard/756-surface" \
+            pnpm --filter @astro-simulator/web run verify:756-surface
+
+      - name: verify:762-monotonic (표시 크기 비율 단조성)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          BASE_URL=http://localhost:3001 \
+            pnpm --filter @astro-simulator/web run verify:762-monotonic -- --headless
+
+      - name: verify:773-light (광원 일관성 day/night + contrast + purple)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          HEADFUL=0 BASE_URL=http://localhost:3001 \
+            CAPTURE_DIR="$GITHUB_WORKSPACE/.verify-screenshots/shader-pixel-guard/773-light" \
+            pnpm --filter @astro-simulator/web run verify:773-light
+
+      - name: verify:774-sun (granulation 엔트로피 + limb darkening + 색온도)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          HEADFUL=0 BASE_URL=http://localhost:3001 \
+            CAPTURE_DIR="$GITHUB_WORKSPACE/.verify-screenshots/shader-pixel-guard/774-sun" \
+            pnpm --filter @astro-simulator/web run verify:774-sun
+
+      - name: verify:782-rotation (자전각 jd 순수 함수 + tilt + 역행 + ring wobble)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          HEADFUL=0 BASE_URL=http://localhost:3001 \
+            CAPTURE_DIR="$GITHUB_WORKSPACE/.verify-screenshots/shader-pixel-guard/782-rotation" \
+            pnpm --filter @astro-simulator/web run verify:782-rotation
+
+      - name: verify:783-earth-detail (극관 + biome 위도 + 마젠타 0)
+        run: |
+          trap 'pkill -f "ms-playwright" 2>/dev/null || true' EXIT
+          HEADFUL=0 BASE_URL=http://localhost:3001 \
+            CAPTURE_DIR="$GITHUB_WORKSPACE/.verify-screenshots/shader-pixel-guard/783-earth" \
+            pnpm --filter @astro-simulator/web run verify:783-earth-detail
+
+      - name: dev server 정리
+        if: always()
+        run: |
+          if [[ -f /tmp/next-pid ]]; then
+            kill $(cat /tmp/next-pid) || true
+          fi
+
+      # 실패 시 캡처/JSON artifact — retention 7일 (ADR cross-validate 부분 수용 2, 스토리지 누적 방지).
+      - name: 실패 캡처 업로드
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shader-pixel-guard-report
+          path: |
+            .verify-screenshots/shader-pixel-guard/
+            docs/reports/762-monotonic/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,13 @@
     "verify:699-freefly-unified": "node scripts/browser-verify-699-freefly-unified.mjs",
     "verify:704-sensitivity": "node scripts/browser-verify-704-sensitivity.mjs",
     "verify:732-overview": "node scripts/browser-verify-732-overview.mjs",
-    "verify:737-onboarding": "node scripts/browser-verify-737-onboarding.mjs"
+    "verify:737-onboarding": "node scripts/browser-verify-737-onboarding.mjs",
+    "verify:756-surface": "node scripts/browser-verify-756-surface.mjs",
+    "verify:762-monotonic": "node scripts/browser-verify-762-monotonic.mjs",
+    "verify:773-light": "node scripts/browser-verify-773-light.mjs",
+    "verify:774-sun": "node scripts/browser-verify-774-sun.mjs",
+    "verify:782-rotation": "node scripts/browser-verify-782-rotation.mjs",
+    "verify:783-earth-detail": "node scripts/browser-verify-783-earth-detail.mjs"
   },
   "dependencies": {
     "@astro-simulator/core": "workspace:*",

--- a/apps/web/scripts/browser-verify-756-surface.mjs
+++ b/apps/web/scripts/browser-verify-756-surface.mjs
@@ -39,8 +39,10 @@ const SWIFTSHADER = process.env.SWIFTSHADER === '1';
  * #759 판정 마진 (가산, hfEntropy ON−OFF 갭 하한) — measurement-first 근거:
  *  - 하드웨어 headless 실측 최소 갭 moon 0.415 / CI 근사 swiftshader earth 0.469 (ADR §실측 3)
  *  - 고정 배수 임계 (×1.3 등) 는 moon(1.24×) 에서 즉시 false-fail → 가산 마진 방향 채택.
- *  - 초기값 0.15 (실측 최소 갭 대비 2.7× 여유). D1: 도입 PR 의 CI swiftshader 실측값으로 확정
- *    — 정정 시 silent 완화 금지, 3중 박제 의무 (본 주석 / PR 본문 / ADR Amendment).
+ *  - D1 확정 (2026-07-05, PR #803 run 28712529835 — CI ubuntu swiftshader 실측):
+ *    earth 0.768 / mars 0.873 / jupiter 0.688 / moon 0.359 (최소) → 마진 0.15 의 2.4× 여유.
+ *    로컬 하드웨어 재실행 분산 포함 전체 최소 관측 갭 0.295 (여유 1.97×) → 0.15 유지 확정.
+ *    변경 시 silent 완화 금지, 3중 박제 의무 (본 주석 / PR #803 본문 / ADR Amendment 1).
  */
 const HF_ENTROPY_MARGIN = 0.15;
 

--- a/apps/web/scripts/browser-verify-756-surface.mjs
+++ b/apps/web/scripts/browser-verify-756-surface.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * #756 — 절차적 행성 표면 셰이더 qa 동적 검증.
+ *
+ * 실 Chrome GUI (headless: false, channel: chrome) — WebGPU swiftshader freeze 회피 (#663).
+ * 픽셀 측정 = composited canvas.screenshot() (PNG) → 페이지 내 Image 디코드 → 2D getImageData.
+ *   ⚠️ WebGPU drawImage readback 빈버퍼 함정 회피 (#728 SSoT) — page.evaluate 내 2D canvas 경로만.
+ *
+ * disk 영역만 샘플: __simCore.scene.activeCamera 로 mesh bounding box 8 corner 화면 투영 →
+ *   그 bbox 픽셀만 분석 (UI / 궤도선 / glow 오염 제외).
+ *
+ * 판정 (#759 — shader-pixel-guard CI 상시 가드, ADR 20260705-759 결정 3):
+ *   per-body 상대 성질만 (절대 임계 금지 — swiftshader/하드웨어 값 편차).
+ *   4 body 각각 hfEntropy(ON) − hfEntropy(OFF) ≥ HF_ENTROPY_MARGIN + tier-c 저디테일
+ *   (lodStats 배선 검증 — override='low' && high/mid 0, 판정 블록 주석 참조).
+ *   미충족 시 exit 1 (fail-fast).
+ *
+ * 사용법:
+ *   node apps/web/scripts/browser-verify-756-surface.mjs               # 실 Chrome GUI
+ *   HEADFUL=0 node apps/web/scripts/browser-verify-756-surface.mjs     # CI 폴백 (headless)
+ *   SWIFTSHADER=1 node ...                                             # CI(ubuntu 소프트웨어 렌더) 로컬 재현
+ *                                                                      #   (headless + --use-angle=swiftshader 강제)
+ *   CAPTURE_DIR=/abs/dir node ...                                      # 캡처 PNG 저장
+ */
+
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? null;
+const HEADFUL = process.env.HEADFUL !== '0';
+// #759 — CI 실패 로컬 재현 경로 (ADR 20260705-759 §교차검증 부분 수용 3).
+// GitHub ubuntu runner 는 GPU 부재로 headless chromium 이 SwiftShader 로 렌더한다.
+// SWIFTSHADER=1 은 그 환경을 로컬에서 명시 재현 (--use-angle=swiftshader).
+const SWIFTSHADER = process.env.SWIFTSHADER === '1';
+
+/**
+ * #759 판정 마진 (가산, hfEntropy ON−OFF 갭 하한) — measurement-first 근거:
+ *  - 하드웨어 headless 실측 최소 갭 moon 0.415 / CI 근사 swiftshader earth 0.469 (ADR §실측 3)
+ *  - 고정 배수 임계 (×1.3 등) 는 moon(1.24×) 에서 즉시 false-fail → 가산 마진 방향 채택.
+ *  - 초기값 0.15 (실측 최소 갭 대비 2.7× 여유). D1: 도입 PR 의 CI swiftshader 실측값으로 확정
+ *    — 정정 시 silent 완화 금지, 3중 박제 의무 (본 주석 / PR 본문 / ADR Amendment).
+ */
+const HF_ENTROPY_MARGIN = 0.15;
+
+const SURFACE_BODIES = [
+  { id: 'earth', type: 'rocky' },
+  { id: 'mars', type: 'desert' },
+  { id: 'jupiter', type: 'gas-bands' },
+  { id: 'moon', type: 'cratered' },
+];
+const PLAIN_BODIES = [{ id: 'venus' }, { id: 'saturn' }, { id: 'neptune' }];
+
+async function setupPage(browser, query) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text());
+  });
+  page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
+  await page.goto(`${BASE_URL}${query}`, { waitUntil: 'networkidle', timeout: 45_000 });
+  await page.waitForFunction(
+    () => typeof window.__simCore !== 'undefined' && typeof window.__solarScene !== 'undefined',
+    { timeout: 20_000 },
+  );
+  await page.waitForTimeout(2600); // mesh 생성 + 첫 LOD pass + focus tween 정착
+  return { context, page, consoleErrors };
+}
+
+/**
+ * disk 영역 픽셀 통계 — mesh 화면 bbox 안의 천체 픽셀만 분석.
+ * stddev/entropy/uniqueColors 가 모두 ≈0 이면 단색, ↑ 이면 절차 디테일.
+ */
+async function measureDisk(page, bodyId, captureName) {
+  const canvas = page.locator('canvas').first();
+  const buf = await canvas.screenshot();
+  if (CAPTURE_DIR && captureName) {
+    await mkdir(CAPTURE_DIR, { recursive: true });
+    await writeFile(path.join(CAPTURE_DIR, `${captureName}.png`), buf);
+  }
+  const b64 = buf.toString('base64');
+  return page.evaluate(
+    async ({ b64, bodyId }) => {
+      const core = window.__simCore;
+      const solar = window.__solarScene;
+      const scene = core?.scene;
+      const mesh = solar?.meshes?.get(bodyId);
+      if (!scene || !mesh) return { error: `mesh/scene 부재 (${bodyId})` };
+
+      const BABYLON = window.BABYLON;
+      const engine = scene.getEngine();
+      const rw = engine.getRenderWidth();
+      const rh = engine.getRenderHeight();
+      const cam = scene.activeCamera;
+      const vp = cam.viewport.toGlobal(rw, rh);
+      const transform = scene.getTransformMatrix();
+
+      const bb = mesh.getBoundingInfo().boundingBox;
+      const corners = bb.vectorsWorld;
+      const Vector3 = (BABYLON && BABYLON.Vector3) || corners[0].constructor;
+      // BABYLON 전역 미노출 — Matrix 클래스는 mesh.getWorldMatrix() 의 constructor 에서 획득.
+      // vectorsWorld 는 이미 월드 좌표이므로 Project 의 world 인자는 Identity 사용.
+      const Matrix = (BABYLON && BABYLON.Matrix) || mesh.getWorldMatrix().constructor;
+      const idMat = Matrix.Identity();
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
+      for (const c of corners) {
+        const p = Vector3.Project(c, idMat, transform, vp);
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+      const screenBox = {
+        x: Math.max(0, Math.floor(minX)),
+        y: Math.max(0, Math.floor(minY)),
+        w: Math.min(rw, Math.ceil(maxX)) - Math.max(0, Math.floor(minX)),
+        h: Math.min(rh, Math.ceil(maxY)) - Math.max(0, Math.floor(minY)),
+      };
+
+      const img = new Image();
+      await new Promise((res, rej) => {
+        img.onload = res;
+        img.onerror = rej;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+      const off = document.createElement('canvas');
+      off.width = img.width;
+      off.height = img.height;
+      const ctx = off.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+
+      const sx = img.width / rw;
+      const sy = img.height / rh;
+      const bx = Math.max(0, Math.round(screenBox.x * sx));
+      const by = Math.max(0, Math.round(screenBox.y * sy));
+      const bw = Math.min(img.width - bx, Math.max(1, Math.round(screenBox.w * sx)));
+      const bh = Math.min(img.height - by, Math.max(1, Math.round(screenBox.h * sy)));
+      if (bw < 2 || bh < 2) return { error: `disk bbox 너무 작음 ${bw}x${bh}`, screenBox };
+      const data = ctx.getImageData(bx, by, bw, bh).data;
+
+      // luminance 2D 그리드 — 천체 disk 픽셀만 (배경 검정 마스크).
+      const lumGrid = new Float32Array(bw * bh);
+      const mask = new Uint8Array(bw * bh);
+      const lums = [];
+      const colorSet = new Set();
+      for (let i = 0; i < bw * bh; i++) {
+        const r = data[i * 4];
+        const g = data[i * 4 + 1];
+        const b = data[i * 4 + 2];
+        const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+        lumGrid[i] = lum;
+        if (lum < 8) continue; // 우주 배경 배제
+        mask[i] = 1;
+        lums.push(lum);
+        colorSet.add(((r >> 4) << 8) | ((g >> 4) << 4) | (b >> 4));
+      }
+      const n = lums.length;
+      if (n === 0) return { error: 'disk 영역 천체 픽셀 0', screenBox };
+      const mean = lums.reduce((a, b) => a + b, 0) / n;
+      const variance = lums.reduce((a, b) => a + (b - mean) * (b - mean), 0) / n;
+      const stddev = Math.sqrt(variance);
+
+      // ⚠️ 측정 방법 검증 (CRITICAL #6.10): 전역 stddev 는 구체 라이팅 그라데이션(저주파)
+      // 때문에 단색 disk 에서도 크게 나와 "디테일 유무" 를 구분 못 한다.
+      // → 라플라시안 고주파 에너지(인접 4-이웃 차분) 로 저주파 라이팅을 제거하고
+      //   절차 표면 변조(고주파)만 정량화한다. 단색 disk ≈ 0, 디테일 disk ↑.
+      let hfSum = 0;
+      let hfCount = 0;
+      for (let y = 1; y < bh - 1; y++) {
+        for (let x = 1; x < bw - 1; x++) {
+          const i = y * bw + x;
+          // disk 내부 픽셀만 (경계/배경 차분 제외 — disk edge 의 큰 차분이 신호 오염).
+          if (!mask[i] || !mask[i - 1] || !mask[i + 1] || !mask[i - bw] || !mask[i + bw]) continue;
+          const lap =
+            4 * lumGrid[i] - lumGrid[i - 1] - lumGrid[i + 1] - lumGrid[i - bw] - lumGrid[i + bw];
+          hfSum += lap * lap;
+          hfCount++;
+        }
+      }
+      const hfEnergy = hfCount > 0 ? Math.sqrt(hfSum / hfCount) : 0; // 고주파 RMS
+
+      // 디테일 히스토그램 엔트로피도 고주파 차분 기준으로 (저주파 영향 제거).
+      const hfHist = new Array(32).fill(0);
+      let hfHistN = 0;
+      for (let y = 1; y < bh - 1; y++) {
+        for (let x = 1; x < bw - 1; x++) {
+          const i = y * bw + x;
+          if (!mask[i] || !mask[i - 1] || !mask[i + 1] || !mask[i - bw] || !mask[i + bw]) continue;
+          const lap =
+            4 * lumGrid[i] - lumGrid[i - 1] - lumGrid[i + 1] - lumGrid[i - bw] - lumGrid[i + bw];
+          hfHist[Math.min(31, Math.floor(Math.abs(lap)))]++;
+          hfHistN++;
+        }
+      }
+      let hfEntropy = 0;
+      for (const c of hfHist) {
+        if (c === 0) continue;
+        const p = c / hfHistN;
+        hfEntropy -= p * Math.log2(p);
+      }
+
+      return {
+        area: n,
+        stddev: Number(stddev.toFixed(3)), // 전역 (라이팅 포함 — 참고용)
+        hfEnergy: Number(hfEnergy.toFixed(4)), // ★ 고주파 RMS = 절차 디테일 지표
+        hfEntropy: Number(hfEntropy.toFixed(3)),
+        uniqueColors: colorSet.size,
+        meanLum: Number(mean.toFixed(1)),
+        screenBox,
+        imgSize: { w: img.width, h: img.height },
+      };
+    },
+    { b64, bodyId },
+  );
+}
+
+async function getLodStats(page) {
+  return page.evaluate(() => {
+    const s = window.__solarScene;
+    return { stats: s?.getLodStats?.() ?? null, infoCount: s?.getLodInfo?.()?.length ?? null };
+  });
+}
+
+async function launch() {
+  if (SWIFTSHADER) {
+    console.log('[browser] headless chromium + --use-angle=swiftshader (CI 재현 — #759)');
+    return chromium.launch({ headless: true, args: ['--use-angle=swiftshader'] });
+  }
+  const opts = HEADFUL ? { headless: false, channel: 'chrome' } : { headless: true };
+  try {
+    const b = await chromium.launch(opts);
+    console.log(
+      `[browser] ${HEADFUL ? '실 Chrome GUI (headless:false, channel:chrome)' : 'headless chromium'}`,
+    );
+    return b;
+  } catch (e) {
+    console.error(
+      `[launch] chrome channel 부재 (${e.message}) — chromium 폴백 (headless:${!HEADFUL})`,
+    );
+    return chromium.launch({ headless: !HEADFUL });
+  }
+}
+
+(async () => {
+  const browser = await launch();
+  const out = {
+    surfaceOn: {},
+    surfaceOff: {},
+    plain: {},
+    lodMid: {},
+    tierC: {},
+    consoleErrors: {},
+  };
+  try {
+    console.log('\n=== DoD 1 — 4 body 표면 디테일 (surface ON, 기본) ===');
+    for (const { id, type } of SURFACE_BODIES) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto`,
+      );
+      const m = await measureDisk(page, id, `surface-on-${id}`);
+      out.surfaceOn[id] = { type, ...m };
+      out.consoleErrors[`on-${id}`] = consoleErrors.length;
+      console.log(
+        `  ${id.padEnd(8)} [${type}] hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} stddev=${m.stddev} uniqColors=${m.uniqueColors} area=${m.area} err=${consoleErrors.length}`,
+      );
+      if (consoleErrors.length)
+        console.log(`     ↳ console errors: ${JSON.stringify(consoleErrors.slice(0, 3))}`);
+      await context.close();
+    }
+
+    console.log('\n=== DoD 5 — ?surface=off 단색 복귀 대조 ===');
+    for (const { id, type } of SURFACE_BODIES) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto&surface=off`,
+      );
+      const m = await measureDisk(page, id, `surface-off-${id}`);
+      out.surfaceOff[id] = { type, ...m };
+      out.consoleErrors[`off-${id}`] = consoleErrors.length;
+      console.log(
+        `  ${id.padEnd(8)} [${type}] hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} stddev=${m.stddev} uniqColors=${m.uniqueColors} area=${m.area} err=${consoleErrors.length}`,
+      );
+      await context.close();
+    }
+
+    console.log('\n=== DoD 2 — 무회귀 (미등록 body 단색, surface ON) ===');
+    for (const { id } of PLAIN_BODIES) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto`,
+      );
+      const m = await measureDisk(page, id, `plain-${id}`);
+      out.plain[id] = m;
+      console.log(
+        `  ${id.padEnd(8)} hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} stddev=${m.stddev} uniqColors=${m.uniqueColors} area=${m.area} err=${consoleErrors.length}`,
+      );
+      await context.close();
+    }
+
+    console.log('\n=== DoD 3 — LOD mid 전환 표면 연속성 (reviewer 권고 1: cross-fade 팝핑) ===');
+    {
+      const { context, page } = await setupPage(browser, `?gpu=a&focus=earth&lod=auto`);
+      const high = await measureDisk(page, 'earth', 'lod-earth-high');
+      await page.evaluate(() => window.__solarScene?.setLodOverride?.('mid'));
+      await page.waitForTimeout(100); // fade 중간 프레임 (200ms 윈도우)
+      const midFade = await measureDisk(page, 'earth', 'lod-earth-mid-fade100');
+      await page.waitForTimeout(400); // fade 정착
+      const midSettled = await measureDisk(page, 'earth', 'lod-earth-mid-settled');
+      out.lodMid = { high, midFade, midSettled };
+      console.log(
+        `  earth high   : hfEnergy=${high.hfEnergy} hfEntropy=${high.hfEntropy} area=${high.area}`,
+      );
+      console.log(
+        `  earth midFade: hfEnergy=${midFade.hfEnergy} hfEntropy=${midFade.hfEntropy} area=${midFade.area}`,
+      );
+      console.log(
+        `  earth midSet : hfEnergy=${midSettled.hfEnergy} hfEntropy=${midSettled.hfEntropy} area=${midSettled.area}`,
+      );
+      await context.close();
+    }
+
+    console.log('\n=== DoD 4 — tier-c (?gpu=c) 단색 ===');
+    {
+      // #759 판정 신설 시 발견한 기존 시나리오 결함 정정 (2건, 실측):
+      //  (1) `?lod=auto` 를 붙이면 URL `?lod=` 우선 정책 (sim-canvas.tsx #677) 이 tier-c
+      //      `forceOverride:'low'` 를 건너뛰어 표면 셰이더가 그대로 진입 (lodStats high=2,
+      //      hfEntropy 1.399 ≈ ON) → lod 파라미터 제거.
+      //  (2) `focus=earth` 시 #546 satellite visibility guard 가 moon 을 low→mid 승격 (override
+      //      이후 후처리 — 문서화된 설계) → mid=1 로 전수 low 판정 불가 → default view (no focus,
+      //      가드 비활성 Q2=(a)) 에서 forceOverride 배선을 검증.
+      const { context, page } = await setupPage(browser, `?gpu=c`);
+      const lod = await getLodStats(page);
+      const m = await measureDisk(page, 'earth', 'tierc-earth');
+      out.tierC = { ...m, lod };
+      console.log(
+        `  earth tier-c : hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} area=${m.area} lodStats=${JSON.stringify(lod.stats)}`,
+      );
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+  console.log('\n=== JSON ===');
+  console.log(JSON.stringify(out, null, 2));
+
+  // ── 판정 (#759 — ADR 20260705-759 결정 3: per-body 상대 성질, fail-fast) ──────
+  // hfEntropy 축 사용 (hfEnergy 아님): OFF 단색 disk 의 경계 antialiasing 이 hfEnergy(RMS) 를
+  // 오염시키는 함정 (#774 실측 — sun OFF 30.2 > ON 18.1 역전). 엔트로피는 "대부분 0 + 경계
+  // 소수 대형" (OFF) 과 "전면 미세 변조" (ON) 를 정확히 구분 (측정 방법 검증 — CRITICAL #6.10).
+  const failures = [];
+  for (const { id } of SURFACE_BODIES) {
+    const on = out.surfaceOn[id];
+    const off = out.surfaceOff[id];
+    if (!on || on.error) {
+      failures.push(`${id}: surface ON 측정 실패 (${on?.error ?? 'no data'})`);
+    } else if (!off || off.error) {
+      failures.push(`${id}: surface OFF 측정 실패 (${off?.error ?? 'no data'})`);
+    } else if (!(on.hfEntropy - off.hfEntropy >= HF_ENTROPY_MARGIN)) {
+      failures.push(
+        `${id}: hfEntropy ON(${on.hfEntropy}) − OFF(${off.hfEntropy}) = ${(on.hfEntropy - off.hfEntropy).toFixed(3)} < 마진 ${HF_ENTROPY_MARGIN}`,
+      );
+    }
+  }
+  // DoD 4 — tier-c 저디테일: 픽셀 엔트로피가 아닌 **lodStats 배선 검증** (measurement-first 전환).
+  // 픽셀 축은 (1) 기존 시나리오의 `lod=auto` 가 forceOverride 를 무효화한 결함 + (2) billboard
+  // 축소 후 bbox 대부분이 배경 (로컬은 starfield 별 오염, CI 는 검정 — 환경 의존 비결정) 이라
+  // false-fail 을 만든다. `override==='low' && high===0 && mid===0` 이면 표면 셰이더는
+  // high/mid variant 에만 붙으므로 (#756 §결정 3) 구조적으로 미진입 — 결정적·백엔드 무관.
+  const tcStats = out.tierC?.lod?.stats;
+  if (!tcStats) {
+    failures.push('tier-c: lodStats 미노출 (__solarScene.getLodStats 부재)');
+  } else if (!(tcStats.override === 'low' && tcStats.high === 0 && tcStats.mid === 0)) {
+    failures.push(
+      `tier-c: forceOverride 미적용 (override=${tcStats.override}, high=${tcStats.high}, mid=${tcStats.mid}) — 표면 셰이더 진입 가능 상태`,
+    );
+  }
+
+  console.log(
+    '\n=== 판정 (#759 — hfEntropy ON−OFF ≥ ' +
+      HF_ENTROPY_MARGIN +
+      ' + tier-c forceOverride=low) ===',
+  );
+  if (failures.length) {
+    for (const f of failures) console.log(`  ✗ ${f}`);
+    console.log('=== FAIL ===');
+    process.exitCode = 1;
+  } else {
+    for (const { id } of SURFACE_BODIES) {
+      const gap = (out.surfaceOn[id].hfEntropy - out.surfaceOff[id].hfEntropy).toFixed(3);
+      console.log(`  ✓ ${id}: hfEntropy 갭 ${gap} ≥ ${HF_ENTROPY_MARGIN}`);
+    }
+    console.log(
+      `  ✓ tier-c: override=${tcStats.override}, high=${tcStats.high}, mid=${tcStats.mid} (표면 셰이더 구조적 미진입)`,
+    );
+    console.log('=== PASS ===');
+  }
+})();

--- a/apps/web/scripts/browser-verify-762-monotonic.mjs
+++ b/apps/web/scripts/browser-verify-762-monotonic.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * #762 — 천체 표시 크기 비율 단조성 회복 qa 검증 (실 Chrome GUI, NDC px diameter 측정).
+ *
+ * 사용자 보고 시나리오: 카메라를 광역(줌아웃)으로 빼거나 거성 focus 후 안쪽으로 회전해
+ * 거성 + 안쪽 행성이 co-visible 일 때 earth/mars 가 jupiter 보다 크게 보이던 역전.
+ * 새 정책(sqrt 압축 곡선)으로 단조성(목성 > 지구·화성) 회복을 runtime px 로 확증.
+ *
+ * 측정 방법 (#728 SSoT — WebGPU readback 금지, NDC projection 기반 px diameter):
+ *  - mesh.getBoundingInfo().boundingSphere.radiusWorld → NDC 투영으로 화면 px diameter 환산
+ *  - billboard variant (bodyScale 미적용) 가 아닌 high/sphere variant 측정 (focus 거리에서 sphere 활성)
+ *
+ * 시나리오:
+ *  S1. default-solar    (radius 35)        — 기본 진입 시점 co-visible 천체 px
+ *  S2. wide-solar       (radius 동적 줌아웃) — 거성까지 co-visible 광역 시점 (역전 해소 핵심)
+ *  S3. focus-jupiter-zoomout — jupiter focus 후 줌아웃해 안쪽 행성 co-visible
+ *
+ * 각 시나리오에서 onScreen=true 인 행성만 추려 px diameter 단조성(목성 ≥ 지구·화성) 검증.
+ *
+ * 실 GUI: headless=false (swiftshader freeze / WebGPU readback false-positive 회피 — #663/#728).
+ */
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const OUT_DIR = path.join(__dirname, '..', '..', '..', 'docs', 'reports', '762-monotonic');
+const args = process.argv.slice(2);
+const HEADED = !args.includes('--headless');
+
+const VIEWPORT = { width: 1280, height: 720 };
+const PLANETS = ['mercury', 'venus', 'earth', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune'];
+const POST_WAIT_MS = 2600;
+
+/** scene 내 모든 행성의 NDC px diameter 측정 + 카메라 radius 동적 조작. */
+async function measureBodies(page, { camRadius } = {}) {
+  return await page.evaluate(
+    ({ ids, camRadius, vw, vh }) => {
+      const solar = window.__solarScene;
+      if (!solar) return { error: '__solarScene 미노출 (dev 빌드 필요)' };
+      const meshes = solar.meshes;
+      const anyMesh = meshes.values().next().value;
+      if (!anyMesh) return { error: 'mesh 없음' };
+      const scene = anyMesh.getScene();
+      const camera = scene.activeCamera;
+      if (!camera) return { error: 'activeCamera null' };
+
+      // 줌아웃: camera.radius 직접 조작 (사용자 휠 줌아웃 재현). null 이면 현 상태.
+      if (typeof camRadius === 'number') {
+        camera.radius = camRadius;
+      }
+      scene.render(); // 카메라 변경 즉시 반영
+      camera.getViewMatrix(true);
+      const transform = camera.getTransformationMatrix();
+      const BABYLON = window.BABYLON || (anyMesh.constructor && anyMesh.getScene().constructor);
+
+      const out = {};
+      for (const id of ids) {
+        const mesh = meshes.get(id);
+        if (!mesh) {
+          out[id] = { present: false };
+          continue;
+        }
+        mesh.computeWorldMatrix(true);
+        const bi = mesh.getBoundingInfo();
+        const rWorld = bi.boundingSphere.radiusWorld;
+        const center = mesh.absolutePosition;
+
+        // NDC 투영 — Vector3.Project 동등 수동 계산.
+        const Vector3 = anyMesh.position.constructor;
+        const ndc = Vector3.Project
+          ? Vector3.Project(
+              center,
+              window.BABYLON
+                ? window.BABYLON.Matrix.Identity()
+                : (mesh.getWorldMatrix().clone().reset?.() ?? mesh.getWorldMatrix()),
+              transform,
+              { x: 0, y: 0, width: vw, height: vh },
+            )
+          : null;
+
+        // Project 가 world transform 을 기대하므로 identity 로 center 가 이미 world 좌표.
+        // 안전 경로: 직접 행렬 변환.
+        let pxDiameter = null;
+        let onScreen = false;
+        let behindCamera = false;
+        // 두 화면점(center ± radius·camRight) 투영 차이로 px diameter 산출 (회전 무관).
+        const camRight = camera.getDirection
+          ? camera.getDirection(new Vector3(1, 0, 0))
+          : new Vector3(1, 0, 0);
+        const pA = center.add(camRight.scale(rWorld));
+        const pB = center.subtract(camRight.scale(rWorld));
+        const Matrix = transform.constructor;
+        const identity = Matrix.Identity();
+        const projA = Vector3.Project(pA, identity, transform, {
+          x: 0,
+          y: 0,
+          width: vw,
+          height: vh,
+        });
+        const projB = Vector3.Project(pB, identity, transform, {
+          x: 0,
+          y: 0,
+          width: vw,
+          height: vh,
+        });
+        const projC = Vector3.Project(center, identity, transform, {
+          x: 0,
+          y: 0,
+          width: vw,
+          height: vh,
+        });
+        // behind camera 판정: view space z
+        const viewPos = Vector3.TransformCoordinates(center, camera.getViewMatrix());
+        behindCamera = viewPos.z < 0; // RH/LH 차이 가능 — onScreen 으로 보강
+        const dx = projA.x - projB.x;
+        const dy = projA.y - projB.y;
+        pxDiameter = Math.sqrt(dx * dx + dy * dy);
+        onScreen =
+          projC.x >= 0 &&
+          projC.x <= vw &&
+          projC.y >= 0 &&
+          projC.y <= vh &&
+          projC.z >= 0 &&
+          projC.z <= 1;
+
+        out[id] = {
+          present: true,
+          radiusWorld: rWorld,
+          pxDiameter: Math.round(pxDiameter * 1000) / 1000,
+          centerPx: { x: Math.round(projC.x), y: Math.round(projC.y) },
+          ndcZ: Math.round(projC.z * 10000) / 10000,
+          onScreen,
+        };
+      }
+      return {
+        tier: solar.getTier ? solar.getTier() : 'unknown',
+        camRadius: camera.radius,
+        bodies: out,
+      };
+    },
+    { ids: PLANETS, camRadius, vw: VIEWPORT.width, vh: VIEWPORT.height },
+  );
+}
+
+async function setup(browser, url) {
+  const context = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  const page = await context.newPage();
+  page.on('console', (m) => {
+    if (m.type() === 'error') console.log(`    [console.error] ${m.text()}`);
+  });
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 });
+  await page.waitForFunction(
+    () => typeof window.__solarScene !== 'undefined' && typeof window.__simCore !== 'undefined',
+    { timeout: 20_000 },
+  );
+  await page.waitForTimeout(POST_WAIT_MS);
+  return { context, page };
+}
+
+/** onScreen 행성들의 px diameter 단조성 평가 (jupiter ≥ earth, jupiter ≥ mars 핵심). */
+function evalMonotonic(measurement, label) {
+  const b = measurement.bodies;
+  const visible = PLANETS.filter((id) => b[id]?.present && b[id]?.onScreen);
+  const px = (id) => b[id]?.pxDiameter ?? null;
+  const checks = [];
+
+  // 핵심: jupiter 가 화면에 있고 earth/mars 도 있을 때 jupiter > earth, jupiter > mars
+  const jup = px('jupiter');
+  for (const small of ['earth', 'mars', 'venus', 'mercury']) {
+    if (b.jupiter?.onScreen && b[small]?.onScreen) {
+      const s = px(small);
+      const pass = jup > s;
+      checks.push({
+        rule: `jupiter > ${small}`,
+        jupiter: jup,
+        [small]: s,
+        pass,
+      });
+    }
+  }
+  // saturn > earth/mars 도 (co-visible 시)
+  const sat = px('saturn');
+  for (const small of ['earth', 'mars']) {
+    if (b.saturn?.onScreen && b[small]?.onScreen) {
+      const s = px(small);
+      checks.push({ rule: `saturn > ${small}`, saturn: sat, [small]: s, pass: sat > s });
+    }
+  }
+
+  return { label, visible, checks, allPass: checks.every((c) => c.pass) };
+}
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: !HEADED });
+  const results = [];
+  try {
+    // S1 default solar (radius 35)
+    {
+      const { context, page } = await setup(browser, `${BASE_URL}/?gpu=a&lod=auto`);
+      const m = await measureBodies(page);
+      await page.screenshot({ path: path.join(OUT_DIR, 'qa-762-S1-default-solar.png') });
+      const ev = evalMonotonic(m, 'S1-default-solar');
+      results.push({ scenario: 'S1-default-solar', measurement: m, eval: ev });
+      console.log(`\n[S1 default-solar] tier=${m.tier} camR=${m.camRadius?.toFixed(1)}`);
+      console.log('  visible planets:', ev.visible.join(', '));
+      for (const id of PLANETS) {
+        const x = m.bodies[id];
+        if (x?.present)
+          console.log(
+            `    ${id.padEnd(8)} px=${String(x.pxDiameter).padStart(8)} onScreen=${x.onScreen} center=(${x.centerPx.x},${x.centerPx.y})`,
+          );
+      }
+      await context.close();
+    }
+
+    // S2 wide solar — 줌아웃해 거성 co-visible (radius 450 으로 광역)
+    for (const camRadius of [120, 450]) {
+      const { context, page } = await setup(browser, `${BASE_URL}/?gpu=a&lod=auto`);
+      const m = await measureBodies(page, { camRadius });
+      await page.waitForTimeout(600);
+      const m2 = await measureBodies(page, { camRadius }); // 재측정 안정화
+      await page.screenshot({ path: path.join(OUT_DIR, `qa-762-S2-wide-r${camRadius}.png`) });
+      const ev = evalMonotonic(m2, `S2-wide-r${camRadius}`);
+      results.push({ scenario: `S2-wide-r${camRadius}`, measurement: m2, eval: ev });
+      console.log(
+        `\n[S2 wide-solar r=${camRadius}] tier=${m2.tier} camR=${m2.camRadius?.toFixed(1)}`,
+      );
+      console.log('  visible planets:', ev.visible.join(', '));
+      for (const id of PLANETS) {
+        const x = m2.bodies[id];
+        if (x?.present)
+          console.log(
+            `    ${id.padEnd(8)} px=${String(x.pxDiameter).padStart(8)} onScreen=${x.onScreen} center=(${x.centerPx.x},${x.centerPx.y})`,
+          );
+      }
+      console.log('  monotonic checks:');
+      for (const c of ev.checks)
+        console.log(`    ${c.rule}: ${c.pass ? 'PASS' : 'FAIL'}  (${JSON.stringify(c)})`);
+      await context.close();
+    }
+
+    // S3 focus jupiter 후 줌아웃해 안쪽 행성 co-visible
+    {
+      const { context, page } = await setup(browser, `${BASE_URL}/?gpu=a&focus=jupiter&lod=auto`);
+      // jupiter focus 상태에서 줌아웃 (radius 크게)
+      const m = await measureBodies(page, { camRadius: 400 });
+      await page.waitForTimeout(600);
+      const m2 = await measureBodies(page, { camRadius: 400 });
+      await page.screenshot({ path: path.join(OUT_DIR, 'qa-762-S3-focus-jupiter-zoomout.png') });
+      const ev = evalMonotonic(m2, 'S3-focus-jupiter-zoomout');
+      results.push({ scenario: 'S3-focus-jupiter-zoomout', measurement: m2, eval: ev });
+      console.log(`\n[S3 focus-jupiter-zoomout] tier=${m2.tier} camR=${m2.camRadius?.toFixed(1)}`);
+      console.log('  visible planets:', ev.visible.join(', '));
+      for (const id of PLANETS) {
+        const x = m2.bodies[id];
+        if (x?.present)
+          console.log(
+            `    ${id.padEnd(8)} px=${String(x.pxDiameter).padStart(8)} onScreen=${x.onScreen} center=(${x.centerPx.x},${x.centerPx.y})`,
+          );
+      }
+      console.log('  monotonic checks:');
+      for (const c of ev.checks)
+        console.log(`    ${c.rule}: ${c.pass ? 'PASS' : 'FAIL'}  (${JSON.stringify(c)})`);
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const outPath = path.join(OUT_DIR, 'qa-762-monotonic-result.json');
+  fs.writeFileSync(outPath, JSON.stringify(results, null, 2));
+  console.log(`\n결과 JSON: ${outPath}`);
+
+  // 종합 판정: co-visible 시점(jupiter+earth/mars 동시 onScreen)이 1개 이상 + 그 시점 단조성 PASS
+  const covisScenarios = results.filter((r) => r.eval.checks.length > 0);
+  const anyCovis = covisScenarios.length > 0;
+  const allCovisPass = covisScenarios.every((r) => r.eval.allPass);
+  console.log('\n=== 종합 ===');
+  console.log(`  co-visible 시나리오 수: ${covisScenarios.length}`);
+  console.log(`  단조성 PASS: ${allCovisPass}`);
+  process.exit(anyCovis && allCovisPass ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(2);
+});

--- a/apps/web/scripts/browser-verify-773-light.mjs
+++ b/apps/web/scripts/browser-verify-773-light.mjs
@@ -134,11 +134,7 @@ async function measureLight(page, bodyId, captureName) {
       }
       if (!sunPos) return { error: 'sunLight 부재' };
       const sunWorldDir = sunPos.subtract(meshPos); // 태양 방향 (월드).
-      // 태양 방향 끝점을 화면 투영해 화면 평면 sunDir 추출.
-      const sunFar = meshPos.add(
-        sunWorldDir.scale(1e-3 * (1 / Math.max(sunWorldDir.length(), 1e-9)) + 0),
-      );
-      // 위 스케일은 불안정 → 정규화 후 mesh 반경 비례 길이로 끝점 생성.
+      // 태양 방향 끝점을 화면 투영해 화면 평면 sunDir 추출 (정규화 후 mesh 반경 비례 길이).
       const sunDirN = sunWorldDir.normalize();
       const meshRadius = bb.maximum.subtract(bb.minimum).length() * 0.5 || 1;
       const tip = meshPos.add(sunDirN.scale(meshRadius * 4));

--- a/apps/web/scripts/browser-verify-773-light.mjs
+++ b/apps/web/scripts/browser-verify-773-light.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+/**
+ * #773/#775 — 표면 셰이더 광원 일관성 + 지구 대륙 mix qa 동적 검증 (Amendment 1).
+ *
+ * 실 Chrome GUI (headless: false, channel: chrome) — WebGPU swiftshader freeze 회피 (#663/#756).
+ * 픽셀 측정 = composited canvas.screenshot() (PNG) → 페이지 내 Image 디코드 → 2D getImageData.
+ *   ⚠️ WebGPU drawImage readback 빈버퍼 함정 회피 (#728 SSoT) — page.evaluate 내 2D canvas 경로만.
+ *
+ * 측정 축 (ADR §A1.5 DoD):
+ *  - DoD 1: 밤면/낮면 휘도 대비비 (day/night contrast ratio) ≥ 5x — 표면 셰이더 행성 vs 단색 행성 대조.
+ *  - DoD 2: 태양 추종 — disk 안 밝은 절반이 sunDir(태양 방향) 쪽인지 검증 (lit-side 정합).
+ *  - DoD 4: 지구 대륙 — disk 픽셀의 색조(hue) 분포에서 land(올리브-브라운) vs ocean(청록) 2-모드 분리.
+ *  - DoD 5: 절차 무회귀 — 낮면 기준 고주파 엔트로피 ON > OFF.
+ *  - DoD 6: 보라/마젠타 0 — disk 픽셀 중 (R>G && B>G) 기괴 색역 비율.
+ *
+ * disk 영역만 샘플: scene.activeCamera 로 mesh bounding box 8 corner 화면 투영 → 그 bbox 픽셀만 분석.
+ * 낮/밤 분할: sunDir(scene-unit) 을 화면 평면에 투영 → disk 중심 기준 sun 쪽 절반 = 낮면, 반대 = 밤면.
+ *
+ * 판정 (#759 — shader-pixel-guard CI 상시 가드, ADR 20260705-759 결정 3):
+ *   4 body 각각 (1) dayMean > nightMean × 2 (2) contrastMean(ON) > contrastMean(OFF)
+ *   (3) purplePct == 0. 미충족 시 exit 1 (fail-fast).
+ *   ⚠️ hfEntropy ON>OFF 는 판정 축에서 제외 — moon day-side 실측 역전 (ON 1.402 < OFF 1.989,
+ *   disk 소면적 framing + land/ocean 소표본 artifact — ADR §실측 3). 측정·로그는 유지하되
+ *   moon 커버는 대비(contrastMean)/보라(purplePct) 축이 담당 (의식적 축소 — 가드 약화 아님).
+ *
+ * 사용법:
+ *   node apps/web/scripts/browser-verify-773-light.mjs               # 실 Chrome GUI
+ *   HEADFUL=0 node ...                                               # CI 폴백 (headless)
+ *   SWIFTSHADER=1 node ...                                           # CI(ubuntu 소프트웨어 렌더) 로컬 재현
+ *   CAPTURE_DIR=/abs/dir node ...                                    # 캡처 PNG 저장
+ */
+
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? null;
+const HEADFUL = process.env.HEADFUL !== '0';
+// #759 — CI 실패 로컬 재현 (--use-angle=swiftshader). browser-verify-756-surface.mjs 주석 참조.
+const SWIFTSHADER = process.env.SWIFTSHADER === '1';
+
+// #759 판정 상수 — 낮/밤 대비 하한 배수. 실측 최소 (swiftshader 포함 전 라운드) saturn 2.14×,
+// 표면 4 body 하드웨어 실측 3.07~5.37× (docs/reports/773-light/qa-773-comment.md) → 2× 하한 안전.
+const DAY_NIGHT_RATIO_MIN = 2;
+
+const SURFACE_BODIES = [
+  { id: 'earth', type: 'rocky' },
+  { id: 'mars', type: 'desert' },
+  { id: 'jupiter', type: 'gas-bands' },
+  { id: 'moon', type: 'cratered' },
+];
+// 단색 행성 (회귀만 확인 — terminator/밤면 대조 baseline).
+const PLAIN_BODIES = [{ id: 'venus' }, { id: 'mercury' }, { id: 'saturn' }, { id: 'neptune' }];
+
+async function setupPage(browser, query) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  const consoleWarns = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text());
+    if (m.type() === 'warning') consoleWarns.push(m.text());
+  });
+  page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
+  await page.goto(`${BASE_URL}${query}`, { waitUntil: 'networkidle', timeout: 45_000 });
+  await page.waitForFunction(
+    () => typeof window.__simCore !== 'undefined' && typeof window.__solarScene !== 'undefined',
+    { timeout: 20_000 },
+  );
+  await page.waitForTimeout(2800); // mesh 생성 + 첫 LOD pass + focus tween 정착
+  return { context, page, consoleErrors, consoleWarns };
+}
+
+/**
+ * disk 영역 픽셀 통계 — 낮/밤 분할 + 색조 분포.
+ * sunDir 을 화면 평면에 투영해 disk 중심 기준 낮면(태양 쪽) / 밤면(반대) 분할.
+ */
+async function measureLight(page, bodyId, captureName) {
+  const canvas = page.locator('canvas').first();
+  const buf = await canvas.screenshot();
+  if (CAPTURE_DIR && captureName) {
+    await mkdir(CAPTURE_DIR, { recursive: true });
+    await writeFile(path.join(CAPTURE_DIR, `${captureName}.png`), buf);
+  }
+  const b64 = buf.toString('base64');
+  return page.evaluate(
+    async ({ b64, bodyId }) => {
+      const core = window.__simCore;
+      const solar = window.__solarScene;
+      const scene = core?.scene;
+      const mesh = solar?.meshes?.get(bodyId);
+      if (!scene || !mesh) return { error: `mesh/scene 부재 (${bodyId})` };
+
+      const BABYLON = window.BABYLON;
+      const engine = scene.getEngine();
+      const rw = engine.getRenderWidth();
+      const rh = engine.getRenderHeight();
+      const cam = scene.activeCamera;
+      const vp = cam.viewport.toGlobal(rw, rh);
+      const transform = scene.getTransformMatrix();
+
+      const Vector3 = (BABYLON && BABYLON.Vector3) || mesh.getAbsolutePosition().constructor;
+      const Matrix = (BABYLON && BABYLON.Matrix) || mesh.getWorldMatrix().constructor;
+      const idMat = Matrix.Identity();
+
+      // mesh 중심 + bbox 화면 투영.
+      const meshPos = mesh.getAbsolutePosition();
+      const bb = mesh.getBoundingInfo().boundingBox;
+      const corners = bb.vectorsWorld;
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
+      for (const c of corners) {
+        const p = Vector3.Project(c, idMat, transform, vp);
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+      const centerScreen = Vector3.Project(meshPos, idMat, transform, vp);
+
+      // sunDir (scene-unit world) — sunLight.position − meshPos. PointLight 검색.
+      let sunPos = null;
+      for (const l of scene.lights) {
+        if (l.position && (l.name === 'sun-light' || l.getClassName?.() === 'PointLight')) {
+          sunPos = l.position;
+          break;
+        }
+      }
+      if (!sunPos) return { error: 'sunLight 부재' };
+      const sunWorldDir = sunPos.subtract(meshPos); // 태양 방향 (월드).
+      // 태양 방향 끝점을 화면 투영해 화면 평면 sunDir 추출.
+      const sunFar = meshPos.add(
+        sunWorldDir.scale(1e-3 * (1 / Math.max(sunWorldDir.length(), 1e-9)) + 0),
+      );
+      // 위 스케일은 불안정 → 정규화 후 mesh 반경 비례 길이로 끝점 생성.
+      const sunDirN = sunWorldDir.normalize();
+      const meshRadius = bb.maximum.subtract(bb.minimum).length() * 0.5 || 1;
+      const tip = meshPos.add(sunDirN.scale(meshRadius * 4));
+      const tipScreen = Vector3.Project(tip, idMat, transform, vp);
+      // 화면 sunDir (정규화). y 는 화면 좌표 (아래로 +).
+      let sdx = tipScreen.x - centerScreen.x;
+      let sdy = tipScreen.y - centerScreen.y;
+      const sdLen = Math.hypot(sdx, sdy) || 1;
+      sdx /= sdLen;
+      sdy /= sdLen;
+
+      const screenBox = {
+        x: Math.max(0, Math.floor(minX)),
+        y: Math.max(0, Math.floor(minY)),
+        w: Math.min(rw, Math.ceil(maxX)) - Math.max(0, Math.floor(minX)),
+        h: Math.min(rh, Math.ceil(maxY)) - Math.max(0, Math.floor(minY)),
+      };
+
+      const img = new Image();
+      await new Promise((res, rej) => {
+        img.onload = res;
+        img.onerror = rej;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+      const off = document.createElement('canvas');
+      off.width = img.width;
+      off.height = img.height;
+      const ctx = off.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+
+      const sx = img.width / rw;
+      const sy = img.height / rh;
+      const bx = Math.max(0, Math.round(screenBox.x * sx));
+      const by = Math.max(0, Math.round(screenBox.y * sy));
+      const bw = Math.min(img.width - bx, Math.max(1, Math.round(screenBox.w * sx)));
+      const bh = Math.min(img.height - by, Math.max(1, Math.round(screenBox.h * sy)));
+      if (bw < 2 || bh < 2) return { error: `disk bbox 너무 작음 ${bw}x${bh}`, screenBox };
+      const data = ctx.getImageData(bx, by, bw, bh).data;
+
+      // disk 중심 (img 좌표) = centerScreen 를 img 스케일 변환 후 bbox-상대.
+      const cxImg = centerScreen.x * sx - bx;
+      const cyImg = centerScreen.y * sy - by;
+
+      const lumGrid = new Float32Array(bw * bh);
+      const mask = new Uint8Array(bw * bh);
+      // 낮/밤 픽셀 분할: (px - cx, py - cy) · sunDir > 0 → 낮면.
+      const dayLums = [];
+      const nightLums = [];
+      let purpleCount = 0;
+      let diskCount = 0;
+      // 색조 분류 (지구 대륙) — land(올리브브라운 R≳G>B) vs ocean(청록 G≳B>R).
+      let landCount = 0;
+      let oceanCount = 0;
+
+      for (let y = 0; y < bh; y++) {
+        for (let x = 0; x < bw; x++) {
+          const i = y * bw + x;
+          const r = data[i * 4];
+          const g = data[i * 4 + 1];
+          const b = data[i * 4 + 2];
+          const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+          lumGrid[i] = lum;
+          if (lum < 8) continue; // 우주 배경 배제
+          mask[i] = 1;
+          diskCount++;
+          // 낮/밤 분할.
+          const dotSun = (x - cxImg) * sdx + (y - cyImg) * sdy;
+          if (dotSun > 0) dayLums.push(lum);
+          else nightLums.push(lum);
+          // 보라/마젠타 (R>G && B>G — 자홍/보라 색역).
+          if (r > g + 12 && b > g + 12) purpleCount++;
+          // 색조 분류 (지구) — 충분히 밝은 픽셀만 (밤면 어두운 픽셀 제외, lum>40).
+          if (lum > 40) {
+            if (r >= g - 4 && g > b + 6)
+              landCount++; // R≳G, G>B → 갈색/올리브 (land)
+            else if (g >= r + 6 && b >= r - 4) oceanCount++; // G,B > R → 청록 (ocean)
+          }
+        }
+      }
+
+      const stat = (arr) => {
+        if (arr.length === 0) return { n: 0, mean: 0, p90: 0, p10: 0 };
+        const s = [...arr].sort((a, b) => a - b);
+        const mean = s.reduce((a, b) => a + b, 0) / s.length;
+        return {
+          n: s.length,
+          mean: Number(mean.toFixed(1)),
+          p90: Number(s[Math.floor(s.length * 0.9)].toFixed(1)),
+          p10: Number(s[Math.floor(s.length * 0.1)].toFixed(1)),
+        };
+      };
+      const day = stat(dayLums);
+      const night = stat(nightLums);
+      // 대비비 = 낮면 mean / 밤면 mean (밤면 0 방지 +1).
+      const contrastMean =
+        night.mean > 0 ? Number((day.mean / Math.max(night.mean, 0.5)).toFixed(2)) : Infinity;
+      // p90(낮면 밝은 부분) / p10(밤면 어두운 부분) — terminator 양극 대비.
+      const contrastExtreme = Number((day.p90 / Math.max(night.p10, 0.5)).toFixed(2));
+
+      // 고주파 엔트로피 (낮면 기준 — 절차 무회귀, #756 패턴).
+      let hfSum = 0;
+      let hfCount = 0;
+      const hfHist = new Array(32).fill(0);
+      let hfHistN = 0;
+      for (let y = 1; y < bh - 1; y++) {
+        for (let x = 1; x < bw - 1; x++) {
+          const i = y * bw + x;
+          if (!mask[i] || !mask[i - 1] || !mask[i + 1] || !mask[i - bw] || !mask[i + bw]) continue;
+          // 낮면만 (절차 디테일은 낮면에서 측정).
+          const dotSun = (x - cxImg) * sdx + (y - cyImg) * sdy;
+          if (dotSun <= 0) continue;
+          const lap =
+            4 * lumGrid[i] - lumGrid[i - 1] - lumGrid[i + 1] - lumGrid[i - bw] - lumGrid[i + bw];
+          hfSum += lap * lap;
+          hfCount++;
+          hfHist[Math.min(31, Math.floor(Math.abs(lap)))]++;
+          hfHistN++;
+        }
+      }
+      const hfEnergy = hfCount > 0 ? Number(Math.sqrt(hfSum / hfCount).toFixed(4)) : 0;
+      let hfEntropy = 0;
+      for (const c of hfHist) {
+        if (c === 0) continue;
+        const p = c / hfHistN;
+        hfEntropy -= p * Math.log2(p);
+      }
+
+      return {
+        diskArea: diskCount,
+        day,
+        night,
+        contrastMean, // ★ DoD 1 — 낮면/밤면 mean 대비비
+        contrastExtreme, // 낮면 p90 / 밤면 p10
+        hfEnergy: Number(hfEnergy.toFixed(4)),
+        hfEntropy: Number(hfEntropy.toFixed(3)),
+        purplePct: diskCount > 0 ? Number(((purpleCount / diskCount) * 100).toFixed(2)) : 0, // DoD 6
+        landCount, // DoD 4 (지구만 유의미)
+        oceanCount,
+        screenSunDir: { x: Number(sdx.toFixed(3)), y: Number(sdy.toFixed(3)) },
+        screenBox,
+      };
+    },
+    { b64, bodyId },
+  );
+}
+
+async function launch() {
+  if (SWIFTSHADER) {
+    console.log('[browser] headless chromium + --use-angle=swiftshader (CI 재현 — #759)');
+    return chromium.launch({ headless: true, args: ['--use-angle=swiftshader'] });
+  }
+  const opts = HEADFUL ? { headless: false, channel: 'chrome' } : { headless: true };
+  try {
+    const b = await chromium.launch(opts);
+    console.log(
+      `[browser] ${HEADFUL ? '실 Chrome GUI (headless:false, channel:chrome)' : 'headless chromium'}`,
+    );
+    return b;
+  } catch (e) {
+    console.error(`[launch] chrome channel 부재 (${e.message}) — chromium 폴백`);
+    return chromium.launch({ headless: !HEADFUL });
+  }
+}
+
+(async () => {
+  const browser = await launch();
+  const out = { surfaceOn: {}, surfaceOff: {}, plain: {}, consoleErrors: {}, rotWarns: {} };
+  try {
+    console.log('\n=== DoD 1+2+4+6 — 표면 셰이더 행성 (surface ON, 기본) ===');
+    for (const { id, type } of SURFACE_BODIES) {
+      const { context, page, consoleErrors, consoleWarns } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto`,
+      );
+      const m = await measureLight(page, id, `qa-773-on-${id}`);
+      out.surfaceOn[id] = { type, ...m };
+      out.consoleErrors[`on-${id}`] = consoleErrors.length;
+      out.rotWarns[`on-${id}`] = consoleWarns.filter((w) => w.includes('회전 non-zero')).length;
+      console.log(
+        `  ${id.padEnd(8)} [${type}] contrastMean=${m.contrastMean} contrastExtreme=${m.contrastExtreme} dayMean=${m.day?.mean} nightMean=${m.night?.mean} hfEnt(day)=${m.hfEntropy} purple%=${m.purplePct} land/ocean=${m.landCount}/${m.oceanCount} err=${consoleErrors.length}`,
+      );
+      if (consoleErrors.length)
+        console.log(`     ↳ errors: ${JSON.stringify(consoleErrors.slice(0, 3))}`);
+      await context.close();
+    }
+
+    console.log('\n=== 단색 행성 (baseline — terminator/대비비 기준) ===');
+    for (const { id } of PLAIN_BODIES) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto`,
+      );
+      const m = await measureLight(page, id, `qa-773-plain-${id}`);
+      out.plain[id] = m;
+      console.log(
+        `  ${id.padEnd(8)} contrastMean=${m.contrastMean} contrastExtreme=${m.contrastExtreme} dayMean=${m.day?.mean} nightMean=${m.night?.mean} purple%=${m.purplePct} err=${consoleErrors.length}`,
+      );
+      await context.close();
+    }
+
+    console.log('\n=== DoD 5 — ?surface=off 대조 (낮면 hfEntropy ON>OFF) ===');
+    for (const { id, type } of SURFACE_BODIES) {
+      const { context, page } = await setupPage(browser, `?gpu=a&focus=${id}&lod=auto&surface=off`);
+      const m = await measureLight(page, id, `qa-773-off-${id}`);
+      out.surfaceOff[id] = { type, ...m };
+      console.log(
+        `  ${id.padEnd(8)} [${type}] contrastMean=${m.contrastMean} dayMean=${m.day?.mean} nightMean=${m.night?.mean} hfEnt(day)=${m.hfEntropy} purple%=${m.purplePct}`,
+      );
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+  console.log('\n=== JSON ===');
+  console.log(JSON.stringify(out, null, 2));
+
+  // ── 판정 (#759 — ADR 20260705-759 결정 3: per-body 상대 성질, fail-fast) ──────
+  // 축: (1) dayMean > nightMean×2 — 광원 붕괴 검출 (2) contrastMean ON > OFF — 밤면 회귀
+  // (#773 원 회귀) 검출 (3) purplePct == 0 — 기괴 색역 검출. hfEntropy 는 헤더 주석 사유로 제외.
+  const failures = [];
+  for (const { id } of SURFACE_BODIES) {
+    const on = out.surfaceOn[id];
+    const off = out.surfaceOff[id];
+    if (!on || on.error) {
+      failures.push(`${id}: surface ON 측정 실패 (${on?.error ?? 'no data'})`);
+      continue;
+    }
+    if (!off || off.error) {
+      failures.push(`${id}: surface OFF 측정 실패 (${off?.error ?? 'no data'})`);
+      continue;
+    }
+    if (!(on.day.mean > on.night.mean * DAY_NIGHT_RATIO_MIN)) {
+      failures.push(
+        `${id}: dayMean(${on.day.mean}) ≤ nightMean(${on.night.mean}) × ${DAY_NIGHT_RATIO_MIN} (광원 대비 붕괴)`,
+      );
+    }
+    if (!(on.contrastMean > off.contrastMean)) {
+      failures.push(
+        `${id}: contrastMean ON(${on.contrastMean}) ≤ OFF(${off.contrastMean}) (밤면 회귀 — #773 원 증상)`,
+      );
+    }
+    if (on.purplePct !== 0) {
+      failures.push(`${id}: purplePct ${on.purplePct}% ≠ 0 (보라/마젠타 색역 오염)`);
+    }
+  }
+
+  console.log(
+    `\n=== 판정 (#759 — day>night×${DAY_NIGHT_RATIO_MIN} + contrastMean ON>OFF + purple 0, hfEntropy 축 제외) ===`,
+  );
+  if (failures.length) {
+    for (const f of failures) console.log(`  ✗ ${f}`);
+    console.log('=== FAIL ===');
+    process.exitCode = 1;
+  } else {
+    for (const { id } of SURFACE_BODIES) {
+      const on = out.surfaceOn[id];
+      const off = out.surfaceOff[id];
+      console.log(
+        `  ✓ ${id}: day ${on.day.mean}/night ${on.night.mean} (×${DAY_NIGHT_RATIO_MIN} 초과), contrastMean ON ${on.contrastMean} > OFF ${off.contrastMean}, purple ${on.purplePct}%`,
+      );
+    }
+    console.log('=== PASS ===');
+  }
+})();

--- a/apps/web/scripts/browser-verify-774-sun.mjs
+++ b/apps/web/scripts/browser-verify-774-sun.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * #774 — 태양 emissive 절차 표면 셰이더 dev 동적 검증.
+ *
+ * 실 Chrome GUI (headless: false, channel: chrome) — WebGPU swiftshader freeze 회피 (#663).
+ * 픽셀 측정 = composited canvas.screenshot() (PNG) → 페이지 내 Image 디코드 → 2D getImageData.
+ *   ⚠️ WebGPU drawImage readback 빈버퍼 함정 회피 (#728 SSoT) — page.evaluate 내 2D canvas 경로만.
+ *
+ * 측정 (ADR 20260703-774 §DoD):
+ *   DoD 1 — granulation: 태양 disk 라플라시안 고주파 에너지/엔트로피 ON > OFF.
+ *   DoD 2 — limb darkening: radial Rec.709 휘도 프로파일 단조 감소 + edge(r≈0.9R)/center < 0.85.
+ *   DoD 3 — 색온도: 가장자리 B/R 채널비 < 중심 B/R.
+ *   DoD 4 — ?surface=off 단색 복귀 (hf ≈ 0) + planet 4종 ON 무회귀.
+ *
+ * 사용법:
+ *   node apps/web/scripts/browser-verify-774-sun.mjs
+ *   HEADFUL=0 node apps/web/scripts/browser-verify-774-sun.mjs     # headless 폴백
+ *   CAPTURE_DIR=/abs/dir node ...                                  # 캡처 PNG 저장
+ */
+
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? null;
+const HEADFUL = process.env.HEADFUL !== '0';
+
+async function setupPage(browser, query) {
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text());
+  });
+  page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`));
+  await page.goto(`${BASE_URL}${query}`, { waitUntil: 'networkidle', timeout: 45_000 });
+  await page.waitForFunction(
+    () => typeof window.__simCore !== 'undefined' && typeof window.__solarScene !== 'undefined',
+    { timeout: 20_000 },
+  );
+  await page.waitForTimeout(2600); // mesh 생성 + 첫 LOD pass + focus tween 정착
+  return { context, page, consoleErrors };
+}
+
+/**
+ * disk 측정 — mesh 화면 bbox 안의 천체 픽셀 분석 (#756 measureDisk 답습) +
+ * radial 휘도/채널비 프로파일 (#774 limb darkening / 색온도 전용 확장).
+ */
+async function measureSunDisk(page, bodyId, captureName) {
+  const canvas = page.locator('canvas').first();
+  const buf = await canvas.screenshot();
+  if (CAPTURE_DIR && captureName) {
+    await mkdir(CAPTURE_DIR, { recursive: true });
+    await writeFile(path.join(CAPTURE_DIR, `${captureName}.png`), buf);
+  }
+  const b64 = buf.toString('base64');
+  return page.evaluate(
+    async ({ b64, bodyId }) => {
+      const core = window.__simCore;
+      const solar = window.__solarScene;
+      const scene = core?.scene;
+      const mesh = solar?.meshes?.get(bodyId);
+      if (!scene || !mesh) return { error: `mesh/scene 부재 (${bodyId})` };
+
+      const BABYLON = window.BABYLON;
+      const engine = scene.getEngine();
+      const rw = engine.getRenderWidth();
+      const rh = engine.getRenderHeight();
+      const cam = scene.activeCamera;
+      const vp = cam.viewport.toGlobal(rw, rh);
+      const transform = scene.getTransformMatrix();
+
+      const bb = mesh.getBoundingInfo().boundingBox;
+      const corners = bb.vectorsWorld;
+      const Vector3 = (BABYLON && BABYLON.Vector3) || corners[0].constructor;
+      const Matrix = (BABYLON && BABYLON.Matrix) || mesh.getWorldMatrix().constructor;
+      const idMat = Matrix.Identity();
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
+      for (const c of corners) {
+        const p = Vector3.Project(c, idMat, transform, vp);
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+      const screenBox = {
+        x: Math.max(0, Math.floor(minX)),
+        y: Math.max(0, Math.floor(minY)),
+        w: Math.min(rw, Math.ceil(maxX)) - Math.max(0, Math.floor(minX)),
+        h: Math.min(rh, Math.ceil(maxY)) - Math.max(0, Math.floor(minY)),
+      };
+
+      const img = new Image();
+      await new Promise((res, rej) => {
+        img.onload = res;
+        img.onerror = rej;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+      const off = document.createElement('canvas');
+      off.width = img.width;
+      off.height = img.height;
+      const ctx = off.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+
+      const sx = img.width / rw;
+      const sy = img.height / rh;
+      const bx = Math.max(0, Math.round(screenBox.x * sx));
+      const by = Math.max(0, Math.round(screenBox.y * sy));
+      const bw = Math.min(img.width - bx, Math.max(1, Math.round(screenBox.w * sx)));
+      const bh = Math.min(img.height - by, Math.max(1, Math.round(screenBox.h * sy)));
+      if (bw < 2 || bh < 2) return { error: `disk bbox 너무 작음 ${bw}x${bh}`, screenBox };
+      const data = ctx.getImageData(bx, by, bw, bh).data;
+
+      // ── #756 답습: 라플라시안 고주파 (granulation 지표) ────────────────────
+      const lumGrid = new Float32Array(bw * bh);
+      const mask = new Uint8Array(bw * bh);
+      const lums = [];
+      for (let i = 0; i < bw * bh; i++) {
+        const r = data[i * 4];
+        const g = data[i * 4 + 1];
+        const b = data[i * 4 + 2];
+        const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b; // Rec.709 (DoD 2 명시)
+        lumGrid[i] = lum;
+        if (lum < 8) continue; // 우주 배경 배제
+        mask[i] = 1;
+        lums.push(lum);
+      }
+      const n = lums.length;
+      if (n === 0) return { error: 'disk 영역 천체 픽셀 0', screenBox };
+      const mean = lums.reduce((a, b) => a + b, 0) / n;
+      const variance = lums.reduce((a, b) => a + (b - mean) * (b - mean), 0) / n;
+      const stddev = Math.sqrt(variance);
+
+      let hfSum = 0;
+      let hfCount = 0;
+      const hfHist = new Array(32).fill(0);
+      for (let y = 1; y < bh - 1; y++) {
+        for (let x = 1; x < bw - 1; x++) {
+          const i = y * bw + x;
+          if (!mask[i] || !mask[i - 1] || !mask[i + 1] || !mask[i - bw] || !mask[i + bw]) continue;
+          const lap =
+            4 * lumGrid[i] - lumGrid[i - 1] - lumGrid[i + 1] - lumGrid[i - bw] - lumGrid[i + bw];
+          hfSum += lap * lap;
+          hfCount++;
+          hfHist[Math.min(31, Math.floor(Math.abs(lap)))]++;
+        }
+      }
+      const hfEnergy = hfCount > 0 ? Math.sqrt(hfSum / hfCount) : 0;
+      let hfEntropy = 0;
+      for (const c of hfHist) {
+        if (c === 0) continue;
+        const p = c / hfCount;
+        hfEntropy -= p * Math.log2(p);
+      }
+
+      // ── #774 radial 프로파일 (limb darkening + 색온도) ──────────────────────
+      // disk 중심 = bbox 중앙 (bbox 는 disk 외접 사각형), 반경 = min(bw,bh)/2.
+      const cx = bw / 2;
+      const cy = bh / 2;
+      const R = Math.min(bw, bh) / 2;
+      const RADII = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95];
+      const ANGLES = 48;
+      const radial = [];
+      for (const rr of RADII) {
+        let sumLum = 0,
+          sumR = 0,
+          sumB = 0,
+          cnt = 0;
+        for (let a = 0; a < ANGLES; a++) {
+          const theta = (a / ANGLES) * Math.PI * 2;
+          const px = Math.round(cx + rr * R * Math.cos(theta));
+          const py = Math.round(cy + rr * R * Math.sin(theta));
+          if (px < 0 || py < 0 || px >= bw || py >= bh) continue;
+          const i = py * bw + px;
+          if (!mask[i]) continue; // disk 밖 배경 제외
+          sumLum += lumGrid[i];
+          sumR += data[i * 4];
+          sumB += data[i * 4 + 2];
+          cnt++;
+        }
+        radial.push({
+          r: rr,
+          lum: cnt ? Number((sumLum / cnt).toFixed(2)) : null,
+          bOverR: cnt && sumR > 0 ? Number((sumB / sumR).toFixed(4)) : null,
+          samples: cnt,
+        });
+      }
+
+      return {
+        area: n,
+        stddev: Number(stddev.toFixed(3)),
+        hfEnergy: Number(hfEnergy.toFixed(4)),
+        hfEntropy: Number(hfEntropy.toFixed(3)),
+        meanLum: Number(mean.toFixed(1)),
+        radial,
+        screenBox,
+      };
+    },
+    { b64, bodyId },
+  );
+}
+
+async function launch() {
+  const opts = HEADFUL ? { headless: false, channel: 'chrome' } : { headless: true };
+  try {
+    const b = await chromium.launch(opts);
+    console.log(
+      `[browser] ${HEADFUL ? '실 Chrome GUI (headless:false, channel:chrome)' : 'headless chromium'}`,
+    );
+    return b;
+  } catch (e) {
+    console.error(`[launch] chrome channel 부재 (${e.message}) — chromium 폴백`);
+    return chromium.launch({ headless: !HEADFUL });
+  }
+}
+
+/** radial 프로파일 판정 — 단조 감소(허용 오차) + edge/center 비. */
+function judgeRadial(radial) {
+  const valid = radial.filter((s) => s.lum !== null && s.samples >= 8);
+  if (valid.length < 5) return { ok: false, reason: `유효 radial 샘플 부족 (${valid.length})` };
+  const center = valid[0].lum;
+  const edge = valid.find((s) => s.r === 0.9) ?? valid[valid.length - 1];
+  // 단조 감소 (granulation 노이즈 허용 — 3 lum 이내 역전은 무시).
+  let monotonicViolations = 0;
+  for (let i = 1; i < valid.length; i++) {
+    if (valid[i].lum > valid[i - 1].lum + 3) monotonicViolations++;
+  }
+  const edgeCenterRatio = edge.lum / center;
+  const bOverRCenter = valid[0].bOverR;
+  const bOverREdge = edge.bOverR;
+  return {
+    ok: monotonicViolations === 0 && edgeCenterRatio < 0.85 && bOverREdge < bOverRCenter,
+    monotonicViolations,
+    edgeCenterRatio: Number(edgeCenterRatio.toFixed(4)),
+    bOverRCenter,
+    bOverREdge,
+    center,
+    edge: edge.lum,
+  };
+}
+
+(async () => {
+  const browser = await launch();
+  const out = { sunOn: null, sunOff: null, planets: {}, consoleErrors: {} };
+  try {
+    console.log('\n=== DoD 1·2·3 — ?focus=sun (surface ON, 기본) ===');
+    {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=sun&lod=auto`,
+      );
+      const m = await measureSunDisk(page, 'sun', 'sun-on');
+      out.sunOn = m;
+      out.consoleErrors['sun-on'] = consoleErrors;
+      const judge = m.radial ? judgeRadial(m.radial) : { ok: false, reason: m.error };
+      out.sunOn.judge = judge;
+      console.log(`  granulation: hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} area=${m.area}`);
+      console.log(`  radial lum : ${m.radial?.map((s) => s.lum).join(' ')}`);
+      console.log(`  radial B/R : ${m.radial?.map((s) => s.bOverR).join(' ')}`);
+      console.log(
+        `  limb judge : edge/center=${judge.edgeCenterRatio} (<0.85?) monoViol=${judge.monotonicViolations} B/R center=${judge.bOverRCenter} edge=${judge.bOverREdge} → ${judge.ok ? 'PASS' : 'FAIL'}`,
+      );
+      if (consoleErrors.length)
+        console.log(`  console errors: ${JSON.stringify(consoleErrors.slice(0, 3))}`);
+      await context.close();
+    }
+
+    console.log('\n=== DoD 4 — ?focus=sun&surface=off 단색 복귀 ===');
+    {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=sun&lod=auto&surface=off`,
+      );
+      const m = await measureSunDisk(page, 'sun', 'sun-off');
+      out.sunOff = m;
+      out.consoleErrors['sun-off'] = consoleErrors;
+      console.log(
+        `  hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} stddev=${m.stddev} area=${m.area}`,
+      );
+      console.log(`  radial lum : ${m.radial?.map((s) => s.lum).join(' ')}`);
+      await context.close();
+    }
+
+    console.log('\n=== DoD 4 — planet 4종 무회귀 (surface ON) ===');
+    for (const id of ['earth', 'mars', 'jupiter', 'moon']) {
+      const { context, page, consoleErrors } = await setupPage(
+        browser,
+        `?gpu=a&focus=${id}&lod=auto`,
+      );
+      const m = await measureSunDisk(page, id, `planet-${id}`);
+      out.planets[id] = { hfEnergy: m.hfEnergy, hfEntropy: m.hfEntropy, area: m.area };
+      console.log(
+        `  ${id.padEnd(8)} hfEnergy=${m.hfEnergy} hfEntropy=${m.hfEntropy} area=${m.area} err=${consoleErrors.length}`,
+      );
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log('\n=== JSON ===');
+  console.log(JSON.stringify(out, null, 2));
+
+  // 종합 판정 — granulation 지표는 hf **엔트로피** (ADR §DoD 1 명시).
+  // ⚠️ hfEnergy(RMS) 는 OFF 단색 disk 의 경계 antialiasing 급락 (232→0) 이 소수 픽셀에서
+  // 큰 라플라시안을 만들어 오염된다 (측정 방법 검증 — CRITICAL #6.10). 엔트로피는 차분 분포의
+  // 다양성이라 "대부분 0 + 경계 소수 대형" (OFF) 과 "전면 미세 변조" (ON) 를 정확히 구분.
+  const g1 = out.sunOn?.hfEntropy > (out.sunOff?.hfEntropy ?? 0); // granulation ON > OFF
+  const g2 = out.sunOn?.judge?.ok === true;
+  const pass = g1 && g2;
+  console.log(
+    `\n=== 판정: granulation 엔트로피 ON>OFF=${g1} / limb+색온도=${g2} → ${pass ? 'PASS' : 'FAIL'} ===`,
+  );
+  process.exit(pass ? 0 : 1);
+})();

--- a/apps/web/scripts/browser-verify-783-earth-detail.mjs
+++ b/apps/web/scripts/browser-verify-783-earth-detail.mjs
@@ -44,6 +44,8 @@ const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
 const CAPTURE_DIR = process.env.CAPTURE_DIR ?? null;
 const HEADFUL = process.env.HEADFUL !== '0';
 const MODE = process.env.MODE ?? 'dod';
+// #759 — CI 실패 로컬 재현 (--use-angle=swiftshader). browser-verify-756-surface.mjs 주석 참조.
+const SWIFTSHADER = process.env.SWIFTSHADER === '1';
 
 /** 결정적 프레임 고정 JD — 2000-03-22 (춘분 근방, 태양 ⊥ 패턴 극축 — 헤더 주석 3). */
 const T_JD = 2451626.0;
@@ -55,6 +57,10 @@ const MAGENTA_TAU = 15; // DoD 3 — R>G+τ && B>G+τ
 const DISK_LUM_MIN = 20;
 
 async function launch() {
+  if (SWIFTSHADER) {
+    console.log('[browser] headless chromium + --use-angle=swiftshader (CI 재현 — #759)');
+    return chromium.launch({ headless: true, args: ['--use-angle=swiftshader'] });
+  }
   const opts = HEADFUL ? { headless: false, channel: 'chrome' } : { headless: true };
   try {
     const b = await chromium.launch(opts);
@@ -266,13 +272,19 @@ async function measureEarth(page, buf) {
   );
 }
 
-/** MODE=diff — 두 캡처 dir 의 동명 PNG 픽셀 diff (Concrete Prediction: mars/jupiter/moon ≈ 0). */
+/**
+ * MODE=diff — 두 캡처 dir 의 동명 PNG 픽셀 diff (Concrete Prediction: mars/jupiter/moon ≈ 0).
+ * #759 (PR #796 reviewer 권고 4): 판정 미달 시 'CHECK' 로그만 남기고 exit 0 이던 것을
+ * fail-fast 로 정정 — 불일치/미달 발견 시 true 반환 → 호출부가 exitCode=1 설정.
+ */
 async function diffDirs(dirA, dirB, names) {
+  let anyFail = false;
   for (const name of names) {
     const a = PNG.sync.read(await readFile(path.join(dirA, `${name}.png`)));
     const b = PNG.sync.read(await readFile(path.join(dirB, `${name}.png`)));
     if (a.width !== b.width || a.height !== b.height) {
       console.log(`  ${name}: 크기 불일치 ${a.width}x${a.height} vs ${b.width}x${b.height} — FAIL`);
+      anyFail = true;
       continue;
     }
     let diffPx = 0,
@@ -288,10 +300,13 @@ async function diffDirs(dirA, dirB, names) {
     }
     const total = a.data.length / 4;
     const pct = ((diffPx / total) * 100).toFixed(4);
+    const pass = diffPx / total < 0.001;
+    if (!pass) anyFail = true;
     console.log(
-      `  ${name}: diffPx=${diffPx}/${total} (${pct}%) maxDelta=${maxDelta} → ${diffPx / total < 0.001 ? 'PASS (≈0)' : 'CHECK'}`,
+      `  ${name}: diffPx=${diffPx}/${total} (${pct}%) maxDelta=${maxDelta} → ${pass ? 'PASS (≈0)' : 'FAIL'}`,
     );
   }
+  return anyFail;
 }
 
 const OTHER_BODIES = ['mars', 'jupiter', 'moon'];
@@ -304,11 +319,12 @@ const OTHER_BODIES = ['mars', 'jupiter', 'moon'];
       process.exit(2);
     }
     console.log(`=== 분기 격리 diff (${dirA} vs ${dirB}) — Concrete Prediction ≈0 ===`);
-    await diffDirs(
+    const anyFail = await diffDirs(
       dirA,
       dirB,
       OTHER_BODIES.map((id) => `qa-783-${id}`),
     );
+    if (anyFail) process.exitCode = 1; // #759 — fail-fast (PR #796 권고 4)
     return;
   }
 

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -457,7 +457,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           starfield: starfieldVisible,
           // #756 — 절차적 행성 표면. 기본 ON 은 parseSurfaceVisible 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR 20260628-756 §결정 4 레이어 분리).
-          surfaceDetail: surfaceVisible && false, // #759 P2 negative 시뮬레이션 — 즉시 revert 예정 (머지 금지)
+          surfaceDetail: surfaceVisible,
           // #782 — 행성 self-rotation. 기본 ON 은 parseRotateEnabled 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR §A2.3 결정 7 레이어 분리, surfaceDetail 동형).
           selfRotation: rotateEnabled,

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -457,7 +457,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           starfield: starfieldVisible,
           // #756 — 절차적 행성 표면. 기본 ON 은 parseSurfaceVisible 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR 20260628-756 §결정 4 레이어 분리).
-          surfaceDetail: surfaceVisible,
+          surfaceDetail: false, // #759 P2 negative 시뮬레이션 — 즉시 revert 예정 (머지 금지)
           // #782 — 행성 self-rotation. 기본 ON 은 parseRotateEnabled 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR §A2.3 결정 7 레이어 분리, surfaceDetail 동형).
           selfRotation: rotateEnabled,

--- a/apps/web/src/components/sim-canvas.tsx
+++ b/apps/web/src/components/sim-canvas.tsx
@@ -457,7 +457,7 @@ export function SimCanvas({ children }: { children?: ReactNode }) {
           starfield: starfieldVisible,
           // #756 — 절차적 행성 표면. 기본 ON 은 parseSurfaceVisible 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR 20260628-756 §결정 4 레이어 분리).
-          surfaceDetail: false, // #759 P2 negative 시뮬레이션 — 즉시 revert 예정 (머지 금지)
+          surfaceDetail: surfaceVisible && false, // #759 P2 negative 시뮬레이션 — 즉시 revert 예정 (머지 금지)
           // #782 — 행성 self-rotation. 기본 ON 은 parseRotateEnabled 기본값 (true) 이 결정 —
           // core 옵션 기본값은 false 유지 (ADR §A2.3 결정 7 레이어 분리, surfaceDetail 동형).
           selfRotation: rotateEnabled,

--- a/docs/decisions/20260705-759-shader-verify-ci-guard.md
+++ b/docs/decisions/20260705-759-shader-verify-ci-guard.md
@@ -1,0 +1,125 @@
+# ADR 20260705-759 — 표면 셰이더 verify 6종 CI 상시 가드 (shader-pixel-guard workflow)
+
+- 상태: **Provisional** (cross-validate 발동 대상 — CLAUDE.md `## 교차검증` 박제 직후 1회 루틴. 메인 오케스트레이터가 agy cross-validate 수행 + §교차검증 반영 사항 통합 후 Accepted 전이 — #370 옵션 C)
+- 날짜: 2026-07-05
+- 이슈: [#759](https://github.com/coseo12/astro-simulator/issues/759)
+- 관련: #756 (표면 셰이더 — ADR [20260628-756](20260628-756-procedural-planet-surface.md) §결정 3 tier-c 자동 단색 / §A2 결정 7 r1-guard canvas 미측정), #762/#773/#774/#782/#783 (셰이더 feature 트랙), #779 (flake step-retry / fresh-runner escalation — ADR [20260701-779](20260701-779-ci-alert-fatigue-concurrency.md)), #728 (WebGPU readback 함정 SSoT), #626 (paths-ignore docs skip), #793 (산출물 수명주기 규약 — 합류 지점), PR #796 reviewer 권고 4 (783 diffDirs exitCode)
+- 용어: [glossary.md](../glossary.md) — tier / LOD / swiftshader / flake
+
+> **범위 주의**: 본 ADR 은 **설계 결정 박제** 다. 스크립트 정비/워크플로 `.yml` 작성은 developer 가 수행한다 (architect 는 설계 결정 + 실측 전제 검증만).
+
+---
+
+## 배경
+
+카메라/LOD 시대(#378~#737)의 verify 12종은 전부 커밋 + `detect-and-test` CI 통합인 반면, **#756 이후 셰이더 feature 의 verify 6종은 전부 로컬 전용**이다 (4종 untracked / 782·783 은 커밋만 되고 CI 미등록). r1-guard 는 `[data-r1-region]` UI 영역만 clip 캡처하고 **canvas 픽셀은 baseline 대상이 아니므로** (#756 ADR §A2 결정 7), 표면 셰이더 지대는 단위 테스트(GLSL 미러) + fps 가드만 CI 를 지킨다 — **uniform 배선 절단·분기 오염 같은 픽셀 회귀는 단위 테스트가 전부 통과한 채 조용히 퇴행**한다 (#756 이슈 원문 "scene 배선 끊김 = 조용한 퇴행").
+
+통합의 결정적 전제는 "CI swiftshader 환경에서 표면 셰이더가 렌더되는가"였다. CI 는 소프트웨어 렌더 → `detect-gpu-tier` tier-c → `forceOverride:'low'` → **표면 셰이더 자동 미진입** (#756 §결정 3) 이므로, `?gpu=a` tier 강제 플래그 (P11-C #290, `parse-gpu-tier.ts`) 없이는 CI 에서 측정 대상 자체가 렌더되지 않는다. 6종 스크립트는 이미 전부 `?gpu=a` 를 사용한다.
+
+## 실측 근거 (measurement-first, 2026-07-05 architect)
+
+### (1) swiftshader 강제 렌더 실측 — 전제 성립 확인
+
+로컬 headless chromium + `--use-angle=swiftshader` (CI 근사, `_debug-759-swiftshader-tmp.mjs` — 측정 후 rm, volt #67 규약). renderer 문자열 `ANGLE (…SwiftShader Device (LLVM 10.0.0)…)`, `__isSoftwareRenderer=true`, WebGL2 경로 (isWebGPU=false) 확인.
+
+| 케이스            | hfEnergy  | hfEntropy | 판정 호환성                                |
+| ----------------- | --------- | --------- | ------------------------------------------ |
+| earth surface ON  | 20.39     | **1.188** | ON > OFF 성질 유지 (양 지표)               |
+| earth surface OFF | 14.77     | 0.719     |                                            |
+| sun surface ON    | 18.13     | **3.501** | 엔트로피 압도적 (774 판정 = 엔트로피 기반) |
+| sun surface OFF   | **30.17** | 0.222     | ⚠ hfEnergy 는 OFF 가 더 높음 (glow edge)   |
+
+→ **swiftshader 에서 절차 셰이더 렌더 성립 + 상대 성질(ON>OFF) 판정 호환**. 단 sun 의 hfEnergy 역전이 보여주듯 **엔트로피 기반 상대 판정만 CI 안전** — hfEnergy 절대 임계는 금지.
+
+### (2) 실행 시간 실측 — 시간 예산
+
+로컬 headless (하드웨어 ANGLE Metal, dev server 기동 별도) 6종 전부 exit 0 PASS:
+
+| 스크립트      | 로컬 실측 | 스크립트         | 로컬 실측 |
+| ------------- | --------- | ---------------- | --------- |
+| 756-surface   | 67s       | 774-sun          | 27s       |
+| 762-monotonic | 20s       | 782-rotation     | 59s       |
+| 773-light     | 59s       | 783-earth-detail | 14s       |
+
+합계 **246s (4.1분)**. CI ubuntu runner (2-core, swiftshader) 보수 계수 2~3× → **8~13분** + setup (checkout/pnpm/wasm/playwright 캐시 히트 시 ~5-8분) + dev server 기동. `detect-and-test` (~18분) 에 직렬 추가하면 job 이 ~30분+ 로 늘어난다.
+
+### (3) 판정 마진 실측 — 임계 설계 근거
+
+756 하드웨어 headless 실측 hfEntropy (ON vs OFF): earth 1.329/0.914 (1.45×), mars 1.501/0.653 (2.30×), jupiter 1.799/1.184 (1.52×), **moon 2.109/1.694 (1.24× — 최소 마진)**. 773 에서 moon 의 day-side hfEntropy 는 **ON(1.402) < OFF(1.989) 역전** (moon disk 소면적 framing, land/ocean n=64/25 소표본). → 고정 배수 임계 (×1.3 등) 는 moon 에서 즉시 false-fail. **per-body 상대 성질 + dev D1 실측 확정** 이 유일하게 안전하다 ([guard-design-principles](../lessons/guard-design-principles.md) §1 measurement-first).
+
+## 후보 비교
+
+### 축 1 — CI 배치
+
+| 후보                                                          | 장점                                                                                      | 단점                                                                         | 판정     |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| (a) detect-and-test 에 step 6개 직렬 추가 (기존 패턴)         | 기존 12 가드와 동일 패턴, setup 재사용                                                    | job 18분 → ~30분+. flake 시 전체 job rerun. dev server 6회 재기동 낭비       | 기각     |
+| (b) detect-and-test 에 그룹 1 step (단일 서버)                | 서버 기동 1회                                                                             | job 길이 증가 동일. docs-only PR 에서도 실행 (#626 함정 재현)                | 기각     |
+| (c) ci.yml 내 별도 job                                        | wall-clock 병렬                                                                           | ci.yml 은 paths filter 없음 → docs-only PR 에서도 8~13분 픽셀 측정           | 기각     |
+| **(d) 별도 프로젝트-로컬 workflow (fps-baseline-guard 선례)** | **병렬 + paths-ignore (docs/md/.github 스킵) + 실패 격리 rerun + detect-and-test 무증가** | setup 구간 3번째 복제 (ci.yml r1-guard / fps-guard / 신규) — drift 관리 비용 | **채택** |
+
+### 축 2 — 판정 방식
+
+| 후보                                 | 장점                                                            | 단점                                                                              | 판정          |
+| ------------------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------- |
+| 절대 임계 (hfEntropy ≥ 1.0 등)       | 단순                                                            | swiftshader/하드웨어 값 상이 + moon 1.24× 마진 → false-fail/false-pass 양방향     | 기각          |
+| 픽셀 baseline 스냅샷 (r1-guard 확장) | 회귀 감도 최대                                                  | swiftshader↔실 GPU 픽셀 불일치로 baseline 이원화, 유지비 급증. r1-guard 책임 침범 | 기각 (비목표) |
+| **상대 성질 (per-body ON vs OFF)**   | **백엔드 값 편차에 강건 — swiftshader 실측으로 성질 보존 확인** | 감도는 baseline 대비 낮음 (성질 붕괴만 검출)                                      | **채택**      |
+
+### 축 3 — flake retry 포함 여부 (#779 Phase 2 방금 도입)
+
+| 후보                                                 | 판정     | 근거                                                                                                                                         |
+| ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 처음부터 step-retry 포함                             | 기각     | 기존 9종 중 flake 는 verify:699 (deltaTime 타이밍 의존) 유일. 셰이더 판정은 시간 비의존 성질 검증 — 선제 retry 는 진짜 회귀 흡수 위험만 추가 |
+| **fail-fast 시작, flake 실측 1회 시 #779 패턴 편입** | **채택** | measurement-first — flake 주장은 실측 후에만. 편입 절차가 #779 로 이미 표준화되어 비용 낮음                                                  |
+
+## 결정
+
+1. **신규 프로젝트-로컬 workflow `.github/workflows/shader-pixel-guard.yml`** (후보 d)
+   - 트리거: `pull_request`/`push` (develop, main) + `paths-ignore: ['**/*.md', 'docs/**', '.github/**']` (fps-baseline-guard 동일 — 단 자기 자신 `.yml` 변경 시 실행되도록 `.github/**` 제외 여부는 dev 가 fps 선례 그대로 답습) + concurrency group (#779 sha 기준)
+   - 단일 job: setup (fps-guard measure job 과 동일 구간 — checkout/pnpm/node `.node-version` 핀/rust/wasm-pack/playwright 캐시) → `pnpm build` → **dev server 1회 기동 (단일 포트)** → **6 스크립트 직렬 실행, 각각 exit code 전파 (fail-fast)** → 실패 시 캡처/JSON artifact 업로드. `timeout-minutes: 30`
+   - 호출 규약: `HEADFUL=0` (756/773/774/782/783) / `--headless` (762) + `BASE_URL` 주입. CI 에 chrome channel 없음 → headless chromium 폴백 경로가 아닌 **명시적 headless** 로 결정적 실행
+2. **스크립트 정비 (최소 수정 원칙 + CI 적합화만)**
+   - 4종 untracked 커밋 (756/762/773/774) + `apps/web/package.json` 에 `verify:756-surface / 762-monotonic / 773-light / 774-sun / 782-rotation / 783-earth-detail` 6종 등록 (위치 표준 `apps/web/scripts/` 이미 충족 — #793 잔여와 분리)
+   - **756/773 은 판정·exit code 자체가 없음 (측정+JSON 만)** → fail-fast 판정 추가 필수. 762/774/782 는 판정 이미 존재 — 무수정
+   - **783 diffDirs CHECK → `process.exitCode=1` fail-fast** (PR #796 reviewer 권고 4 이관 항목 해소)
+3. **판정 규약 — per-body 상대 성질, 절대 임계 금지**
+   - 756: 4 body 각각 `hfEntropy(ON) − hfEntropy(OFF) ≥ margin` (실측 최소 갭 moon 0.415 / swiftshader earth 0.469 → **가산 마진 방향, 초기 제안 0.15**) + tier-c(?gpu=c) 저디테일 확인. **최종 마진은 dev 가 D1 에서 CI swiftshader 실측 후 확정·정정 박제** (measurement-first 3중 박제 — 코드 주석/PR 본문/ADR Amendment)
+   - 773: 4 body `dayMean > nightMean × 2` (실측 최소 saturn 2.14×) + `contrastMean(ON) > contrastMean(OFF)` (moon 포함 4/4 성립 실측) + `purplePct == 0`. **hfEntropy ON>OFF 는 moon 역전 실측으로 판정 축에서 제외** (실측 §3)
+4. **비목표**
+   - 픽셀 baseline 스냅샷 확장 (r1-guard 와 책임 분리 — r1 = UI 영역 diff, 본 가드 = canvas 성질)
+   - 기존 detect-and-test 12 가드 재배치 / setup 구간 composite action 추출 (3번째 복제 발생 — ADR 20260701-779 §A1 재검토 7 "첫 drift 발견 시 착수" 트리거 유지, 후속 이슈로만 기록)
+   - `docs/reports/` 산출물 처분 규약 (#793 범위)
+
+## 결과·재검토 조건
+
+- 기대 효과: 셰이더 feature 5개 지대의 픽셀 회귀 (uniform 배선 절단/분기 오염/광원 붕괴/자전 정지/극관·biome 소실) 가 PR 단계에서 차단. 사용자 D-T2 재발견 비용 (#773 사용자 발견 회귀 선례) → CI 시간 비용으로 치환
+- 수용 비용: CI runner 시간 +15~25분/run (병렬이므로 wall-clock 영향 ≈ 0~수분), setup 구간 3중 복제 유지비
+
+### Concrete Prediction
+
+- **P1 (시간 예산)**: 신규 job 총 소요 **≤ 25분** (timeout 30 여유), `detect-and-test` 실행 시간 증가 **0** — 검증: 도입 PR 의 Actions run 시간 실측
+- **P2 (negative 검출력)**: 표면 배선 절단 시뮬레이션 (예: `surfaceDetail` 강제 false 커밋) 에서 **verify:756 + verify:773 최소 2종 FAIL** — 검증: 3중 시뮬레이션 (positive→negative→recovery) 로그
+- **P3 (결정성)**: 동일 커밋 2연속 run 판정 동일 (flake 0) — 검증: 도입 PR 에서 rerun 1회
+- **P4 (코어 무변경)**: `packages/core` + `apps/web/src` 코드 변경 **0 줄** (스크립트/workflow/package.json 만) — 검증: `git diff --stat` — 실패 시 = 가드가 앱 코드 침범 (재설계 신호)
+
+### 재검토 트리거
+
+- flake 발화 ≥ 1회/주 → #779 Phase 2 step-retry (또는 fresh-runner escalation) 편입. **silent 약화 (판정 완화) 금지** — 의식적 완화는 본 ADR Amendment 로만 ([guard-design-principles](../lessons/guard-design-principles.md) §2)
+- job 소요 > 30분 (timeout 발화) → 스크립트 그룹 분할 (2 job 병렬) 재설계
+- headless CI 에서 WebGPU 안정 가용 (chromium 플래그 없이) → WebGL2/WebGPU 양 백엔드 매트릭스 재검토 (#756 ADR §재검토 4 parity 항목과 합류)
+- setup 구간 3중 복제에서 첫 drift 발견 → composite action 추출 착수 (ADR 20260701-779 §A1 재검토 7)
+- 신규 셰이더 feature (R-Phase 확장) 추가 시 → 해당 verify 를 본 workflow 에 등록하는 것을 feature DoD 에 포함 (로컬 전용 verify 재누적 차단)
+
+## 교차검증 반영 사항
+
+> Provisional — 메인 오케스트레이터가 cross-validate (agy) 수행 후 본 섹션에 4축 분류 (합의 / 이견 수용 / 기각 / 고유 발견 후속 분리) + Claude 편향 셀프 체크를 통합하고 Accepted 로 전이한다.
+
+- **호출 전 Claude 편향 셀프 체크 (architect 선행 기록)**: 4종 중 **낙관적 일정** (CI 계수 2~3× 추정이 낙관일 수 있음 — P1 로 실측 가드) + **결합 간과** (swiftshader 로컬 근사 ≠ CI runner 실측 — DoD 에 CI 실측 단계 분리로 보정) 2축 의심 → cross-validate 프롬프트에 명시 질문 삽입 권장
+
+## 참고
+
+- 이슈: [#759](https://github.com/coseo12/astro-simulator/issues/759) (원 범위 + 2026-07-04 확장 코멘트), [#793](https://github.com/coseo12/astro-simulator/issues/793) (산출물 수명주기 — 합류/분리 명시)
+- ADR: [20260628-756-procedural-planet-surface.md](20260628-756-procedural-planet-surface.md), [20260701-779-ci-alert-fatigue-concurrency.md](20260701-779-ci-alert-fatigue-concurrency.md)
+- 교훈: [guard-pr-dod.md](../lessons/guard-pr-dod.md) (4축 검증), [guard-design-principles.md](../lessons/guard-design-principles.md), [headless-browser-verification.md](../lessons/headless-browser-verification.md)
+- reviewer 이관: [PR #796 권고 4](https://github.com/coseo12/astro-simulator/pull/796#issuecomment-4878802356)

--- a/docs/decisions/20260705-759-shader-verify-ci-guard.md
+++ b/docs/decisions/20260705-759-shader-verify-ci-guard.md
@@ -123,6 +123,21 @@
 
 **Claude 편향 셀프 체크 결과**: 낙관적 일정 (의심 축) — agy 가 5~8× 반례 제시 → timeout 완충 + D1 실측 규약으로 해소. 결합 간과 (의심 축) — swiftshader 로컬 근사 ≠ CI 실측 갭은 pull_request 트리거 구조상 머지 전 실측으로 닫힘 확인. 나머지 2종 통과.
 
+## Amendment 1 — D1 마진 확정 + tier-c 판정 축 measurement-first 정정 (2026-07-05 dev, PR #803)
+
+**1. 756 가산 마진 0.15 확정** (결정 3 의 D1 규약 이행 — 3중 박제: `browser-verify-756-surface.mjs` 상단 주석 / PR #803 본문 D1 표 / 본 각주):
+
+| 환경                                    | earth         | mars          | jupiter       | moon              |
+| --------------------------------------- | ------------- | ------------- | ------------- | ----------------- |
+| CI ubuntu swiftshader (run 28712529835) | 0.768         | 0.873         | 0.688         | **0.359 (최소)**  |
+| 로컬 headless 하드웨어 (2회)            | 0.451 / 0.360 | 0.757 / 0.839 | 0.716 / 0.909 | 0.651 / **0.295** |
+
+CI 최소 갭 0.359 = 마진의 2.4×, 전체 관측 최소 (로컬 분산 포함) 0.295 = 1.97× → **0.15 유지**. 배선 절단 negative 실측 시 갭은 −0.13~0.09 로 붕괴 (마진 아래 명확 분리 — 검출력 여유 확인).
+
+**2. tier-c 판정 축 정정 — 픽셀 hfEntropy → lodStats 배선 검증** (결정 3 "tier-c 저디테일 확인" 의 구현 방식 확정): dev 판정 신설 중 기존 756 스크립트 tier-c 시나리오의 **잠재 결함 2건**이 실측으로 드러남 — (a) `?lod=auto` 가 URL `?lod=` 우선 정책 (#677) 으로 tier-c `forceOverride:'low'` 를 무효화해 표면 셰이더가 진입한 채 측정되고 있었음 (실측 lodStats high=2, hfEntropy 1.399 ≈ ON — 판정 부재로 미발각) (b) `focus=earth` 시 #546 satellite guard 가 moon 을 low→mid 승격 (override 이후 후처리 — 문서화된 설계). 픽셀 축은 billboard 축소 후 bbox 대부분이 배경 (로컬 starfield 별 오염 vs CI 검정 — 환경 의존 비결정) 이라 false-fail 원천. → **default view (`?gpu=c`, no focus/lod) 에서 `override==='low' && high===0 && mid===0` 구조 검증**으로 확정 (표면 셰이더는 high/mid variant 에만 부착되므로 구조적 미진입 증명 — 결정적·백엔드 무관). guard-design-principles §1 (measurement-first: broad 설계 → dev 실측 false-positive → precision 정정 박제) 이행.
+
+**3. P1 실측**: 신규 job 총 6m49s (setup ~2m + verify 6종 4m43s) — 예측 ≤25분 대비 27% 수준. CI 계수 실측 ≈ 1.15× (로컬 4.1분 → CI 4.7분. agy 의 5~8× 경고는 미발현 — timeout 40 완충은 유지).
+
 ## 참고
 
 - 이슈: [#759](https://github.com/coseo12/astro-simulator/issues/759) (원 범위 + 2026-07-04 확장 코멘트), [#793](https://github.com/coseo12/astro-simulator/issues/793) (산출물 수명주기 — 합류/분리 명시)

--- a/docs/decisions/20260705-759-shader-verify-ci-guard.md
+++ b/docs/decisions/20260705-759-shader-verify-ci-guard.md
@@ -1,6 +1,6 @@
 # ADR 20260705-759 — 표면 셰이더 verify 6종 CI 상시 가드 (shader-pixel-guard workflow)
 
-- 상태: **Provisional** (cross-validate 발동 대상 — CLAUDE.md `## 교차검증` 박제 직후 1회 루틴. 메인 오케스트레이터가 agy cross-validate 수행 + §교차검증 반영 사항 통합 후 Accepted 전이 — #370 옵션 C)
+- 상태: **Accepted** (cross-validate agy 2026-07-05 — §교차검증 반영 사항 통합)
 - 날짜: 2026-07-05
 - 이슈: [#759](https://github.com/coseo12/astro-simulator/issues/759)
 - 관련: #756 (표면 셰이더 — ADR [20260628-756](20260628-756-procedural-planet-surface.md) §결정 3 tier-c 자동 단색 / §A2 결정 7 r1-guard canvas 미측정), #762/#773/#774/#782/#783 (셰이더 feature 트랙), #779 (flake step-retry / fresh-runner escalation — ADR [20260701-779](20260701-779-ci-alert-fatigue-concurrency.md)), #728 (WebGPU readback 함정 SSoT), #626 (paths-ignore docs skip), #793 (산출물 수명주기 규약 — 합류 지점), PR #796 reviewer 권고 4 (783 diffDirs exitCode)
@@ -77,7 +77,7 @@
 
 1. **신규 프로젝트-로컬 workflow `.github/workflows/shader-pixel-guard.yml`** (후보 d)
    - 트리거: `pull_request`/`push` (develop, main) + `paths-ignore: ['**/*.md', 'docs/**', '.github/**']` (fps-baseline-guard 동일 — 단 자기 자신 `.yml` 변경 시 실행되도록 `.github/**` 제외 여부는 dev 가 fps 선례 그대로 답습) + concurrency group (#779 sha 기준)
-   - 단일 job: setup (fps-guard measure job 과 동일 구간 — checkout/pnpm/node `.node-version` 핀/rust/wasm-pack/playwright 캐시) → `pnpm build` → **dev server 1회 기동 (단일 포트)** → **6 스크립트 직렬 실행, 각각 exit code 전파 (fail-fast)** → 실패 시 캡처/JSON artifact 업로드. `timeout-minutes: 30`
+   - 단일 job: setup (fps-guard measure job 과 동일 구간 — checkout/pnpm/node `.node-version` 핀/rust/wasm-pack/playwright 캐시) → `pnpm build` → **dev server 1회 기동 (단일 포트)** → **6 스크립트 직렬 실행, 각각 exit code 전파 (fail-fast)** → 실패 시 캡처/JSON artifact 업로드 (`retention-days: 7` — cross-validate 수용). `timeout-minutes: 40` (cross-validate 부분 수용 — CI 계수가 2~3× 추정을 초과할 가능성 대비 완충. P1 예측 ≤25분은 유지, D1 실측이 확정하며 30분 초과 실측 시 재검토 트리거 2항 발동)
    - 호출 규약: `HEADFUL=0` (756/773/774/782/783) / `--headless` (762) + `BASE_URL` 주입. CI 에 chrome channel 없음 → headless chromium 폴백 경로가 아닌 **명시적 headless** 로 결정적 실행
 2. **스크립트 정비 (최소 수정 원칙 + CI 적합화만)**
    - 4종 untracked 커밋 (756/762/773/774) + `apps/web/package.json` 에 `verify:756-surface / 762-monotonic / 773-light / 774-sun / 782-rotation / 783-earth-detail` 6종 등록 (위치 표준 `apps/web/scripts/` 이미 충족 — #793 잔여와 분리)
@@ -88,7 +88,7 @@
    - 773: 4 body `dayMean > nightMean × 2` (실측 최소 saturn 2.14×) + `contrastMean(ON) > contrastMean(OFF)` (moon 포함 4/4 성립 실측) + `purplePct == 0`. **hfEntropy ON>OFF 는 moon 역전 실측으로 판정 축에서 제외** (실측 §3)
 4. **비목표**
    - 픽셀 baseline 스냅샷 확장 (r1-guard 와 책임 분리 — r1 = UI 영역 diff, 본 가드 = canvas 성질)
-   - 기존 detect-and-test 12 가드 재배치 / setup 구간 composite action 추출 (3번째 복제 발생 — ADR 20260701-779 §A1 재검토 7 "첫 drift 발견 시 착수" 트리거 유지, 후속 이슈로만 기록)
+   - 기존 detect-and-test 12 가드 재배치 / setup 구간 composite action 추출 — **후속 이슈 [#802](https://github.com/coseo12/astro-simulator/issues/802) 분리** (rule-of-three 도달 — cross-validate 재권고 2회차 수용하되 본 PR 검증 표면 최소화 원칙으로 분리, 선행 조건 = 본 건 머지)
    - `docs/reports/` 산출물 처분 규약 (#793 범위)
 
 ## 결과·재검토 조건
@@ -111,11 +111,17 @@
 - setup 구간 3중 복제에서 첫 drift 발견 → composite action 추출 착수 (ADR 20260701-779 §A1 재검토 7)
 - 신규 셰이더 feature (R-Phase 확장) 추가 시 → 해당 verify 를 본 workflow 에 등록하는 것을 feature DoD 에 포함 (로컬 전용 verify 재누적 차단)
 
-## 교차검증 반영 사항
+## 교차검증 반영 사항 (agy 2026-07-05 — 로그 `.claude/logs/cross-validate-architecture-759.log`)
 
-> Provisional — 메인 오케스트레이터가 cross-validate (agy) 수행 후 본 섹션에 4축 분류 (합의 / 이견 수용 / 기각 / 고유 발견 후속 분리) + Claude 편향 셀프 체크를 통합하고 Accepted 로 전이한다.
+**합의 (이미 반영 확인)**: Q1 moon 처리 — agy 권고 "엔트로피 축만 제외 + 대비/보라 축으로 대체 가드" 는 결정 3 의 773 판정 규약과 **동일** (역전 축 제외 = 명시 박제된 의식적 축소, 대비·purple 축이 moon 커버 유지 — 가드 약화 아님). 756 의 moon 얇은 마진 (1.24×, 갭 0.415) 은 가산 마진 0.15 대비 2.7× 여유 + D1 CI 실측 확정 규약으로 충분. 상대 성질 판정/paths-ignore/별도 workflow 채택 지지. WebGPU 경로 공백 지적은 재검토 트리거 3항에 기박제 (합의 재확인 — 로컬 qa 실 Chrome WebGPU 가 feature 단위 보완).
 
-- **호출 전 Claude 편향 셀프 체크 (architect 선행 기록)**: 4종 중 **낙관적 일정** (CI 계수 2~3× 추정이 낙관일 수 있음 — P1 로 실측 가드) + **결합 간과** (swiftshader 로컬 근사 ≠ CI runner 실측 — DoD 에 CI 실측 단계 분리로 보정) 2축 의심 → cross-validate 프롬프트에 명시 질문 삽입 권장
+**부분 수용**: (1) **Q2 시간 예산** — CI 계수 5~8× 가능성 경고 수용: `timeout-minutes` 30→**40** 완충 (조기 timeout noise 방지). P1 ≤25분 예측은 유지 — D1 실측 확정, 30분 초과 시 재검토 2항 (2-job 분할) 발동. (2) **artifact `retention-days: 7`** — 스토리지 누적 방지 (결정 1 반영). (3) **로컬 swiftshader 재현 커맨드** — architect 실측 방식 (`--use-angle=swiftshader`) 을 developer 가 스크립트 env 또는 README 스니펫으로 문서화 (CI 실패 재현 경로). (4) **스크립트 간 실패 격리** — dev server 단일 기동 구조에서 개별 스크립트 비정상 종료 시 잔존 브라우저 정리 (trap) — developer 지시 반영.
+
+**기각 (근거)**: (1) **retry `retries:1` 선주입** — agy 자신이 #779 A1 cross-validate 에서 "flake 미증명 가드에 선제 지연 주입 = 오진 확률 확대, 이력 기반 동적 옵트인이 원칙" 이라 판정한 것과 정면 모순. 축 3 결정 유지 (fail-fast 시작, flake 실측 1회 시 #779 편입). (2) **shadow phase (`continue-on-error` 3~5일)** — continue-on-error 금지 원칙 (silent 약화) + 본 workflow 는 `pull_request` 트리거라 **머지 전 PR 단계에서 실 CI 실측·rerun (P3)·마진 확정 (D1) 이 전부 가능** — 사후 shadow 가 불필요한 구조. (3) **`?gpu=a` dev-환경 게이팅** — 전제 부재: P11-C #290 부터 존재하는 사용자 노출 디버그 플래그의 재사용이며 본 ADR 이 신규 도입하는 것이 아님. 게이팅은 기존 디버그 도구 회귀 + scope 밖 (강제 시 저사양 기기 느려짐은 현재도 동일 — OOM 크래시 주장은 근거 미제시).
+
+**고유 발견 (후속 분리)**: composite action 추출 (3번째 복제 = rule-of-three) → **이슈 #802 즉시 생성** (선행: 본 건 머지. agy 동일 권고 2회 누적으로 "첫 drift 대기" 에서 승격하되 본 PR 과는 분리 — 검증 표면 최소화).
+
+**Claude 편향 셀프 체크 결과**: 낙관적 일정 (의심 축) — agy 가 5~8× 반례 제시 → timeout 완충 + D1 실측 규약으로 해소. 결합 간과 (의심 축) — swiftshader 로컬 근사 ≠ CI 실측 갭은 pull_request 트리거 구조상 머지 전 실측으로 닫힘 확인. 나머지 2종 통과.
 
 ## 참고
 

--- a/docs/decisions/20260705-759-shader-verify-ci-guard.md
+++ b/docs/decisions/20260705-759-shader-verify-ci-guard.md
@@ -98,7 +98,7 @@
 
 ### Concrete Prediction
 
-- **P1 (시간 예산)**: 신규 job 총 소요 **≤ 25분** (timeout 30 여유), `detect-and-test` 실행 시간 증가 **0** — 검증: 도입 PR 의 Actions run 시간 실측
+- **P1 (시간 예산)**: 신규 job 총 소요 **≤ 25분** (timeout 40 여유 — cross-validate 완충 반영), `detect-and-test` 실행 시간 증가 **0** — 검증: 도입 PR 의 Actions run 시간 실측 (**실측 6m49s — 적중, CI 계수 1.15×**)
 - **P2 (negative 검출력)**: 표면 배선 절단 시뮬레이션 (예: `surfaceDetail` 강제 false 커밋) 에서 **verify:756 + verify:773 최소 2종 FAIL** — 검증: 3중 시뮬레이션 (positive→negative→recovery) 로그
 - **P3 (결정성)**: 동일 커밋 2연속 run 판정 동일 (flake 0) — 검증: 도입 PR 에서 rerun 1회
 - **P4 (코어 무변경)**: `packages/core` + `apps/web/src` 코드 변경 **0 줄** (스크립트/workflow/package.json 만) — 검증: `git diff --stat` — 실패 시 = 가드가 앱 코드 침범 (재설계 신호)


### PR DESCRIPTION
### 변경 사항

- **신규 workflow `.github/workflows/shader-pixel-guard.yml`** — 표면 셰이더 verify 6종 (756/762/773/774/782/783) CI 상시 가드 (ADR [20260705-759](https://github.com/coseo12/astro-simulator/blob/feature/759-shader-verify-ci/docs/decisions/20260705-759-shader-verify-ci-guard.md) 결정 1, 축 1 후보 d). fps-baseline-guard 선례: pull_request/push(develop,main) + paths-ignore(md/docs/.github) + concurrency(sha) + 단일 job (setup → build → dev server 1회 → 6 스크립트 직렬 fail-fast → 실패 시 artifact retention 7일) + `timeout-minutes: 40` + step trap 잔존 chromium 정리
- **verify 4종 untracked 커밋** (756/762/773/774) + `apps/web/package.json` `verify:*` 6종 등록
- **756 fail-fast 판정 신설** — per-body `hfEntropy(ON) − hfEntropy(OFF) ≥ 0.15` (가산 마진, D1 확정 완료 — 아래 표) + tier-c lodStats 배선 검증. 판정 신설 중 기존 tier-c 시나리오 결함 2건 실측 발견·정정: (1) `?lod=auto` 가 URL 우선 정책 (#677) 으로 tier-c `forceOverride:'low'` 를 무효화 → 표면 셰이더 진입 상태로 측정 (실측 lodStats high=2, hfEntropy 1.399 ≈ ON) (2) `focus=earth` 시 #546 satellite guard 가 moon 을 mid 승격 → default view 로 전환 후 `override==='low' && high===0 && mid===0` 구조 검증 (결정적·백엔드 무관). ADR Amendment 1 §2 박제
- **773 fail-fast 판정 신설** — per-body `dayMean > nightMean × 2` + `contrastMean(ON) > contrastMean(OFF)` + `purplePct == 0`. hfEntropy ON>OFF 축은 moon 실측 역전 (ON 1.402 < OFF 1.989, 소면적 소표본 artifact) 으로 판정 제외 — moon 커버는 대비/보라 축 담당 (의식적 축소, ADR §교차검증 합의)
- **783 diffDirs fail-fast** — 판정 미달 `CHECK` 로그 → `process.exitCode=1` (PR #796 reviewer 권고 4 이관 해소)
- **SWIFTSHADER=1 로컬 재현 env** (756/773/783) — CI(ubuntu swiftshader) 실패 재현 경로: `SWIFTSHADER=1 HEADFUL=0 BASE_URL=http://localhost:3001 pnpm --filter @astro-simulator/web run verify:756-surface` (ADR §교차검증 부분 수용 3)
- 762/774/782 판정 로직 무수정 (ADR 결정 2 — 판정 기존재)
- ADR 20260705-759 (Accepted) + **Amendment 1** (D1 마진 확정 + tier-c 축 정정 + P1 실측 — 본 PR 에서 박제)

### Behavior Changes

- **신규 CI 가드**: 모든 develop/main 대상 PR + push 에서 shader-pixel-guard workflow 가 병렬 실행 (detect-and-test 무접촉 — 실측 18m24s, develop 기준 18m02s~18m41s 범위 내 = 증가 0). 셰이더 픽셀 회귀 (uniform 배선 절단/분기 오염/광원 붕괴/자전 정지/극관·biome 소실) 시 PR 차단
- **메일 정책 영향**: fail-fast (retry 미포함 시작) — FAIL 시 workflow failure 메일 1통. flake 실측 ≥1회/주 시 #779 Phase 2 패턴 편입 (silent 판정 완화 금지 — ADR Amendment 로만)
- docs-only PR 은 paths-ignore 로 skip (#626 — 효력은 develop 반영 후 후속 PR 부터)

### Test plan

- [x] All 6 verify scripts PASS locally in headless mode against dev server (exit 0): 756 (65s) / 762 (19s) / 773 (~60s) / 774 (29s) / 782 (57s) / 783 (14s) — total ≈ 4.1 min
- [x] Negative detection (local, wiring-cut `surfaceDetail: false`): verify:756 FAIL exit 1 (4/4 bodies) + verify:773 FAIL exit 1 (4/4 bodies, contrastMean ON ≤ OFF) — ADR P2 "2 scripts FAIL" reproduced locally
- [x] Recovery (local): after revert, verify:756 PASS exit 0
- [x] 783 diffDirs both directions: differing PNGs → exit 1 / identical PNGs → exit 0
- [x] YAML parse OK + `node --check` OK + ESLint clean + encoding check (U+FFFD 0)
- [x] CI: shader-pixel-guard PASS on this PR — [run 28712529835](https://github.com/coseo12/astro-simulator/actions/runs/28712529835) (6m49s)
- [x] CI: negative commit push → workflow FAIL (verify:756 판정 층) → revert push → PASS 복귀 (P2, run links below)
- [x] CI: rerun same commit → identical verdict (P3, below)

### DoD — Concrete Prediction 실측 표 (ADR §결과)

| # | 예측 | 실측 | 판정 |
|---|---|---|---|
| P1 | 신규 job 총 소요 ≤ 25분 (timeout 40 완충) + detect-and-test 증가 0 | **6m49s** (setup ~2m + verify 6종 4m43s — CI 계수 1.15×, agy 5~8× 경고 미발현). detect-and-test 18m24s = develop 기준 (18m02s~18m41s) 범위 내 증가 0 | ✅ PASS |
| P2 | 배선 절단 시 verify:756 + verify:773 최소 2종 FAIL | 로컬: 2/2 FAIL. CI: [FAIL run 28712879193](https://github.com/coseo12/astro-simulator/actions/runs/28712879193) — verify:756 판정 4/4 body 갭 붕괴 (0.081/0.114/−0.010/−0.008 < 0.15), setup/build/dev server 전부 success = **가드 판정 층에서만 실패**. 773 은 fail-fast 로 CI 미도달 (로컬 실증) → [recovery PASS run 28713095486](https://github.com/coseo12/astro-simulator/actions/runs/28713095486) | ✅ PASS |
| P3 | 동일 커밋 rerun 판정 동일 (flake 0) | [run 28713095486](https://github.com/coseo12/astro-simulator/actions/runs/28713095486) attempt 1 (success, 6m45s) == attempt 2 (success, 6m58s). 756 갭 attempt 2 = earth 0.532 / mars 0.815 / jupiter 0.740 / moon 0.375 — 전 축 ✓ 동일 | ✅ PASS |
| P4 | `packages/core` + `apps/web/src` 변경 0줄 | `git diff origin/develop...HEAD --stat -- packages/core apps/web/src` = 빈 출력 (negative 커밋 2개는 revert 로 net 0) | ✅ PASS |

- **3중 시뮬레이션 실 CI 사이클**: positive [28712529835](https://github.com/coseo12/astro-simulator/actions/runs/28712529835) (success) → negative [28712879193](https://github.com/coseo12/astro-simulator/actions/runs/28712879193) (failure — 판정 층) → recovery [28713095486](https://github.com/coseo12/astro-simulator/actions/runs/28713095486) (success)
- **1차 negative 시도 부적합 기록** ([run 28712801594](https://github.com/coseo12/astro-simulator/actions/runs/28712801594)): `surfaceDetail: false` 단순 치환은 `surfaceVisible` unused 로 **next build typecheck 가 verify 도달 전 선차단** — negative 시뮬레이션은 검증하려는 가드 판정 층에 도달하도록 상위 게이트 (typecheck/lint) 를 통과하는 형태로 설계해야 함 (`surfaceVisible && false` 로 정정). 부수 관찰: 빌드 게이트가 방어의 깊이 1층으로 선행 작동

### D1 — 756 판정 마진 0.15 확정 (3중 박제: 스크립트 주석 / 본 표 / ADR Amendment 1)

| 환경 | earth | mars | jupiter | moon | 판정 |
|---|---|---|---|---|---|
| **CI ubuntu swiftshader** ([run 28712529835](https://github.com/coseo12/astro-simulator/actions/runs/28712529835)) | 0.768 | 0.873 | 0.688 | **0.359 (최소)** | 전부 ≥ 0.15 |
| 로컬 headless 하드웨어 run 1 | 0.451 | 0.757 | 0.716 | 0.651 | 전부 ≥ 0.15 |
| 로컬 headless run 2 (recovery) | 0.360 | 0.839 | 0.909 | **0.295** | 전부 ≥ 0.15 |
| (참고) 배선 절단 negative | 0.081 | 0.114 | −0.010 | −0.008 | 전부 < 0.15 (검출) |

- **확정: 0.15 유지** — CI 최소 갭 0.359 = 마진의 2.4× 여유, 전체 관측 최소 (로컬 분산 포함) 0.295 = 1.97×. negative 갭 (−0.01~0.11) 과 명확 분리. 773 CI 실측: contrastMean ON 3.17~5.84 > OFF 2.31~4.66, purple 0% (4/4)

### 가드 도입 PR DoD 4축 (guard-pr-dod)

1. **격리 동적 테스트**: 6종 로컬 headless 전부 exit 0 + CI 전 구간 PASS
2. **3중 시뮬레이션**: positive → negative (배선 절단) → recovery — 로컬 + 실 CI 양쪽 완료 (위 run link 3개)
3. **5 페르소나 self-consistency**: **N/A** — agent SSoT 가드가 아닌 픽셀 측정 가드. 판정 = 스크립트 exit code 로 결정적 (페르소나 해석 개입 여지 0)
4. **메타 측정 안정성**: P3 rerun 판정 동일 (위 표)

### 머지 후 관찰 항목

- develop push trigger 첫 run PASS 확인 (메인)
- paths-ignore 효력 검증 — 후속 docs-only PR 에서 skip (#626: filter 는 base 반영 후 부터)
- flake 관찰 1주 — 발화 ≥1회/주 시 #779 편입 (재검토 트리거 1). 특히 moon 갭 분산 (0.295~0.651 관측) 주시
- 신규 셰이더 feature 추가 시 verify 를 본 workflow 에 등록 (feature DoD 포함 — 재검토 트리거 5)
- setup 구간 3중 복제 → composite action 추출은 후속 #802 (선행 조건 = 본 건 머지)

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료
- [x] 모든 완료 기준 충족

(완료 기준 = ADR 20260705-759 결정 1~4 + 판정 규약 + P1~P4 + DoD PR 단계 5항 — 위 실측 표 전부 충족)

### 테스트
- [x] 단위 테스트 추가/수정
- [x] 기존 테스트 통과 확인
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인

(단위 테스트 대상 앱 코드 변경 0 — 판정은 브라우저 verify 스크립트가 담당. Test plan 참조. 신규 워크스페이스 없음. detect-and-test PASS = 기존 테스트 전체 통과)

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [ ] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [x] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR: `docs/decisions/20260705-759-shader-verify-ci-guard.md` (**신규**, Accepted — cross-validate agy 2026-07-05 §교차검증 통합) + **Amendment 1** (D1 마진 확정 / tier-c 축 정정 / P1 실측 — 본 PR dev 단계 박제)
  - 검증 결과: **호환** — 신규 ADR (기존 ADR 개정/폐기/Supersedes 없음). 기존 ADR 참조는 합류 명시만: 20260628-756 §결정 3·§A2 결정 7 (전제 재사용), 20260701-779 §A1 재검토 7 (composite action 트리거 → #802 분리), PR #796 권고 4 (이관 해소). Amendment 1 은 결정 3 의 D1 규약 이행 (결정 자체 무변경 — 파라미터 확정 + 구현 방식 precision 정정)

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [ ] **[1/3] 정적**: 렌더링 OK, 콘솔 에러 0 — 스크린샷 경로:
- [ ] **[2/3] 인터랙션**: 버튼/폼/토글 동작 — 스크린샷 경로:
- [ ] **[3/3] 흐름**: URL↔상태, 네비게이션 — 스크린샷 경로:
- [x] verify 스크립트(있는 경우) 경로: `apps/web/scripts/browser-verify-{756-surface,762-monotonic,773-light,774-sun,782-rotation,783-earth-detail}.mjs`

(앱 UI/렌더 코드 변경 0 — 본 PR 은 가드 인프라. 6종 verify 실행 증거는 Test plan / DoD 표 참조. 콘솔 에러 0 은 756/773 스크립트가 per-page 수집 — 전 시나리오 0 실측)

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님 (단일 이슈 인프라 가드 도입)

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 feature PR (base=develop)

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 feature PR

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음
- [x] 보안 취약점 없음
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145)
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드)

(4번: SSoT JSON 스키마 미수정 — 해당 없음 자명 PASS. 5번: cross-validate 는 메인 오케스트레이터가 ADR 박제 직후 수행 완료, outcome 박제 위치 = ADR 본문 §교차검증 반영 사항 — 중복 박제 금지 원칙에 따라 본 PR 에는 링크만. Amendment 1 은 결정 무변경 파라미터 확정이라 재발동 비대상)

### 관련 이슈
Closes #759
