### PR TITLE
[#814] CI composite action 후속 정비 — 잔존 setup 복제 4개소 치환 + paths-ignore 사각 축소

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -13,9 +13,10 @@ description: >-
 #   3. start-dev-server=true 시 PID 를 /tmp/next-pid 에 박제 — 정리 (kill) 는 호출측
 #      `dev server 정리` step (if: always()) 책임 (composite 은 post hook 미지원).
 
-# inputs 이력 (#814): 도입 시점의 `playwright` / `build` inputs 는 전 호출부 (7개소) 가
-#   default 'true' 만 사용해 실사용 0 → YAGNI 제거. 선택 실행이 필요해지면 git history
-#   (#813, 348891c) 의 구현을 재도입.
+# inputs 이력 (#814): 도입 시점의 `playwright` / `build` inputs 는 전 호출부 7 workflow
+#   (8 invocation — fps 는 measure/retry-fresh-runner 2 invocation) 가 default 'true' 만
+#   사용해 실사용 0 → YAGNI 제거. 선택 실행이 필요해지면 git history (#813, 348891c) 의
+#   구현을 재도입.
 inputs:
   setup-node:
     description: >-

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -13,21 +13,14 @@ description: >-
 #   3. start-dev-server=true 시 PID 를 /tmp/next-pid 에 박제 — 정리 (kill) 는 호출측
 #      `dev server 정리` step (if: always()) 책임 (composite 은 post hook 미지원).
 
+# inputs 이력 (#814): 도입 시점의 `playwright` / `build` inputs 는 전 호출부 (7개소) 가
+#   default 'true' 만 사용해 실사용 0 → YAGNI 제거. 선택 실행이 필요해지면 git history
+#   (#813, 348891c) 의 구현을 재도입.
 inputs:
   setup-node:
     description: >-
       pnpm/action-setup + setup-node (.node-version 핀, pnpm 캐시) + pnpm install 수행 여부.
       ci.yml 처럼 생태계 감지 구간이 이미 수행한 job 은 'false'.
-    required: false
-    default: 'true'
-  playwright:
-    description: >-
-      Playwright 바이너리 캐시 (#684) + chromium 설치 여부. 캐시 히트 시 extract 생략
-      (= #606 deadlock 2차 방어) 경로 포함.
-    required: false
-    default: 'true'
-  build:
-    description: 'pnpm build (wasm + workspace) 수행 여부.'
     required: false
     default: 'true'
   start-dev-server:
@@ -81,7 +74,6 @@ runs:
     # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀이 1차).
     # 캐시 히트 시 ~/.cache/ms-playwright 복원 → 아래 설치 step 의 extract 단계 자체 미발생.
     - name: Playwright 브라우저 캐시
-      if: inputs.playwright == 'true'
       uses: actions/cache@v4
       id: playwright-cache
       with:
@@ -92,17 +84,16 @@ runs:
         key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Playwright chromium 설치 (캐시 미스 — 다운로드+extract)
-      if: inputs.playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
       run: pnpm exec playwright install --with-deps chromium
 
     - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
-      if: inputs.playwright == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
       shell: bash
       run: pnpm exec playwright install-deps chromium
 
     - name: wasm + workspace 빌드
-      if: inputs.build == 'true'
       shell: bash
       run: pnpm build
 

--- a/.github/workflows/a11y-baseline-guard.yml
+++ b/.github/workflows/a11y-baseline-guard.yml
@@ -18,16 +18,18 @@ on:
     # #626 — docs/ADR/워크플로만 바뀐 PR 은 a11y 측정이 무의미(런타임 무관)한데 20분 실 브라우저
     # 측정 후 timeout cancelled (PR #625 ADR-only 실측). 런타임 영향 없는 경로는 skip (fail-safe —
     # 코드/데이터/config 가 하나라도 있으면 실행). paths filter 효과는 base 브랜치 반영 후 후속 PR 부터.
+    # #814 — `.github/**` → `.github/workflows/**` 축소: composite action (.github/actions/**) 은
+    # setup/build 런타임에 직접 관여하므로 변경 PR 에서 본 가드가 발화해야 함 (#813 구조적 사각 해소).
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
   push:
     branches: [develop, main]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
   # #663 — 수동 재실측 경로. workflow_dispatch 2단계 함정 (volt #45): dispatch 버튼은
   # 본 트리거가 default branch (main) 에 반영된 후에만 표시됨 (v0.24.0 릴리스 이후 사용 가능).
   workflow_dispatch:
@@ -39,72 +41,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+      # setup 공통 구간 (pnpm/node/rust/wasm-pack/playwright 캐시/build/dev server) — #802 SSoT,
+      # #814 잔존 복제 치환. ci.yml R1 가드 패턴 따름 — wasm 빌드 후 next dev 기동
+      # (next build (production) 는 dev 전용 핸들 (`__solarScene`) 미노출이므로 next dev 사용).
+      - name: setup + build + dev server (composite)
+        uses: ./.github/actions/setup-and-build
         with:
-          # #663 fix (#606 ADR §Amendment 3) — playwright 1.59.1 extract 가 Node 24.16 에서
-          #   deadlock. engines ">=20.0.0" 범위 해석은 setup-node 가 최신 24.16 을 설치
-          #   → "Playwright chromium 설치" 단계 timeout cancelled (R9 시점부터 상시).
-          #   #666 (Amendment 4): 정확 버전 중앙 파일 `.node-version` (22.16.0) 로 일원화.
-          node-version-file: '.node-version'
-          cache: 'pnpm'
-
-      # ci.yml R1 가드 패턴 따름 — wasm-pack 으로 physics-wasm 빌드 후 next dev 기동.
-      # next build (production) 는 dev 전용 핸들 (`__solarScene`) 미노출이므로 next dev 사용.
-      - name: Rust 툴체인 설정
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: '1.94.1'
-          targets: wasm32-unknown-unknown
-
-      - name: Rust 빌드 캐시
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/physics-wasm
-
-      - name: wasm-pack 설치
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack@0.14.0
-
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
-
-      # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀 #663 이 1차).
-      # 캐시 히트 시 ~/.cache/ms-playwright 복원 → extract 단계 자체 미발생.
-      - name: Playwright 브라우저 캐시
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          # key: runner OS + lockfile hash. @playwright/test 버전이 lockfile 에 포함되므로
-          # playwright 버전 변경 시 자동 무효화 (stale 바이너리 서빙 0). 무관 lock 변경 시
-          # over-eager miss (전체 재설치) 가능하나 안전 방향 (느려질 뿐, fallback = 기존 동작).
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Playwright chromium 설치 (캐시 미스 — 다운로드+extract)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
-
-      - name: wasm + workspace 빌드
-        run: pnpm build
-
-      - name: next dev server 기동
-        run: |
-          pnpm --filter @astro-simulator/web exec next dev -p 3001 &
-          echo $! > /tmp/next-pid
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:3001/ko > /dev/null; then
-              echo "ready"; exit 0
-            fi
-            sleep 2
-          done
-          echo "timeout"; exit 1
+          start-dev-server: 'true'
 
       - name: a11y baseline 회귀 검증
         run: BASE_URL=http://localhost:3001 node scripts/verify-a11y-baseline.mjs

--- a/.github/workflows/bench-baseline-remeasure.yml
+++ b/.github/workflows/bench-baseline-remeasure.yml
@@ -59,59 +59,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
-      - uses: actions/setup-node@v4
-        with:
-          # #666 (Amendment 4) — 정확 버전 중앙 파일 일원화 (기존 node-version: 20).
-          #   bench 측정 루프는 WASM + Chromium headless 로 Node 버전 비종속 → 20→22 통일이
-          #   bench 수치에 영향 없음. #606 playwright extract deadlock 회피 정합.
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      - name: Rust 툴체인 설정
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: '1.94.1'
-          targets: wasm32-unknown-unknown
-
-      - name: Rust 빌드 캐시
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/physics-wasm
-
-      - name: wasm-pack 설치
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack@0.14.0
-
-      - name: 의존성 설치
-        run: pnpm install --frozen-lockfile
-
-      # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀 #663 이 1차).
-      # 캐시 히트 시 ~/.cache/ms-playwright 복원 → extract 단계 자체 미발생.
-      - name: Playwright 브라우저 캐시
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          # key: runner OS + lockfile hash. @playwright/test 버전이 lockfile 에 포함되므로
-          # playwright 버전 변경 시 자동 무효화 (stale 바이너리 서빙 0). 무관 lock 변경 시
-          # over-eager miss (전체 재설치) 가능하나 안전 방향 (느려질 뿐, fallback = 기존 동작).
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Playwright 브라우저 설치 (캐시 미스 — 다운로드+extract)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
-
-      - name: 앱 빌드
-        run: pnpm build
+      # setup 공통 구간 (pnpm/node/rust/wasm-pack/playwright 캐시/build) — #802 SSoT, #814 치환.
+      # pnpm 버전: 기존 version: 10.32.1 명시 핀 → package.json packageManager (pnpm@10.32.1)
+      #   위임으로 전환 — 동일 버전, 핀 SSoT 일원화. production `next start` 는 자체 기동 step 유지.
+      - name: setup + build (composite)
+        uses: ./.github/actions/setup-and-build
 
       - name: 웹 서버 기동 (백그라운드)
         run: |
@@ -150,6 +102,9 @@ jobs:
         if: always()
         run: kill $WEB_PID || true
 
+  # aggregate 는 composite 미적용 (#814 의도적 제외) — setup 복제 구간이 아님 (pnpm/node 만 사용,
+  # rust/wasm-pack/playwright/build 불필요). composite 적용 시 해당 구간이 무조건 추가되어
+  # 1:1 동작 보존 위반 + 불필요 비용 (chromium 설치 등).
   aggregate:
     needs: bench
     runs-on: ubuntu-latest

--- a/.github/workflows/bench-baseline-remeasure.yml
+++ b/.github/workflows/bench-baseline-remeasure.yml
@@ -111,9 +111,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm 버전: package.json packageManager (pnpm@10.32.1) 위임 — 핀 SSoT 일원화 (#814 reviewer 권고 1)
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,8 @@ on:
       - 'scripts/bench-scene.mjs'
       - 'docs/benchmarks/baseline.json'
       - '.github/workflows/bench.yml'
+      # #814 — setup 구간이 composite (#802 SSoT) 의존이므로 composite 변경 PR 에서도 발화
+      - '.github/actions/setup-and-build/**'
 
 jobs:
   bench:
@@ -23,62 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
-      - uses: actions/setup-node@v4
-        with:
-          # #666 (Amendment 4) — 정확 버전 중앙 파일 일원화 (기존 node-version: 20).
-          #   bench 측정 루프는 WASM + Chromium headless 로 Node 버전 비종속 (baseline
-          #   environment="gh-actions-ubuntu-chromium-headless", Node 버전 미기록) → 20→22
-          #   통일이 bench 수치에 영향 없음. #606 playwright extract deadlock 회피 정합.
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      - name: Rust 툴체인 설정
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: '1.94.1'
-          targets: wasm32-unknown-unknown
-
-      # Rust 빌드 캐시 — cargo registry + target/ 재사용 (pnpm build 산하 wasm-pack 빌드 단축)
-      - name: Rust 빌드 캐시
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/physics-wasm
-
-      # wasm-pack: cargo install(≈60s) → prebuilt 바이너리로 대체
-      - name: wasm-pack 설치
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack@0.14.0
-
-      - name: 의존성 설치
-        run: pnpm install --frozen-lockfile
-
-      # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀 #663 이 1차).
-      # 캐시 히트 시 ~/.cache/ms-playwright 복원 → extract 단계 자체 미발생.
-      - name: Playwright 브라우저 캐시
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          # key: runner OS + lockfile hash. @playwright/test 버전이 lockfile 에 포함되므로
-          # playwright 버전 변경 시 자동 무효화 (stale 바이너리 서빙 0). 무관 lock 변경 시
-          # over-eager miss (전체 재설치) 가능하나 안전 방향 (느려질 뿐, fallback = 기존 동작).
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Playwright 브라우저 설치 (캐시 미스 — 다운로드+extract)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
-
-      - name: 앱 빌드
-        run: pnpm build
+      # setup 공통 구간 (pnpm/node/rust/wasm-pack/playwright 캐시/build) — #802 SSoT, #814 치환.
+      # pnpm 버전: 기존 version: 10.32.1 명시 핀 → package.json packageManager (pnpm@10.32.1)
+      #   위임으로 전환 — 동일 버전, 핀 SSoT 일원화 (ci.yml 등 기존 composite 경로와 동일 방식).
+      # bench 는 production `next start` 필요 → start-dev-server 기본값 (false) + 자체 기동 step 유지.
+      - name: setup + build (composite)
+        uses: ./.github/actions/setup-and-build
 
       - name: 웹 서버 기동 (백그라운드)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
       #   3) disk/mem/node 폴링 → 자원 전부 정상 (88G avail / 14Gi mem / Node 24.16),
       #      extract I/O 0바이트 deadlock (run 26756305719)
       #   4) Node 22 핀 → install 28초 통과 → Node 24.16 + playwright 1.59.1 extract
-      #      비호환 확정 (run 26756788369). fix: Node 22 LTS 핀 (line 39).
+      #      비호환 확정 (run 26756788369). fix: Node 22 LTS 핀 — 현재는 위 "Node.js setup (pnpm)"
+      #      step 의 node-version-file (.node-version) 로 일원화 (#666, 라인 번호 참조는 drift 하므로
+      #      서술형으로 정리 — #814).
       # step 분리는 fix 후에도 유지 — freeze 재발 시 즉시 step 단위 격리 (ADR 옵션 f 정합).
       # #802: 1/4 (Playwright 캐시+설치) · 2/4 (build) 는 rust/wasm-pack 툴체인과 함께
       #   setup-and-build composite 내부 sub-step 으로 이동 (분리 구조는 composite 내부에

--- a/.github/workflows/fps-baseline-guard.yml
+++ b/.github/workflows/fps-baseline-guard.yml
@@ -22,16 +22,18 @@ on:
     # #626 — docs/ADR/워크플로만 바뀐 PR 은 fps 측정이 무의미(런타임 무관)한데 25분 실 브라우저
     # 측정 후 timeout cancelled (PR #625 ADR-only 실측). 런타임 영향 없는 경로는 skip (fail-safe —
     # 코드/데이터/config 가 하나라도 있으면 실행). paths filter 효과는 base 브랜치 반영 후 후속 PR 부터.
+    # #814 — `.github/**` → `.github/workflows/**` 축소: composite action (.github/actions/**) 은
+    # setup/build 런타임에 직접 관여하므로 변경 PR 에서 본 가드가 발화해야 함 (#813 구조적 사각 해소).
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
   push:
     branches: [develop, main]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
   # #663 — 수동 재실측 경로. workflow_dispatch 2단계 함정 (volt #45): dispatch 버튼은
   # 본 트리거가 default branch (main) 에 반영된 후에만 표시됨 (v0.24.0 릴리스 이후 사용 가능).
   # #709 — variance 진단 input. `--ref feature/X` 로 실행 시 ref 브랜치의 step 정의를 따름.

--- a/.github/workflows/r1-baseline-bootstrap.yml
+++ b/.github/workflows/r1-baseline-bootstrap.yml
@@ -42,60 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
-      - uses: actions/setup-node@v4
-        with:
-          # #666 (Amendment 4) — playwright 사용 workflow 의 정확 버전 중앙 파일 일원화.
-          #   기존 node-version: 20 → .node-version (22.16.0). #606 deadlock 회피 정합.
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      # physics-wasm 워크스페이스가 wasm-pack 의존 — `pnpm build` 의 root recursive 가
-      # core → physics-wasm 경로로 wasm-pack 호출. bench-baseline-remeasure.yml 검증 패턴 차용.
-      - name: Rust 툴체인 설정
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: '1.94.1'
-          targets: wasm32-unknown-unknown
-
-      - name: Rust 빌드 캐시
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: packages/physics-wasm
-
-      - name: wasm-pack 설치
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack@0.14.0
-
-      - name: 의존성 설치
-        run: pnpm install --frozen-lockfile
-
-      # Playwright 바이너리 캐시 — #684. extract deadlock (#606) 2차 방어 (Node 22 핀 #663 이 1차).
-      # 캐시 히트 시 ~/.cache/ms-playwright 복원 → extract 단계 자체 미발생.
-      - name: Playwright 브라우저 캐시
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          # key: runner OS + lockfile hash. @playwright/test 버전이 lockfile 에 포함되므로
-          # playwright 버전 변경 시 자동 무효화 (stale 바이너리 서빙 0). 무관 lock 변경 시
-          # over-eager miss (전체 재설치) 가능하나 안전 방향 (느려질 뿐, fallback = 기존 동작).
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Playwright Chrome (Linux) 설치 (캐시 미스 — 다운로드+extract)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Playwright 시스템 deps (캐시 히트 — extract 생략 = deadlock 2차 방어)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
-
-      - name: 앱 빌드
-        run: pnpm build
+      # setup 공통 구간 (pnpm/node/rust/wasm-pack/playwright 캐시/build) — #802 SSoT, #814 치환.
+      # pnpm 버전: 기존 version: 10.32.1 명시 핀 → package.json packageManager (pnpm@10.32.1)
+      #   위임으로 전환 — 동일 버전, 핀 SSoT 일원화. baseline 캡처는 production `next start`
+      #   경로 (r1-guard ci.yml 정합) → start-dev-server 기본값 (false) + 자체 기동 step 유지.
+      - name: setup + build (composite)
+        uses: ./.github/actions/setup-and-build
 
       - name: 웹 서버 기동 (백그라운드)
         run: |

--- a/.github/workflows/shader-pixel-guard.yml
+++ b/.github/workflows/shader-pixel-guard.yml
@@ -33,16 +33,22 @@ on:
     # #626 — docs/ADR/워크플로만 바뀐 PR 은 픽셀 측정이 무의미 (런타임 무관). fps-baseline-guard
     # 선례 그대로 답습 (자기 자신 .yml 만 변경된 PR 도 skip — fps 동일 정책). paths filter 효과는
     # base 브랜치 반영 후 후속 PR 부터.
+    # #814 — `.github/**` → `.github/workflows/**` 축소: composite action (.github/actions/**) 은
+    # setup/build 런타임에 직접 관여하므로 변경 PR 에서 본 가드가 발화해야 함 (#813 구조적 사각 해소).
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
   push:
     branches: [develop, main]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      - '.github/**'
+      - '.github/workflows/**'
+  # #814 — 수동 재실측 경로 (a11y/fps 정합). workflow_dispatch 2단계 함정 (volt #45):
+  # dispatch 버튼은 본 트리거가 default branch (main) 에 반영된 후에만 표시됨 —
+  # main 반영 후 실행 검증은 머지 후 관찰 항목.
+  workflow_dispatch:
 
 jobs:
   verify:


### PR DESCRIPTION
### 변경 사항

- 잔존 setup 복제 4개소를 `.github/actions/setup-and-build` composite (#802 SSoT) 로 치환: **a11y-baseline-guard** / **bench** / **bench-baseline-remeasure** (bench job) / **r1-baseline-bootstrap** — 8 files, +52 −249 (순삭감 −197줄)
- **paths-ignore `.github/**` → `.github/workflows/**` 축소** (shader / fps / a11y × pull_request + push 각 2개소): composite action 변경 PR 에서 브라우저 가드가 미발화되는 구조적 사각 해소 (#813 "머지 후 관찰" 우회의 반복 방지). workflow 자기 변경 skip 정책 (#626) 은 유지
- **bench.yml positive paths 에 `.github/actions/setup-and-build/**` 추가** — setup 구간이 composite 의존이므로 composite 변경 PR 에서도 발화 (paths-ignore 축소와 동일 취지)
- **shader-pixel-guard 에 `workflow_dispatch` 트리거 추가** (a11y/fps 정합 — 수동 재실측 경로)
- **composite `playwright` / `build` inputs YAGNI 제거** (하단 판단)
- **reviewer 권고 2건 반영 (aeb2217)**: remeasure aggregate job pnpm `version: 10.32.1` 명시 핀 제거 (packageManager 위임 일원화 — 본 PR 이 만든 핀 혼재 해소) + action.yml inputs 이력 주석 invocation 카운트 명확화
- **ci.yml #606 주석 'line 39' 오참조 정리** (pre-existing — 실제 핀은 "Node.js setup (pnpm)" step 의 node-version-file) — 라인 번호 참조 대신 서술형 참조로 교체

### 개소별 치환 대응표 (1:1 동작 보존 — 완료 조건 1)

4개소 공통 — 기존 복제 블록 step 이 composite sub-step 과 명령·조건·순서 동일 (#813 / 348891c 추출 원본과 같은 계보):

| 기존 step (복제 블록) | composite sub-step | 비고 |
|---|---|---|
| `pnpm/action-setup@v4` | `pnpm setup` | bench 계열 3개소만 의도적 차이 1 (하단) |
| `actions/setup-node@v4` (`.node-version` 핀 + pnpm 캐시) | `Node.js setup` | 동일 |
| Rust 툴체인 (`1.94.1` + wasm32-unknown-unknown) | `Rust 툴체인 설정` | 동일 |
| `Swatinem/rust-cache@v2` (physics-wasm) | `Rust 빌드 캐시` | 동일 |
| `taiki-e/install-action@v2` (`wasm-pack@0.14.0`) | `wasm-pack 설치` | 동일 |
| `pnpm install --frozen-lockfile` | `pnpm install` | step 명만 상이 (bench 계열 "의존성 설치") |
| Playwright 캐시 (#684, key `playwright-OS-lockhash` 동일) | `Playwright 브라우저 캐시` | 동일 |
| chromium 설치 (캐시 미스) / install-deps (히트) | 동일 2 step | bootstrap 만 step 명 상이 ("Playwright Chrome (Linux) 설치" — 명령 동일) |
| `pnpm build` | `wasm + workspace 빌드` | step 명만 상이 ("앱 빌드") |
| next dev 기동 (a11y 만 해당) | `next dev server 기동` | 문자 동일 (`/tmp/next-pid` 박제 + `/ko` 60×2s 폴링) |

개소별 파라미터 조합:

| workflow (job) | composite 호출 | 서버 경로 |
|---|---|---|
| a11y-baseline-guard | `start-dev-server: 'true'` | composite 이 next dev 3001 기동 (기존과 동일). `dev server 정리` step (if: always()) 호출측 유지 |
| bench (bench) | 파라미터 없음 (전부 default) | production `next start` 자체 기동 step 유지 (start-dev-server 기본 false) |
| bench-baseline-remeasure (bench) | 파라미터 없음 | 동일 |
| r1-baseline-bootstrap (bootstrap) | 파라미터 없음 | 동일 |

**의도적 차이 (전수 선언, 3건)**:

1. **pnpm version 명시 핀 제거** (bench / remeasure / bootstrap): 기존 `version: 10.32.1` → `package.json` `packageManager: "pnpm@10.32.1"` field 위임. **동일 버전 해석** — pnpm/action-setup@v4 는 version 미지정 시 packageManager field 를 사용하며, ci.yml / shader / fps 가 이미 이 경로로 green (#813 실측). 핀 SSoT 일원화.
2. **remeasure `aggregate` job 미치환**: setup 복제 구간이 아님 (pnpm/node 만 사용, rust/wasm-pack/playwright/build 불필요). composite 적용 시 해당 구간이 무조건 추가 실행되어 1:1 보존 위반 + 불필요 비용 (chromium 설치 등) — workflow 주석으로 사유 박제.
3. **step 명 통일**: "의존성 설치" / "앱 빌드" / "Playwright Chrome (Linux) 설치" 등 개소별로 상이하던 step 명이 composite 표준 명으로 통일 (명령 동일 — 과거 run 로그 검색 시 참고).

timeout 은 4개소 모두 기존 job-level bound (a11y/bootstrap 20분, bench/remeasure 30분) 그대로 유지 — composite 내부 step timeout 미지원 제약과 무관 (invocation-level 추가 불요).

### inputs YAGNI 판단 (완료 조건 4)

신규 4개소 치환에서 `playwright` / `build` 의 실사용 (`'false'` 지정) 이 발생하는지 먼저 판단 → **미발생** (4개소 전부 playwright + build 필요). 치환 후 전 호출부 7 workflow · **8 invocation** (ci.yml r1-guard / fps measure + retry-fresh-runner 2 invocation / shader / a11y / bench / remeasure bench / bootstrap) 전부 default `'true'` → **제거 확정** (reviewer 권고 2 카운트 명확화 — aeb2217). 유일한 잠재 소비처였던 remeasure aggregate job 은 composite 자체가 부적합 (의도적 차이 2) 이라 반증 불성립.

- 유지: `setup-node` (ci.yml 이 `'false'` 실사용) / `start-dev-server` (fps ×2 / shader / a11y 가 `'true'` 실사용)
- 재도입 필요 시 git history (#813, 348891c) 참조 — action.yml 주석으로 박제

### 실측 설계 — 본 PR run 으로 가드 발화 (완료 조건 1·2 동시 충족 경로)

pull_request 트리거는 PR 브랜치의 workflow 정의 (paths 필터 포함) 를 사용한다. 본 PR 이 (a) paths-ignore 를 `.github/workflows/**` 로 좁히고 (b) `.github/actions/setup-and-build/action.yml` 을 변경 (inputs 제거) 하므로, **좁혀진 필터 하에서 action.yml 이 비무시 경로로 남아 shader / fps / a11y 가드가 본 PR run 으로 발화** = paths-ignore 축소의 발화 실측 (완료 조건 2) 과 각 workflow 첫 composite run green (완료 조건 1) 을 본 PR 시점에 동시 실측. #813 머지 후 관찰 1항 (shader 첫 composite run) 도 이 경로로 해소.

| workflow | 본 PR 실측 경로 | 결과 |
|---|---|---|
| a11y-baseline-guard | PR run (paths-ignore 축소 + action.yml 변경으로 발화) — 첫 composite run | **발화 실측 ✅** — [run 28946969481](https://github.com/coseo12/astro-simulator/actions/runs/28946969481) → **success** (첫 composite run green) |
| bench:scene | PR run (positive paths: bench.yml + action.yml 변경) — 첫 composite run | **발화 실측 ✅** — [run 28946969633](https://github.com/coseo12/astro-simulator/actions/runs/28946969633) → **success** (첫 composite run green) |
| shader-pixel-guard | PR run — #813 머지 후 관찰 1항을 본 PR 시점 실측으로 해소 | **발화 실측 ✅** — [run 28946969579](https://github.com/coseo12/astro-simulator/actions/runs/28946969579) → **success** (첫 composite run green — **#813 머지 후 관찰 1항 해소**) |
| fps-baseline-guard | PR run — paths-ignore 축소 후 발화 실측 (composite 경로 자체는 #813 dispatch 실측 완료) | **발화 실측 ✅** — [run 28946968936](https://github.com/coseo12/astro-simulator/actions/runs/28946968936) → **success** |
| CI detect-and-test | PR run (paths 필터 없음) — composite inputs 제거 후 r1-guard 경로 | **발화 실측 ✅** — [run 28946969641](https://github.com/coseo12/astro-simulator/actions/runs/28946969641) → **success** |
| bench-baseline-remeasure | 사전 실측 불가 — 하단 머지 후 관찰 2항 | — |
| r1-baseline-bootstrap | 사전 실측 불가 — 하단 머지 후 관찰 3항 | — |

**캐시 정책**: 캐시 삭제 없음 — 히트/미스 양 경로는 #813 에서 실측 완료 (fps dispatch attempt 1 히트 / attempt 2 미스). 본 PR 은 동일 composite 재사용이므로 반복 불필요.

### 머지 후 관찰 항목 (#759/#813 선례)

- [ ] **shader-pixel-guard workflow_dispatch discover**: 2단계 함정 (volt #45) — dispatch 버튼은 본 트리거가 default branch (main) 에 반영된 후에만 표시. 다음 release 로 main 반영 후 1회 dispatch 실행 검증 (완료 조건 3 의 "main 반영 후 실행 검증")
- [ ] **r1-baseline-bootstrap composite 경로**: dispatch 전용 + **부작용 존재** (R1 baseline 12장 재캡처 → `peter-evans/create-pull-request` 로 갱신 PR 자동 생성 = baseline 오염 위험) → 사전 dispatch 실측 금지 판단. 정적 등가 대조 (위 대응표) 로 대체 — 다음 자연 dispatch (baseline 갱신 필요 시점) 에서 setup 구간 green 확인
- [ ] **bench-baseline-remeasure composite 경로**: 동일 사유 (dispatch 전용 + baseline.json 갱신 PR 자동 생성 부작용) → 다음 자연 dispatch 에서 확인. setup 구간은 bench.yml 과 동일 composite 호출 (본 PR bench 실측이 간접 증거)

참고 — **#813 머지 후 관찰 2항 (fps develop 경로) 해소**: 메인이 develop ref 로 dispatch 한 [run 28946143017](https://github.com/coseo12/astro-simulator/actions/runs/28946143017) → **success**. 이로써 #813 머지 후 관찰 2항 (shader 첫 composite run / fps develop 경로) 은 전부 green 실측으로 종결.

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 — 이슈 #814 완료 조건 5항 (4개소 치환 + 실측 / paths-ignore 축소 + 발화 실측 / shader dispatch / inputs YAGNI / ci.yml 오참조)
- [x] 모든 완료 기준 충족 — 단 dispatch 전용 2 workflow 와 shader dispatch discover 는 사전 실측 구조적 불가 (위 "머지 후 관찰 항목", #759/#813 선례 준용)

### 테스트
- [x] 단위 테스트 추가/수정 — N/A: CI 인프라 (workflow YAML) 만 변경, 앱 코드 0줄. 검증은 YAML 정적 파싱 + workflow 실측 (위 실측 설계)
- [x] 기존 테스트 통과 확인 — detect-and-test PR run green 으로 확인 (pnpm test + 가드 전체 경로)
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인 — N/A: 워크스페이스 변경 없음

### Test plan — CI workflow 실측 (완료 조건 1·2)

- [x] 변경 8 파일 YAML 정적 파싱 PASS (PyYAML safe_load 전수)
- [x] 제거된 `inputs.playwright` / `inputs.build` 잔존 참조 0 (grep 전수)
- [x] 한글 인코딩 U+FFFD 0 (`grep -rn '�' .github/`)
- [x] harness drift 데코레이터 가드 PASS (`verify-harness-drift-decorator.mjs` — 변경 파일 전부 비 harness-managed 확인)
- [x] 본 PR run 발화 실측: shader / fps / a11y / bench / CI 5개 전부 발화 확인 (위 실측 설계 표 run 링크) — **paths-ignore 축소가 composite 변경 PR 에서 가드를 발화시킴을 실측** (완료 조건 2)
- [x] 본 PR run green: 5개 전부 **success** (a11y [28946969481](https://github.com/coseo12/astro-simulator/actions/runs/28946969481) / bench [28946969633](https://github.com/coseo12/astro-simulator/actions/runs/28946969633) / shader [28946969579](https://github.com/coseo12/astro-simulator/actions/runs/28946969579) / fps [28946968936](https://github.com/coseo12/astro-simulator/actions/runs/28946968936) / CI [28946969641](https://github.com/coseo12/astro-simulator/actions/runs/28946969641)) — 완료 조건 1 (4개소 중 PR 발화 가능 2개소 + 기존 3 workflow 무회귀) + 완료 조건 2 (paths-ignore 축소 후 composite 변경 PR 에서 가드 발화) 실측 성립. #813 머지 후 관찰 1항 (shader) 은 본 PR 실측으로, 2항 (fps develop) 은 dispatch run [28946143017](https://github.com/coseo12/astro-simulator/actions/runs/28946143017) success 로 해소

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [x] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경 (ADR 20260701-779 §A1 재검토 7 종결 각주는 #813 에서 박제 완료 — 본 PR 은 그 종결의 잔여 이행)
- [ ] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR:
  - 검증 결과: 호환 / 비호환 (이유):

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [x] **[1/3] 정적**: N/A — UI 변경 0 (CI 인프라만). 대체 증거: 본 PR 의 가드 run green (r1-guard 픽셀 diff + a11y 실 브라우저 측정 포함)
- [x] **[2/3] 인터랙션**: N/A — 동일 (대체 증거: detect-and-test 의 브라우저 가드 9종 실경로)
- [x] **[3/3] 흐름**: N/A — 동일
- [x] verify 스크립트(있는 경우) 경로: N/A — 신규 verify 스크립트 없음 (기존 가드 스크립트 무변경)

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 feature PR

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 feature PR

### 체크리스트
- [x] 커밋 컨벤션 준수 — `chore(infra): ...` + #814 ref (#813 선례)
- [x] 불필요한 변경 없음 — 이슈 완료 조건 5항 외 변경 0 (remeasure aggregate job 은 의도적 미치환 — 사유 주석 박제)
- [x] 보안 취약점 없음 — 신규 외부 action 0 (기존 사용 action 의 composite 이동만), 권한 변경 0. paths-ignore 축소는 가드 강화 방향 (발화 범위 확대)
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145) — N/A: 스키마 미수정
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드) — N/A: 에이전트/스킬 행동 규칙 미변경. 본 PR 은 #813 에서 이행 확정된 방향 (composite SSoT) 의 잔여 정비로 신규 결정 없음

### 관련 이슈
Closes #814


