### PR TITLE
[#764] body-scale radius 미러 drift 가드 — 위성·혜성 전수 단언 확장

### DIFF
--- a/apps/web/src/constants/body-scale.test.ts
+++ b/apps/web/src/constants/body-scale.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import solarSystem from '@astro-simulator/shared/data/solar-system.json';
 import {
+  BODY_RADIUS_M,
   BODY_SCALE,
   DEFAULT_BODY_SCALE_P,
   DWARF_IDS,
@@ -21,6 +22,7 @@ import {
  *   4. 그룹 경계 assert — max(satellite) < min(planet) 등 (achievable invariant)
  *   5. NaN guard / 미정의 fallback
  *   6. BODY_RADIUS_M ↔ solar-system.json drift 가드 (volt #69 숨은 상수)
+ *      — #764 에서 32 body 전수 직접 단언으로 확장 (위성·혜성 포함, #763 reviewer 권고 2)
  */
 
 // 사실 radius (m) — solar-system.json SSoT 에서 동적 추출 (drift 가드).
@@ -262,10 +264,33 @@ describe('#762 — ?bodyScaleP= factory (D-T2 실시간 튜닝)', () => {
   });
 });
 
-describe('#762 — BODY_RADIUS_M ↔ solar-system.json drift 가드 (volt #69 숨은 상수)', () => {
-  // body-scale.ts 내부 radius 미러가 데이터 SSoT 와 일치하는지 검증 (모듈 미export 라
-  // effective 값으로 간접 검증 — scale = curveScale(radius) 이므로 radius drift 시 effective 가 변함).
-  // 직접 비교 대신: BODY_SCALE 에 정의된 모든 행성/왜소 의 effective 가 json radius 기반 재산출과 일치.
+describe('#762/#764 — BODY_RADIUS_M ↔ solar-system.json drift 가드 (volt #69 숨은 상수)', () => {
+  // #764 — 미러를 export 해 32 body 전수 직접 단언으로 확장 (#763 reviewer 권고 2).
+  // 기존 가드의 사각: 행성·왜소 13 만 재산출 직접 검증 / 위성은 수렴대(band) 간접 검증인데
+  // 위성 effective 는 radius 상쇄 구조 (`sat_scale = parent_eff × 수렴대비 / sat.radius` →
+  // effective = parent_eff × 수렴대비, radius 무관... 단 테스트의 eff() 는 json radius 를 곱하므로
+  // 미러 +10% drift 시 mesh 비가 0.0681→0.0619 로 이동해도 band [0.05,0.09] 안 → 미검출) /
+  // comet 은 존재(>0)만 확인하고 값 미검증. 아래 전수 단언이 이 사각을 전부 닫는다.
+
+  it('[#764] 32 body 전수 — 미러 radius == json radius 직접 단언 (위성 13 · 혜성 5 포함)', () => {
+    const jsonBodies = (solarSystem as { bodies: { id: string; radius?: number }[] }).bodies;
+    for (const b of jsonBodies) {
+      expect(typeof b.radius, `${b.id} json radius 존재`).toBe('number');
+      // 정확 일치 (toBe) — 미러는 json 값의 복제이므로 부동소수 오차 허용 없음 (drift = 즉시 FAIL).
+      expect(BODY_RADIUS_M[b.id], `${b.id} 미러 radius ↔ json radius drift`).toBe(b.radius);
+    }
+  });
+
+  it('[#764] 미러 ↔ json id 집합 완전 일치 — 누락/잉여(stale) 항목 0', () => {
+    const jsonIds = Object.keys(RADIUS).sort();
+    const mirrorIds = Object.keys(BODY_RADIUS_M).sort();
+    expect(mirrorIds).toEqual(jsonIds);
+    // 전수 로스터 박제: 32 = sun 1 + 행성 8 + 왜소 5 + 위성 13 + comet·극소형 위성 5.
+    // 신규 body 추가 시 json + 미러 + 본 단언 3곳 동시 갱신 (의도된 checkpoint — 미러 누락 시
+    // getBodyScale 이 1.0 fallback 으로 실측 렌더되는 silent 회귀를 여기서 강제 노출).
+    expect(mirrorIds).toHaveLength(32);
+  });
+
   it('행성·왜소 effective 가 json radius 와 정합 (내부 미러 drift 차단)', () => {
     const p = DEFAULT_BODY_SCALE_P;
     const k = 700 * Math.pow(RADIUS.mercury!, 1 - p);

--- a/apps/web/src/constants/body-scale.ts
+++ b/apps/web/src/constants/body-scale.ts
@@ -63,8 +63,13 @@
  * ⚠️ SSoT 는 `solar-system.json`. 본 테이블은 곡선 산출을 위한 모듈 로드 시 정적 미러일 뿐
  * (런타임 json import 회피 — cross-validate agy 3.0 순환 의존 우려 해소). 데이터 변경 시 drift 차단은
  * `body-scale.test.ts` 의 `BODY_RADIUS_M` ↔ json 정합 가드가 담당 (volt #69 숨은 상수 drift 패턴).
+ *
+ * export 는 #764 drift 가드 (32 body 전수 미러 == json 직접 단언) 의 테스트 접근 경로 전용 —
+ * 런타임 소비처는 본 모듈 내부 곡선 산출뿐이다. 위성 effective 는 radius 상쇄 구조
+ * (`sat_scale = parent_eff × 수렴대비 / sat.radius` → effective 에서 radius 소거) 라 간접 검증으로는
+ * 위성 radius drift 를 잡을 수 없어 직접 단언이 필수 (#763 reviewer 권고 2).
  */
-const BODY_RADIUS_M: Readonly<Record<string, number>> = Object.freeze({
+export const BODY_RADIUS_M: Readonly<Record<string, number>> = Object.freeze({
   sun: 6.957e8,
   mercury: 2.4397e6,
   venus: 6.0518e6,


### PR DESCRIPTION
## [#764] body-scale radius 미러 drift 가드 — 32 body 전수 직접 단언 확장

### 변경 사항
- `body-scale.ts` 의 `BODY_RADIUS_M` radius 미러를 export — **테스트 접근 경로 전용** (런타임 소비처는 모듈 내부 곡선 산출뿐, 행동 변화 0)
- `body-scale.test.ts` drift 가드 describe 를 `#762/#764` 로 확장, 신규 단언 2건:
  - `[#764] 32 body 전수 — 미러 radius == json radius 직접 단언 (위성 13 · 혜성 5 포함)` — `toBe` 정확 일치 (부동소수 오차 허용 없음)
  - `[#764] 미러 ↔ json id 집합 완전 일치 — 누락/잉여(stale) 항목 0` + 로스터 32 박제 (신규 body 추가 시 json + 미러 동시 갱신을 테스트가 강제)
- 기존 간접 가드 (행성·왜소 재산출 정합 / comet 존재) 는 곡선 상수 회귀 가드 역할로 유지

### (선택) 항목 판단 — json 직접 import 검토 결과: 미러 유지 + export 채택
1. **번들**: `solar-system.json` 은 이미 web 런타임 번들에 포함 (`satellite-zoom-tooltip.tsx` 가 직접 import) → 번들 크기 단독으로는 차단 사유 아님
2. **#762 cross-validate agy §3.0 회피 사유 여전히 유효**: `body-scale.ts` 는 모듈 로드 시 1회 정적 산출 (`BODY_SCALE` frozen) 구조. json 전환 시 `radius?: number` optional 파싱 + 누락 body fallback 분기가 모듈 초기화 경로에 추가되어 NaN guard 표면 확장 — 행동 변화 0 이 목표인 type:infra 이슈에서 런타임 모듈 재작성은 scope creep
3. **핵심 동기 소멸**: 미러 제거의 동기는 silent drift 위험인데, 본 PR 의 32 body 전수 직접 단언이 그 위험을 정확히 차단 → 제거 실익 없음. 필요 시 후속 이슈로 분리 가능

### Test plan — 3중 시뮬 (positive → negative → recovery) 증거
명령: `pnpm --filter web exec vitest run src/constants/body-scale.test.ts`

| 단계 | 주입 | 결과 |
|---|---|---|
| positive | 없음 | 26/26 PASS |
| negative 1 (위성) | moon 미러 +10% (`1.7374e6` → `1.91114e6`) | 신규 전수 단언만 FAIL — `AssertionError: moon 미러 radius ↔ json radius drift: expected 1911140 to be 1737400`. **기존 25개 전부 PASS** (mesh 비 0.0681→0.0619 로 band [0.05, 0.09] 내 → 기존 간접 가드 미검출 실증, 이슈 배경 그대로) |
| negative 2 (혜성) | halley 미러 +10% (`5.5e3` → `6.05e3`) | 신규 전수 단언만 FAIL — `expected 6050 to be 5500`. 기존 comet 가드 (단일값 5000 / 존재>0) 는 PASS (값 미검증 사각 실증) |
| recovery | 원복 (잔존물 grep 0) | web 전체 41 파일 / **481 테스트 PASS** + `pnpm --filter web typecheck` green |

- 임시 주입 코드는 커밋에 미포함 (`grep TEMP-NEGATIVE-SIM` 0 hit 확인 후 커밋)
- 번들 영향 확인: `pnpm --filter web build` green (export 추가만, Next.js 16 Turbopack 컴파일 성공)

### 영향 범위
- 런타임 행동 변화 0 — export 추가 + 테스트 확장만. `getBodyScale` / `getBodyScaleForP` / `BODY_SCALE` 산출 로직 불변
- 위성·혜성 미러값 변경 시 silent 데이터 회귀 (volt #69 숨은 상수) 가 CI 에서 즉시 차단됨

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (이슈 #764 완료 조건 4항목)
- [x] 모든 완료 기준 충족 (필수 3항목 + (선택) 검토·기록 완료)

### 테스트
- [x] 단위 테스트 추가/수정 (drift 가드 단언 2건 추가)
- [x] 기존 테스트 통과 확인 (web 41 파일 / 481 테스트 green)
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인 (apps/web `vitest run` 기존 존재)

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [x] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [ ] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR: N/A
  - 검증 결과: N/A

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [x] **[1/3] 정적**: 렌더링 OK, 콘솔 에러 0 — 스크린샷 경로: N/A — UI 런타임 행동 변화 0 (테스트 가드 확장 + export 추가만). 대체 증거: `pnpm --filter web build` green
- [x] **[2/3] 인터랙션**: 버튼/폼/토글 동작 — 스크린샷 경로: N/A — 동일 사유
- [x] **[3/3] 흐름**: URL↔상태, 네비게이션 — 스크린샷 경로: N/A — 동일 사유
- [x] verify 스크립트(있는 경우) 경로: N/A — 단위 테스트 가드가 검증 주체 (`body-scale.test.ts`)

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 feature PR (건너뜀)

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 feature PR (건너뜀)

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음
- [x] 보안 취약점 없음
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145) — N/A (스키마 미수정)
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드) — N/A (정책·규약 변경 없음)

### 관련 이슈
Closes #764

