### PR TITLE
[#790] focus 최대 줌인 lowerRadiusLimit 시각 반경 하한 — mesh 내부 진입 암전 차단

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,8 @@
     "verify:773-light": "node scripts/browser-verify-773-light.mjs",
     "verify:774-sun": "node scripts/browser-verify-774-sun.mjs",
     "verify:782-rotation": "node scripts/browser-verify-782-rotation.mjs",
-    "verify:783-earth-detail": "node scripts/browser-verify-783-earth-detail.mjs"
+    "verify:783-earth-detail": "node scripts/browser-verify-783-earth-detail.mjs",
+    "verify:790-focus-zoom": "node scripts/browser-verify-790-focus-zoom.mjs"
   },
   "dependencies": {
     "@astro-simulator/core": "workspace:*",

--- a/apps/web/scripts/browser-verify-790-focus-zoom.mjs
+++ b/apps/web/scripts/browser-verify-790-focus-zoom.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * #790 fix 회귀 가드 — focus body 최대 줌인 시 카메라 mesh 내부 진입 암전 차단.
+ *
+ * 사용법:
+ *   pnpm --filter @astro-simulator/web verify:790-focus-zoom
+ *   CAPTURE_DIR=docs/reports/790-focus-zoom pnpm --filter @astro-simulator/web verify:790-focus-zoom
+ *
+ * ## 배경 (#774 qa 발견, 사전 존재)
+ *
+ * `?focus=sun` 최대 줌인 시 lowerRadiusLimit(0.5) < sun mesh 시각 반경(2.92) → 카메라가
+ * mesh 내부 진입 → backface culling 으로 화면 암전. 대조표 실측 32/32 body 전수 침범
+ * (tier 전환 body 는 가드 A `targetRadius×0.01` ≈ 표면 94% 안쪽).
+ * fix = focus 경로 2곳 (focusOn / runTierTransition) 에서 `min(visualR × 1.05, desiredR)` 하한 상향.
+ *
+ * ## 검증 시나리오 (3 — focus 경로 × tier 전환 유무 직교)
+ *
+ * | 시나리오 | 경로 | DoD |
+ * |---|---|---|
+ * | S1. ?focus=sun (URL, 원 재현) | focusOn 단독 (tier 무전환 solar) | radius ≥ visualR + 중앙 luminance ≥ 임계 |
+ * | S2. jupiter focus (버튼 경로) | focusOn + 줌인 중 inner→body 전환 | 동일 |
+ * | S3. saturn focus (버튼 경로) | 동일 (ring 동반 대형 body) | 동일 |
+ *
+ * 판정 (2축 AND):
+ *  1. 기하: 최대 줌인 radius ≥ mesh 시각 반경 — 표면 밖 보장. 시각 반경은 회전 불변 정의
+ *     `max(boundingBox.extendSize × |scaling|)` (core resolveMeshVisualRadius 와 동일 식).
+ *     boundingSphere.radiusWorld 는 box 외접구 √3 과대 + #782 자전 위상 진동 (jupiter 실측
+ *     33.2~34.8 unit) 이라 판정 기반 부적합 — 진단 보고만.
+ *  2. 픽셀: 중앙 crop 평균 luminance ≥ DARK_THRESHOLD (암전 0 정량) — 침범 시 mesh 미렌더
+ *     (backface culling) 로 배경 starfield/글로우 잔존만 남아 ≈ 9 (수정 전 실측), 정상 시
+ *     표면이 화면을 채워 ≫ 임계 (Playwright composited screenshot + 페이지 내 2D getImageData —
+ *     WebGPU drawImage readback 빈 버퍼 함정 회피, #728 SSoT)
+ *
+ * dev 빌드 의존: window.__solarScene (meshes Map / getTier) + window.__simStore (setSelectedBody)
+ * 환경변수: BASE_URL (기본 http://localhost:3000) / CAPTURE_DIR (PNG 저장, 미지정 시 생략)
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { chromium } from 'playwright';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const CAPTURE_DIR = process.env.CAPTURE_DIR ?? '';
+const args = process.argv.slice(2);
+const flags = { json: args.includes('--json') };
+
+const VIEWPORT = { width: 1280, height: 720 };
+const SETTLE_MS = 2500;
+// 암전 판정 임계 (0~255 luminance). 수정 전 실측 (2026-07-09, PR #790 본문 대조표):
+// 침범 상태 sun 중앙 crop 평균 = 9.2 (backface culling — 잔존 glow/starfield 만).
+// 정상 상태 실측: jupiter 36.6 / saturn 42.2 / sun 150+. 20 은 두 상태를 양방향 마진으로 분리.
+const DARK_THRESHOLD = 20;
+// 중앙 crop 크기 — 화면 중앙 정사각 (짧은 축의 1/3). focus body 는 항상 화면 중앙.
+const CROP_RATIO = 1 / 3;
+// 최대 줌인 수렴 판정: 1 iteration (휠 8틱) 후 radius 상대 변화 < 0.3% 면 lowerRadiusLimit 도달.
+const ZOOM_CONVERGE_EPS = 0.003;
+const MAX_ZOOM_ITERS = 80;
+const WHEEL_TICKS_PER_ITER = 8;
+
+async function bootstrap(page, urlSuffix = '') {
+  await page.goto(`${BASE_URL}/?gpu=a&lod=auto${urlSuffix}`, {
+    waitUntil: 'networkidle',
+    timeout: 30_000,
+  });
+  await page.waitForFunction(
+    () => typeof window.__solarScene !== 'undefined' && typeof window.__simStore !== 'undefined',
+    { timeout: 15_000 },
+  );
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+/** 카메라/focus mesh 상태 측정 — 시각 반경은 회전 불변 (local extendSize × scaling, #611 갱신 후). */
+async function measure(page, bodyId) {
+  return await page.evaluate((id) => {
+    const solar = window.__solarScene;
+    const mesh = solar?.meshes?.get?.(id);
+    if (!mesh) return { error: `no mesh: ${id}` };
+    const scene = mesh.getScene();
+    const cam = scene?.activeCamera;
+    if (!cam) return { error: 'no camera' };
+    mesh.computeWorldMatrix(true);
+    const bi = mesh.getBoundingInfo();
+    const ext = bi.boundingBox.extendSize;
+    const s = mesh.scaling;
+    // core resolveMeshVisualRadius 와 동일 식 (회전 불변 시각 반경).
+    const visualRadius = Math.max(
+      ext.x * Math.abs(s.x),
+      ext.y * Math.abs(s.y),
+      ext.z * Math.abs(s.z),
+    );
+    return {
+      tier: solar.getTier ? solar.getTier() : 'unknown',
+      radius: cam.radius,
+      lowerRadiusLimit: cam.lowerRadiusLimit,
+      visualRadius,
+      boundingRadiusWorld: bi.boundingSphere.radiusWorld, // 진단 보고용 (판정 미사용)
+    };
+  }, bodyId);
+}
+
+/** 최대 줌인 — radius 수렴 (lowerRadiusLimit 도달) 까지 실 휠 이벤트 반복. */
+async function zoomInToLimit(page, bodyId) {
+  await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+  let prev = await measure(page, bodyId);
+  for (let iter = 0; iter < MAX_ZOOM_ITERS; iter += 1) {
+    for (let t = 0; t < WHEEL_TICKS_PER_ITER; t += 1) {
+      await page.mouse.wheel(0, -120);
+      await page.waitForTimeout(60);
+    }
+    // tier 전환 (입력 잠금 ≤ 500ms + radius tween) 완료 대기 여유.
+    await page.waitForTimeout(400);
+    const cur = await measure(page, bodyId);
+    if (cur.error) return cur;
+    const rel = Math.abs(cur.radius - prev.radius) / Math.max(prev.radius, 1e-12);
+    prev = cur;
+    if (rel < ZOOM_CONVERGE_EPS) break;
+  }
+  return prev;
+}
+
+/**
+ * 중앙 crop 평균 luminance — canvas composited screenshot → 페이지 내 Image 디코드 →
+ * 2D getImageData (Rec.601). WebGPU readback 함정 회피 (#728 SSoT, glow-marker 동일 경로).
+ */
+async function centerLuminance(page, captureName) {
+  const canvas = page.locator('canvas').first();
+  const buf = await canvas.screenshot();
+  if (CAPTURE_DIR && captureName) {
+    await mkdir(CAPTURE_DIR, { recursive: true });
+    await writeFile(path.join(CAPTURE_DIR, `${captureName}.png`), buf);
+  }
+  const b64 = buf.toString('base64');
+  return page.evaluate(
+    async ({ b64, cropRatio }) => {
+      const img = new Image();
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = reject;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+      const w = img.width;
+      const h = img.height;
+      const off = document.createElement('canvas');
+      off.width = w;
+      off.height = h;
+      const ctx = off.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const crop = Math.floor(Math.min(w, h) * cropRatio);
+      const x0 = Math.floor((w - crop) / 2);
+      const y0 = Math.floor((h - crop) / 2);
+      const data = ctx.getImageData(x0, y0, crop, crop).data;
+      let sum = 0;
+      const n = crop * crop;
+      for (let i = 0; i < n; i += 1) {
+        // Rec.601 luminance — r1-guard / glow-marker 와 동일 식.
+        sum += 0.299 * data[i * 4] + 0.587 * data[i * 4 + 1] + 0.114 * data[i * 4 + 2];
+      }
+      return { meanLum: sum / n, crop };
+    },
+    { b64, cropRatio: CROP_RATIO },
+  );
+}
+
+async function runScenario(browser, { name, bodyId, urlFocus }) {
+  console.log(`\n[${name}] ${bodyId} focus → 최대 줌인 (침범/암전 판정)`);
+  const context = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  try {
+    if (urlFocus) {
+      await bootstrap(page, `&focus=${bodyId}`);
+    } else {
+      await bootstrap(page);
+      await page.evaluate((id) => window.__simStore?.getState?.().setSelectedBody?.(id), bodyId);
+      await page.waitForTimeout(SETTLE_MS);
+    }
+
+    const atFocus = await measure(page, bodyId);
+    const atLimit = await zoomInToLimit(page, bodyId);
+    if (atLimit.error) {
+      console.log(`  측정 실패: ${atLimit.error}`);
+      return { scenario: name, bodyId, error: atLimit.error, pass: false };
+    }
+    const lum = await centerLuminance(page, `790-${bodyId}-max-zoom`);
+
+    const geomPass = atLimit.radius >= atLimit.visualRadius;
+    const pixelPass = lum.meanLum >= DARK_THRESHOLD;
+    const pass = geomPass && pixelPass;
+    console.log(
+      `  focus(tier=${atFocus.tier} r=${atFocus.radius?.toFixed(2)}) → max-zoom(tier=${atLimit.tier} ` +
+        `r=${atLimit.radius.toFixed(2)} lower=${atLimit.lowerRadiusLimit?.toFixed(2)} ` +
+        `visualR=${atLimit.visualRadius.toFixed(2)} boundingRW=${atLimit.boundingRadiusWorld?.toFixed(2)})`,
+    );
+    console.log(
+      `  기하 r/visualR=${(atLimit.radius / atLimit.visualRadius).toFixed(3)} (≥1 요구) → ${geomPass ? 'PASS' : 'FAIL'} | ` +
+        `픽셀 중앙 lum=${lum.meanLum.toFixed(1)} (≥${DARK_THRESHOLD} 요구) → ${pixelPass ? 'PASS' : 'FAIL'} | ` +
+        `콘솔 에러=${consoleErrors.length}`,
+    );
+    return {
+      scenario: name,
+      bodyId,
+      tierAtLimit: atLimit.tier,
+      radiusAtLimit: atLimit.radius,
+      lowerRadiusLimit: atLimit.lowerRadiusLimit,
+      visualRadius: atLimit.visualRadius,
+      boundingRadiusWorld: atLimit.boundingRadiusWorld,
+      radiusOverVisualR: atLimit.radius / atLimit.visualRadius,
+      meanLum: lum.meanLum,
+      consoleErrors: consoleErrors.length,
+      geomPass,
+      pixelPass,
+      pass,
+    };
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  console.log('\n=== #790 focus 최대 줌인 mesh 침범/암전 회귀 가드 ===');
+  console.log(`  base URL: ${BASE_URL}  임계: r/visualR ≥ 1 AND 중앙 lum ≥ ${DARK_THRESHOLD}`);
+
+  const browser = await chromium.launch({ headless: true });
+  const result = { timestamp: new Date().toISOString(), baseUrl: BASE_URL, scenarios: {} };
+  let allPass = true;
+  try {
+    result.scenarios.s1 = await runScenario(browser, {
+      name: 'S1',
+      bodyId: 'sun',
+      urlFocus: true, // 원 재현 경로 (?focus=sun)
+    });
+    result.scenarios.s2 = await runScenario(browser, { name: 'S2', bodyId: 'jupiter' });
+    result.scenarios.s3 = await runScenario(browser, { name: 'S3', bodyId: 'saturn' });
+    for (const s of Object.values(result.scenarios)) {
+      if (!s.pass) allPass = false;
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log('\n=== 최종 요약 ===');
+  for (const [k, s] of Object.entries(result.scenarios)) {
+    console.log(`  ${k} (${s.bodyId}): ${s.pass ? 'PASS' : 'FAIL'}`);
+  }
+  console.log(`  overall: ${allPass ? 'PASS' : 'FAIL'}`);
+
+  if (flags.json) {
+    console.log('\n--- JSON ---');
+    console.log(JSON.stringify(result, null, 2));
+  }
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/core/src/scene/camera-controller.ts
+++ b/packages/core/src/scene/camera-controller.ts
@@ -32,6 +32,72 @@ export const FOCUS_USER_RADIUS_MULTIPLIER = 5;
  */
 export const FOCUS_USER_RADIUS_MIN_PADDING = 0.01;
 
+/**
+ * #790 — focus 시 lowerRadiusLimit 의 시각 반경 (resolveMeshVisualRadius) 대비 안전 마진.
+ *
+ * 카메라 radius 가 mesh 시각 반경 이하로 내려가면 카메라가 mesh 내부로 진입해 backface
+ * culling 으로 화면 전체 암전 (#774 qa 실측: `?focus=sun` lowerRadiusLimit 0.5 < sun 시각
+ * 반경 2.92). 마진 5% 근거:
+ *  - 표면 밖 유지가 목적이므로 1.0 초과 최소치면 충분 — 과대 마진은 근접 관찰 UX 를 깎고,
+ *    inner tier 대형 planet (jupiter/saturn) 에서 body tier 진입 경계 (0.1 AU) 를 침범할
+ *    여지를 만든다 (시각 반경 15.3 × 1.05 = 16.0 < 23 unit — 경계 대비 30% 여유)
+ *  - meshVisualRadius × 0.05 가 default minZ(0.01) 대비 충분히 커지는 body (시각 반경 ≥ 0.2
+ *    unit — 32 body 전수 침범 대상 전부 해당, #790 대조표) 에서 near-plane 이 mesh 표면과
+ *    교차하지 않는 여유 확보
+ *  - T1 극소 mesh (시각 반경 < 0.2, venus 관찰 모드 등 #378 완화 경로) 에서는 floor 가
+ *    기존 완화값(≥ minZ)보다 작아 바인딩되지 않음 → #378 무회귀
+ */
+export const FOCUS_LOWER_RADIUS_SURFACE_MARGIN = 1.05;
+
+/**
+ * #790 — focus body 의 lowerRadiusLimit 하한 (시각 반경 기반) 산출.
+ *
+ * `min(meshVisualRadius × 1.05, desiredRadius)` — desiredRadius 상한 clamp 는 "focus 프레이밍
+ * radius 는 항상 도달 가능" 불변식 보장 (floor > desiredRadius 면 Babylon _checkLimits 가
+ * 프레이밍 radius 를 floor 로 강제 상향해 focus 연출 자체가 깨짐). 32 body 전수에서
+ * `meshVisualRadius ≤ floor ≤ desiredRadius` 성립 확인 (#790 대조표 — desiredRadius 는
+ * boundingSphere.radiusWorld(≥ 시각 반경) × ≥5 또는 + 0.01 이므로 수학적으로도 항상 floor 초과).
+ *
+ * meshVisualRadius 는 `resolveMeshVisualRadius` (회전 불변) 를 전달할 것 —
+ * boundingSphere.radiusWorld 는 (1) box 외접구라 시각 반경 × √3 상시 과대, (2) #782 자전
+ * quaternion 위상에 따라 world AABB 가 진동해 (jupiter 실측 33.2~34.8 unit vs 시각 반경 15.3)
+ * 비결정적. bounding 기준 floor 는 jupiter/saturn 에서 body tier 진입 경계 (0.1 AU ≈ 23 unit,
+ * inner tier) 를 초과해 줌인 escalation 을 차단하는 신규 회귀를 만든다 (2026-07-09 실측).
+ *
+ * 호출처 (2곳 — 어느 한쪽만 적용 시 나머지 경로가 floor 를 되돌리는 회귀):
+ *  - `CameraController.focusOn` — user-trigger focus (버튼 / URL). tier 무전환 케이스
+ *    (sun: solar→solar) 는 이 경로만 floor 를 세울 수 있다
+ *  - `runTierTransition` (focusMesh 경로) — focus 중 tier 전환이 lowerRadiusLimit 을
+ *    `targetRadius × 0.01` (≈ 표면 94% 안쪽) 로 재설정하므로 재적용 필수
+ */
+export function computeFocusLowerRadiusFloor(
+  meshVisualRadius: number,
+  desiredRadius: number,
+): number {
+  return Math.min(meshVisualRadius * FOCUS_LOWER_RADIUS_SURFACE_MARGIN, desiredRadius);
+}
+
+/**
+ * #790 — mesh 의 회전 불변 시각 반경 (scene unit).
+ *
+ * `max(boundingBox.extendSize(local) 각 축 × |scaling| 각 축)` — sphere mesh 의 local 반경에
+ * tier scaling 을 곱한 값으로, `diameter = radius × 2 × renderScale × bodyScale` 생성식의
+ * 반경과 일치한다 (saturn solar tier 실측 0.7130 vs 산식 0.7128).
+ *
+ * boundingSphere.radiusWorld 를 쓰지 않는 이유는 computeFocusLowerRadiusFloor 주석 참조
+ * (√3 과대 + #782 자전 위상 진동). 본 함수는 회전과 무관하게 결정적이며, 축별 곱의 max 채택으로
+ * 비균등 scaling (oblate 등) 에서도 최대 반경 기준 보수 판정을 유지한다.
+ */
+export function resolveMeshVisualRadius(mesh: Mesh): number {
+  const { extendSize } = mesh.getBoundingInfo().boundingBox;
+  const { scaling } = mesh;
+  return Math.max(
+    extendSize.x * Math.abs(scaling.x),
+    extendSize.y * Math.abs(scaling.y),
+    extendSize.z * Math.abs(scaling.z),
+  );
+}
+
 export interface FocusTarget {
   /** 대상 메쉬 */
   mesh: Mesh;
@@ -149,6 +215,22 @@ export class CameraController {
     // tier-transition.ts:189 와 동일 패턴 — focus 트리거 한정 완화 (manual zoom 영향 0).
     if (this.camera.lowerRadiusLimit != null && desiredRadius < this.camera.lowerRadiusLimit) {
       this.camera.lowerRadiusLimit = Math.max(this.camera.minZ, desiredRadius * 0.5);
+    }
+
+    // #790 — focus 트리거 한정 lowerRadiusLimit 시각 반경 하한 (상향).
+    // #378 완화(하향)와 반대 방향: default 0.5 (또는 tier 전환의 targetRadius×0.01) 가 focus
+    // body 시각 반경보다 작으면 최대 줌인 시 카메라가 mesh 내부 진입 → backface culling 암전
+    // (#774 qa 실측 sun 2.92 vs 0.5 — 대조표상 32 body 전수 침범). 회전 불변 시각 반경 × 1.05
+    // 를 하한으로 올려 카메라가 항상 mesh 표면 밖에 머물게 한다. desiredRadius clamp 로 focus
+    // 프레이밍 도달성 보존. free-fly / reset 진입 시 sim-canvas 가 default 로 원복 (기존 동작).
+    if (this.camera.lowerRadiusLimit != null) {
+      const surfaceFloor = computeFocusLowerRadiusFloor(
+        resolveMeshVisualRadius(mesh),
+        desiredRadius,
+      );
+      if (this.camera.lowerRadiusLimit < surfaceFloor) {
+        this.camera.lowerRadiusLimit = surfaceFloor;
+      }
     }
 
     const targetPos = mesh.absolutePosition.clone();

--- a/packages/core/src/scene/focus-lower-radius-floor.test.ts
+++ b/packages/core/src/scene/focus-lower-radius-floor.test.ts
@@ -1,0 +1,230 @@
+/**
+ * #790 — focus body 최대 줌인 시 카메라 mesh 내부 진입 암전 회귀 가드.
+ *
+ * 현상: `?focus=sun` 에서 lowerRadiusLimit(0.5) < sun 시각 반경(2.922) → 최대 줌인 시
+ * 카메라가 mesh 내부 진입 → backface culling 화면 암전 (#774 qa 실측, 사전 존재).
+ * 대조표 실측 (모듈 로직 재현, PR 본문 박제): 32/32 body 전수 침범 —
+ *  - tier 무전환 (sun): default 0.5 vs meshR 2.922 (limit/meshR = 0.171)
+ *  - tier 전환 body: 가드 A `targetRadius×0.01 = meshR×0.059` — 표면 94% 안쪽
+ *
+ * fix: focus 경로 2곳 (focusOn / runTierTransition focusMesh) 에서
+ * `computeFocusLowerRadiusFloor(visualR, desiredR) = min(visualR × 1.05, desiredR)` 하한 상향.
+ * visualR = `resolveMeshVisualRadius` (local extendSize × scaling, 회전 불변) —
+ * boundingSphere.radiusWorld 는 box 외접구 √3 과대 + #782 자전 위상 진동으로 부적합
+ * (jupiter 실측 33.2~34.8 진동, floor 로 쓰면 body tier 진입 경계 23 unit 침범 회귀).
+ *
+ * 검증 대상 (Babylon 엔진/WebGL 불필요 — duck-typed mock + Animation static spy):
+ *  - FOCUS_LOWER_RADIUS_SURFACE_MARGIN 박제값 (1.05)
+ *  - computeFocusLowerRadiusFloor 순수식 + 불변식 (visualR ≤ floor ≤ desiredR)
+ *  - resolveMeshVisualRadius — 축별 extendSize × scaling 의 max (회전 불변 정의)
+ *  - CameraController.focusOn — sun 재현 케이스 + #378 극소 mesh 완화 무회귀
+ *  - runTierTransition — focusMesh 경로 floor 적용 / free-fly (focusMesh 없음) 무회귀
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Animation, Vector3 } from '@babylonjs/core';
+import type { ArcRotateCamera, Mesh, Scene } from '@babylonjs/core';
+
+import {
+  CameraController,
+  FOCUS_LOWER_RADIUS_SURFACE_MARGIN,
+  computeFocusLowerRadiusFloor,
+  resolveMeshVisualRadius,
+} from './camera-controller.js';
+import { runTierTransition, computeNewMinZ, computeLowerRadiusLimit } from './tier-transition.js';
+
+/** focusOn/runTierTransition 이 만지는 속성만 갖는 최소 카메라 모킹. */
+function mockCamera(lowerRadiusLimit = 0.5, minZ = 0.01): ArcRotateCamera {
+  return {
+    radius: 30,
+    minZ,
+    lowerRadiusLimit,
+    target: new Vector3(0, 0, 0),
+  } as unknown as ArcRotateCamera;
+}
+
+/**
+ * 시각 반경 기반 최소 mesh 모킹 — scaling=1 기본, local extendSize = 시각 반경 (균등 구체).
+ * boundingSphere.radiusWorld 는 실 Babylon 처럼 box 외접구 (시각 반경 × √3) 로 모킹해
+ * "bounding ≥ 시각 반경" 관계를 재현한다 — desiredRadius(프레이밍) 는 bounding 기준,
+ * floor 는 시각 반경 기준이라는 이원 구조가 production 과 동일하게 통과해야 한다.
+ */
+function mockMesh(visualRadius: number, scaling = { x: 1, y: 1, z: 1 }): Mesh {
+  const maxScale = Math.max(Math.abs(scaling.x), Math.abs(scaling.y), Math.abs(scaling.z));
+  return {
+    computeWorldMatrix: vi.fn(),
+    refreshBoundingInfo: vi.fn(),
+    scaling,
+    getBoundingInfo: () => ({
+      boundingSphere: { radiusWorld: visualRadius * maxScale * Math.sqrt(3) },
+      boundingBox: { extendSize: { x: visualRadius, y: visualRadius, z: visualRadius } },
+    }),
+    absolutePosition: new Vector3(0, 0, 0),
+    isDisposed: () => false,
+  } as unknown as Mesh;
+}
+
+function mockScene(): Scene {
+  return {
+    onBeforeRenderObservable: { add: vi.fn(), remove: vi.fn() },
+    detachControl: vi.fn(),
+    attachControl: vi.fn(),
+    stopAnimation: vi.fn(),
+    stopAllAnimations: vi.fn(),
+  } as unknown as Scene;
+}
+
+// Animation.CreateAndStartAnimation 은 실 scene/rendering loop 필요 — 정적 spy 로 차단.
+// focusOn/runTierTransition 의 lowerRadiusLimit 동기 로직만 검증 (tween 자체는 브라우저 가드 영역).
+beforeEach(() => {
+  vi.spyOn(Animation, 'CreateAndStartAnimation').mockReturnValue(null as never);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('#790 computeFocusLowerRadiusFloor — 순수식 + 불변식', () => {
+  it('FOCUS_LOWER_RADIUS_SURFACE_MARGIN 박제값 = 1.05', () => {
+    expect(FOCUS_LOWER_RADIUS_SURFACE_MARGIN).toBe(1.05);
+  });
+
+  it('정상 범위: meshR × 1.05 반환 (desiredR 여유 충분)', () => {
+    // sun: meshR 2.922 (solar tier 시각 반경), desiredR 14.61 (×5)
+    expect(computeFocusLowerRadiusFloor(2.922, 14.61)).toBeCloseTo(3.0681, 4);
+  });
+
+  it('desiredR clamp: floor 가 프레이밍 radius 를 초과하지 않는다 (도달성 불변식)', () => {
+    // 호출자가 명시 radius 를 meshR×1.05 미만으로 전달하는 방어 케이스.
+    expect(computeFocusLowerRadiusFloor(10, 5)).toBe(5);
+  });
+
+  it('대조표 대표 5 body — 불변식 visualR ≤ max(가드 A, floor) ≤ desiredR (production 합성식)', () => {
+    // #790 대조표 (모듈 로직 재현 스크립트 실측값 박제). tier 전환 body 는
+    // runTierTransition 의 합성: max(computeLowerRadiusLimit(targetTT, newMinZ), floor).
+    // targetTT 는 boundingSphere(≈ visualR × √3) × 5.9 — production 이원 구조 재현.
+    const V5_MULTIPLIER = 5.9; // tier-transition.ts FOCUS_RADIUS_MULTIPLIER
+    const SQRT3 = Math.sqrt(3);
+    const cases = [
+      { id: 'earth', visualR: 6.931e4 }, // planet → body tier
+      { id: 'jupiter', visualR: 14.24 }, // planet → inner tier
+      { id: 'moon', visualR: 4.72e3 }, // satellite (×20)
+      { id: 'eris', visualR: 2.96e4 }, // dwarf → body tier
+      { id: 'encke', visualR: 301.2 }, // comet (최소 시각 반경)
+    ];
+    for (const { visualR } of cases) {
+      const boundingR = visualR * SQRT3;
+      const targetTT = Math.max(boundingR * V5_MULTIPLIER, boundingR + 0.01);
+      const guardA = computeLowerRadiusLimit(targetTT, computeNewMinZ(targetTT));
+      const fixed = Math.max(guardA, computeFocusLowerRadiusFloor(visualR, targetTT));
+      expect(fixed).toBeGreaterThanOrEqual(visualR); // 표면 밖 보장
+      expect(fixed).toBeLessThanOrEqual(targetTT); // 프레이밍 도달성 보장
+      // 가드 A (targetTT×0.01 = visualR×0.102) vs floor (visualR×1.05) — floor 가 항상 우세.
+      expect(fixed).toBeCloseTo(visualR * FOCUS_LOWER_RADIUS_SURFACE_MARGIN, 6);
+    }
+  });
+});
+
+describe('#790 resolveMeshVisualRadius — 회전 불변 시각 반경', () => {
+  it('균등 구체: extendSize × scaling (saturn solar tier 실측 0.7130 재현)', () => {
+    expect(resolveMeshVisualRadius(mockMesh(0.713))).toBeCloseTo(0.713, 6);
+  });
+
+  it('tier scaling 반영: local 0.8335 × scaling 18.333 (jupiter inner tier 실측 15.28)', () => {
+    const mesh = mockMesh(0.8335, { x: 18.3333, y: 18.3333, z: 18.3333 });
+    expect(resolveMeshVisualRadius(mesh)).toBeCloseTo(15.28, 2);
+  });
+
+  it('비균등 scaling: 축별 곱의 max (oblate 보수 판정)', () => {
+    const mesh = mockMesh(1, { x: 2, y: 1.5, z: -3 });
+    expect(resolveMeshVisualRadius(mesh)).toBe(3); // |z| 축 우세 (음수 scaling 방어)
+  });
+
+  it('boundingSphere(√3 과대) 보다 항상 작거나 같다 — floor 기반 교체 근거', () => {
+    const mesh = mockMesh(2.922);
+    const visual = resolveMeshVisualRadius(mesh);
+    const bounding = mesh.getBoundingInfo().boundingSphere.radiusWorld;
+    expect(visual).toBeLessThan(bounding);
+    expect(bounding / visual).toBeCloseTo(Math.sqrt(3), 6);
+  });
+});
+
+describe('#790 CameraController.focusOn — lowerRadiusLimit 시각 반경 하한 (상향)', () => {
+  it('sun 재현: default 0.5 → visualR 2.922 × 1.05 로 상향 (침범 차단)', () => {
+    const camera = mockCamera(0.5);
+    const controller = new CameraController(camera, mockScene());
+    controller.focusOn({ mesh: mockMesh(2.922) });
+    expect(camera.lowerRadiusLimit).toBeCloseTo(2.922 * 1.05, 4);
+    expect(camera.lowerRadiusLimit!).toBeGreaterThan(2.922);
+  });
+
+  it('tier 전환 잔존 limit (earth body tier 가드 A 값) → visualR × 1.05 로 상향', () => {
+    // 대조표: earth visualR 6.931e4, 가드 A 잔존 limit (= targetTT × 0.01 ≈ visualR × 0.102)
+    const camera = mockCamera(4089);
+    const controller = new CameraController(camera, mockScene());
+    controller.focusOn({ mesh: mockMesh(6.931e4) });
+    expect(camera.lowerRadiusLimit).toBeCloseTo(6.931e4 * 1.05, 0);
+  });
+
+  it('#378 무회귀: 극소 mesh (T1 venus 관찰) — 완화(하향) 경로 유지, floor 비바인딩', () => {
+    // visualR 0.002 → boundingR 0.00346 → desiredR = boundingR + 0.01 = 0.01346 < 0.5
+    // → #378 완화 = max(minZ 0.01, desiredR × 0.5 = 0.00673) = 0.01.
+    // floor = min(0.002 × 1.05, 0.01346) = 0.0021 < 0.01 → floor 는 바인딩되지 않는다.
+    const camera = mockCamera(0.5, 0.01);
+    const controller = new CameraController(camera, mockScene());
+    controller.focusOn({ mesh: mockMesh(0.002) });
+    expect(camera.lowerRadiusLimit).toBeCloseTo(0.01, 6);
+  });
+
+  it('명시 radius 전달 시에도 floor 적용 (sim-canvas satellite ×20 경로)', () => {
+    // moon: visualR 4720, 명시 desiredR = 94400 → floor = min(4956, 94400) = 4956.
+    const camera = mockCamera(278.5); // 가드 A 잔존값 (대조표)
+    const controller = new CameraController(camera, mockScene());
+    controller.focusOn({ mesh: mockMesh(4720), radius: 94400 });
+    expect(camera.lowerRadiusLimit).toBeCloseTo(4720 * 1.05, 0);
+  });
+
+  it('프레이밍 도달성: 상향 후에도 lowerRadiusLimit ≤ desiredRadius', () => {
+    const camera = mockCamera(0.5);
+    const controller = new CameraController(camera, mockScene());
+    const visualR = 2.922;
+    controller.focusOn({ mesh: mockMesh(visualR) });
+    // desiredRadius = boundingSphere(visualR×√3) × 5 — floor(visualR×1.05) 는 항상 그 이하.
+    const desired = visualR * Math.sqrt(3) * 5;
+    expect(camera.lowerRadiusLimit!).toBeLessThanOrEqual(desired);
+  });
+});
+
+describe('#790 runTierTransition — focusMesh 경로 floor 적용', () => {
+  it('focusMesh 있음: lowerRadiusLimit ≥ visualR × 1.05 (가드 A 단독값 visualR×0.102 를 상향)', () => {
+    const camera = mockCamera(0.5);
+    const scene = mockScene();
+    const visualR = 6.931e4; // earth body tier 시각 반경 (대조표)
+    const cleanup = runTierTransition({
+      scene,
+      camera,
+      oldScale: 8.4e-11,
+      newScale: 2.51e-5,
+      focusMesh: mockMesh(visualR),
+    });
+    cleanup();
+    expect(camera.lowerRadiusLimit).toBeCloseTo(visualR * 1.05, 0);
+    expect(camera.lowerRadiusLimit!).toBeGreaterThan(visualR);
+    // 프레이밍 도달성: targetRadius (boundingR × 5.9 = visualR × √3 × 5.9) 이하.
+    expect(camera.lowerRadiusLimit!).toBeLessThanOrEqual(visualR * Math.sqrt(3) * 5.9);
+  });
+
+  it('focusMesh 없음 (free-fly 전환): 기존 #380 가드 A 값 유지 — 무회귀', () => {
+    const camera = mockCamera(0.5);
+    const scene = mockScene();
+    // free-fly 실거리 보존 수식: targetRadius = 30 × (1.54e-9 / 8.4e-11) ≈ 550.
+    const cleanup = runTierTransition({
+      scene,
+      camera,
+      oldScale: 8.4e-11,
+      newScale: 1.54e-9,
+    });
+    cleanup();
+    const targetRadius = (30 * 1.54e-9) / 8.4e-11;
+    const expected = computeLowerRadiusLimit(targetRadius, computeNewMinZ(targetRadius));
+    expect(camera.lowerRadiusLimit).toBeCloseTo(expected, 6);
+  });
+});

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -20,6 +20,9 @@ export {
   CameraController,
   FOCUS_USER_RADIUS_MULTIPLIER,
   FOCUS_USER_RADIUS_MIN_PADDING,
+  // #790 — focus body 시각 반경 기반 lowerRadiusLimit 하한 (mesh 내부 진입 암전 차단).
+  FOCUS_LOWER_RADIUS_SURFACE_MARGIN,
+  computeFocusLowerRadiusFloor,
 } from './camera-controller.js';
 export type { FocusTarget } from './camera-controller.js';
 // R4 #539 Amendment 3 — satellite focus multiplier 분기 SSoT.

--- a/packages/core/src/scene/tier-transition.ts
+++ b/packages/core/src/scene/tier-transition.ts
@@ -40,6 +40,10 @@ import {
   type Scene,
 } from '@babylonjs/core';
 
+// #790 — focus body 시각 반경 기반 lowerRadiusLimit 하한 (camera-controller SSoT).
+// camera-controller.ts 는 로컬 import 가 없어 본 방향 import 는 순환 없음.
+import { computeFocusLowerRadiusFloor, resolveMeshVisualRadius } from './camera-controller.js';
+
 /**
  * focus 대상 mesh 에서 카메라까지의 목표 radius 배수 — `meshBoundingRadius × N`.
  *
@@ -260,6 +264,9 @@ export function runTierTransition(opts: TierTransitionOptions): () => void {
   // 반영된 상태이므로 boundingSphere.radiusWorld 도 새 tier 기준.
   // 없으면 실거리 보존 수식 fallback (free-fly tier 전환 등 focus 없는 경로).
   let targetRadius: number;
+  // #790 — focusMesh 경로에서 시각 반경 하한 산출용 (회전 불변 — resolveMeshVisualRadius).
+  // 없으면 null (free-fly 전환 등 floor 미적용).
+  let focusMeshVisualRadius: number | null = null;
   if (focusMesh) {
     // #378 옵션 B — boundingInfo 갱신 강제 (defense-in-depth, ADR 가설 4).
     // setTier 가 mesh.scaling 을 newScale 로 갱신했더라도 boundingSphere.radiusWorld 가
@@ -272,6 +279,7 @@ export function runTierTransition(opts: TierTransitionOptions): () => void {
     focusMesh.refreshBoundingInfo();
     const boundingInfo = focusMesh.getBoundingInfo();
     const meshRadius = boundingInfo.boundingSphere.radiusWorld;
+    focusMeshVisualRadius = resolveMeshVisualRadius(focusMesh);
     targetRadius = Math.max(meshRadius * FOCUS_RADIUS_MULTIPLIER, meshRadius + 0.01);
   } else {
     targetRadius = computeTargetRadius(radiusOld, oldScale, newScale);
@@ -291,7 +299,19 @@ export function runTierTransition(opts: TierTransitionOptions): () => void {
   // 본 가드는 tier 진입 시점마다 `computeLowerRadiusLimit(targetRadius, newMinZ)` 로 양방향
   // 동기 → tier 별 적정 줌인 한계 (`targetRadius * 0.01`) 를 항상 보장.
   if (camera.lowerRadiusLimit != null) {
-    camera.lowerRadiusLimit = computeLowerRadiusLimit(targetRadius, newMinZ);
+    let nextLowerLimit = computeLowerRadiusLimit(targetRadius, newMinZ);
+    // #790 — focus body 시각 반경 하한 (camera-controller.focusOn 과 쌍 — 어느 한쪽만 적용 시
+    // 나머지 경로가 floor 를 되돌리는 회귀). `targetRadius × 0.01` (≈ meshRadius × 0.059) 는
+    // mesh 표면의 94% 안쪽이라 focus 중 tier 전환 (planet 줌인 inner→body 등) 후 최대 줌인 시
+    // 카메라가 mesh 내부 진입 → backface culling 암전. focus body 가 있을 때만 회전 불변
+    // 시각 반경 × 1.05 로 상향 (free-fly 전환은 기존 #380 가드 A 유지 — mesh 기준점 부재).
+    if (focusMeshVisualRadius != null) {
+      nextLowerLimit = Math.max(
+        nextLowerLimit,
+        computeFocusLowerRadiusFloor(focusMeshVisualRadius, targetRadius),
+      );
+    }
+    camera.lowerRadiusLimit = nextLowerLimit;
   }
 
   // (2) Pending tween 취소 — user focusOn 직후 tier 경계를 넘을 때 애니메이션 충돌 방지.


### PR DESCRIPTION
### 변경 사항

- **`computeFocusLowerRadiusFloor(visualR, desiredR) = min(visualR × 1.05, desiredR)`** 신설 (`camera-controller.ts`) — focus body 의 lowerRadiusLimit 하한 (상향). `desiredR` clamp 로 focus 프레이밍 도달성 불변식 보존
- **`resolveMeshVisualRadius(mesh)`** 신설 — 회전 불변 시각 반경 `max(boundingBox.extendSize × |scaling|)`. `boundingSphere.radiusWorld` 는 (1) box 외접구라 시각 반경 × √3 상시 과대, (2) #782 자전 quaternion 위상에 따라 world AABB 진동 (jupiter 실측 33.2~34.8 unit vs 시각 반경 15.3) 으로 floor 기반 부적합 — bounding 기준 floor 는 jupiter/saturn 에서 body tier 진입 경계 (0.1 AU ≈ 23 unit) 를 초과해 줌인 escalation 차단 회귀를 만든다 (실측 후 교체)
- **적용 지점 2곳** (어느 한쪽만 적용 시 나머지 경로가 floor 를 되돌리는 회귀):
  - `CameraController.focusOn` — user-trigger focus (버튼/URL). #378 완화(하향)는 유지하고 그 뒤에 시각 반경 하한(상향) 적용. tier 무전환 케이스 (sun: solar→solar) 는 이 경로가 유일
  - `runTierTransition` (focusMesh 경로) — #380 가드 A `computeLowerRadiusLimit` 값과 floor 의 max. free-fly 전환 (focusMesh 없음) 은 기존 가드 A 그대로 (무회귀)
- 신규 단위 테스트 15 (`focus-lower-radius-floor.test.ts`) + 신규 브라우저 가드 `verify:790-focus-zoom` (아래 참조)

### 원인 분석 (왜 발생했는가)

focus 경로의 lowerRadiusLimit 산출 2곳 모두 body 시각 반경을 고려하지 않았다:
1. `focusOn` — #378 완화는 **한 방향(하향)** 만 존재. default 0.5 가 sun 시각 반경 2.922 미만인데 상향 로직 부재
2. `runTierTransition` 가드 A — `targetRadius × 0.01` (≈ 시각반경 × 0.059) 은 mesh 표면과 무관한 식 → 표면 94% 안쪽까지 줌인 허용

→ 최대 줌인 시 카메라가 mesh 내부 진입 → backface culling 으로 화면 암전 (#774 qa 발견, 사전 존재).

### 32 body 전수 침범 대조표 (measurement-first, 모듈 로직 재현 — `scripts/_debug-790-tmp.mjs`, 사용 후 rm)

시나리오: 초기 로드 (tier=solar, lower=0.5, minZ=0.01) 에서 `?focus=<body>`. 시각반경 = 실반경 × renderScale × bodyScale(#762 곡선). **32/32 전수 침범** — sun 은 default 0.5 잔존 (limit/meshR 0.171), tier 전환 body 는 가드 A 구조상 일괄 0.059. "fix 후 limit" 는 본 PR 산식 `max(현 로직, min(시각반경×1.05, desiredR))` 적용값, 불변식 (시각반경 ≤ limit ≤ desiredR) 위반 0.

| body | kind | mult | focus tier | 시각반경 (unit) | desiredR | 현 limit | limit/meshR | 침범 | fix 후 limit |
|---|---|---|---|---|---|---|---|---|---|
| sun | star | ×5 | solar | 2.922 | 14.61 | 0.5000 | 1.71e-1 | **침범** | 3.068 |
| mercury | planet | ×5 | body | 4.287e+4 | 2.143e+5 | 2.529e+3 | 5.90e-2 | **침범** | 4.501e+4 |
| venus | planet | ×5 | body | 6.751e+4 | 3.376e+5 | 3.983e+3 | 5.90e-2 | **침범** | 7.089e+4 |
| earth | planet | ×5 | body | 6.931e+4 | 3.465e+5 | 4.089e+3 | 5.90e-2 | **침범** | 7.277e+4 |
| moon | moon | ×20 | body | 4.720e+3 | 9.440e+4 | 278.5 | 5.90e-2 | **침범** | 4.956e+3 |
| mars | planet | ×5 | body | 5.058e+4 | 2.529e+5 | 2.984e+3 | 5.90e-2 | **침범** | 5.310e+4 |
| phobos | moon | ×20 | body | 1.391e+3 | 2.781e+4 | 82.04 | 5.90e-2 | **침범** | 1.460e+3 |
| deimos | moon | ×20 | body | 786.9 | 1.574e+4 | 46.43 | 5.90e-2 | **침범** | 826.2 |
| jupiter | planet | ×5 | inner | 14.24 | 71.18 | 0.8400 | 5.90e-2 | **침범** | 14.95 |
| io | moon | ×20 | body | 1.232e+4 | 2.464e+5 | 727.0 | 5.90e-2 | **침범** | 1.294e+4 |
| europa | moon | ×20 | body | 1.056e+4 | 2.112e+5 | 622.9 | 5.90e-2 | **침범** | 1.109e+4 |
| ganymede | moon | ×20 | body | 1.782e+4 | 3.564e+5 | 1.051e+3 | 5.90e-2 | **침범** | 1.871e+4 |
| callisto | moon | ×20 | body | 1.629e+4 | 3.258e+5 | 961.1 | 5.90e-2 | **침범** | 1.710e+4 |
| saturn | planet | ×5 | inner | 13.07 | 65.36 | 0.7712 | 5.90e-2 | **침범** | 13.73 |
| titan | moon | ×20 | body | 1.896e+4 | 3.792e+5 | 1.119e+3 | 5.90e-2 | **침범** | 1.991e+4 |
| enceladus | moon | ×20 | body | 4.645e+3 | 9.289e+4 | 274.0 | 5.90e-2 | **침범** | 4.877e+3 |
| rhea | moon | ×20 | body | 1.406e+4 | 2.812e+5 | 829.6 | 5.90e-2 | **침범** | 1.476e+4 |
| iapetus | moon | ×20 | body | 1.353e+4 | 2.706e+5 | 798.2 | 5.90e-2 | **침범** | 1.421e+4 |
| uranus | planet | ×5 | inner | 8.513 | 42.56 | 0.5022 | 5.90e-2 | **침범** | 8.938 |
| titania | moon | ×20 | body | 8.560e+3 | 1.712e+5 | 505.1 | 5.90e-2 | **침범** | 8.988e+3 |
| oberon | moon | ×20 | body | 8.269e+3 | 1.654e+5 | 487.9 | 5.90e-2 | **침범** | 8.683e+3 |
| neptune | planet | ×5 | inner | 8.379 | 41.90 | 0.4944 | 5.90e-2 | **침범** | 8.798 |
| triton | moon | ×20 | body | 8.959e+3 | 1.792e+5 | 528.6 | 5.90e-2 | **침범** | 9.407e+3 |
| proteus | moon | ×20 | body | 1.393e+3 | 2.786e+4 | 82.19 | 5.90e-2 | **침범** | 1.463e+3 |
| ceres | dwarf-planet | ×5 | body | 1.881e+4 | 9.403e+4 | 1.110e+3 | 5.90e-2 | **침범** | 1.975e+4 |
| pluto | dwarf-planet | ×5 | body | 2.992e+4 | 1.496e+5 | 1.765e+3 | 5.90e-2 | **침범** | 3.141e+4 |
| haumea | dwarf-planet | ×5 | body | 2.424e+4 | 1.212e+5 | 1.430e+3 | 5.90e-2 | **침범** | 2.545e+4 |
| makemake | dwarf-planet | ×5 | body | 2.321e+4 | 1.160e+5 | 1.369e+3 | 5.90e-2 | **침범** | 2.437e+4 |
| eris | dwarf-planet | ×5 | body | 2.960e+4 | 1.480e+5 | 1.746e+3 | 5.90e-2 | **침범** | 3.108e+4 |
| halley | comet | ×5 | body | 690.3 | 3.451e+3 | 40.72 | 5.90e-2 | **침범** | 724.8 |
| encke | comet | ×5 | body | 301.2 | 1.506e+3 | 17.77 | 5.90e-2 | **침범** | 316.3 |
| swift-tuttle | comet | ×5 | body | 1.632e+3 | 8.158e+3 | 96.26 | 5.90e-2 | **침범** | 1.713e+3 |

> 주: 표의 desiredR 은 시각 반경 기준 근사 (모듈 재현). runtime 프레이밍은 boundingSphere(≈ 시각반경×√3) × mult 로 표보다 크므로 floor ≤ desiredR 여유는 실제로 더 넓다.

### 픽셀 실측 — 수정 전 재현 / 수정 후 해소 (verify:790-focus-zoom, 실측 쌍)

수정 전 (fix stash + core 재빌드 + dev fresh) / 수정 후 (fix 복원 + core 재빌드 + dev fresh). 판정 = 기하 (max-zoom radius ≥ 시각반경) AND 픽셀 (중앙 1/3 crop 평균 luminance ≥ 20, Rec.601 — Playwright composited screenshot + 페이지 내 2D getImageData, #728 SSoT).

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| S1 `?focus=sun` (원 재현) | r=0.5 clamp, r/visualR=0.17 (**mesh 내부**), 중앙 lum **9.2 (암전)** → FAIL | r=3.068 = visualR 2.922×1.05 정확 clamp, lum **231.8** → PASS |
| S2 jupiter focus | (침범 미도달 — 사전 존재 줌 stall) | r/visualR=2.34, lower=14.95 (=14.24×1.05), lum 35.5 → PASS |
| S3 saturn focus | (침범 미도달 — 동일) | r/visualR=2.96, lower=13.73 (=13.07×1.05), lum 42.4 → PASS |

- 스크린샷 (untracked 로컬 산출, #793 규약 — embed 아님): `docs/reports/790-focus-zoom/before/790-sun-max-zoom.png` (암전) / `after/790-{sun,jupiter,saturn}-max-zoom.png` (표면이 화면을 채움)
- 콘솔 에러: 전 시나리오 0

### 기존 가드 6종 무회귀 (로컬 전수 실행)

| 가드 | 결과 |
|---|---|
| verify:378-focus | **64/64 셀 PASS** (전 body focus 프레이밍 ratio 5.00 / targetΔ 0 / inFrustum) |
| verify:629-freefly-zoom | 2/2 PASS |
| verify:631-freefly-tier | 2/2 PASS |
| verify:699-freefly-unified | 7/7 PASS (s1~s6 + s3b) |
| verify:704-sensitivity | 6/6 PASS |
| verify:732-overview | 3/3 PASS |

free-fly / reset 은 sim-canvas 가 lowerRadiusLimit 을 default(0.5) 로 원복하는 기존 동작 그대로 — floor 는 focus 상태에서만 유효.

### 신규 회귀 가드 판단 (ROI)

`verify:790-focus-zoom` **신설** (`apps/web/scripts/browser-verify-790-focus-zoom.mjs`, npm `verify:790-focus-zoom`). 근거: 기존 6종 중 focus 상태 "최대 줌인 하한" 을 검증하는 가드 부재 (378 은 프레이밍 시점, 629/631/699 는 free-fly) — 직교 시나리오라 기존 확장 대신 신설. 시나리오 3 (sun URL 원 재현 / jupiter / saturn 버튼 경로) × 판정 2축 (기하 + 픽셀 luminance).

### Test plan

- [x] Unit: core **736/736** (15 new in `focus-lower-radius-floor.test.ts` — pure floor formula + invariants, `resolveMeshVisualRadius` rotation-invariant definition, `focusOn` sun repro / #378 tiny-mesh no-regression / explicit-radius path, `runTierTransition` focusMesh floor + free-fly no-regression) + web **481/481**
- [x] Typecheck: `pnpm --filter @astro-simulator/core typecheck` 0 errors (#719 guard) + web typecheck 0 errors
- [x] Browser (pixel): before/after evidence pair — `?focus=sun` max zoom-in center luminance 9.2 (blackout, camera inside mesh) → 231.8 (surface fills viewport); jupiter/saturn 35.5/42.4, console errors 0
- [x] New guard: `pnpm --filter @astro-simulator/web verify:790-focus-zoom` — 3/3 PASS
- [x] Existing guards: verify:378 (64/64) / 629 / 631 / 699 / 704 / 732 — all PASS locally

### 브랜치 / Base 확인 (gitflow)
PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허용 (CLAUDE.md 금지 사항).
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*` 또는 `fix/*`
- [ ] **Release PR**: `base=main`, `head=develop` (CHANGELOG 범위 + 태그 계획 하단 release 섹션에 기재)
- [ ] **Hotfix PR**: `base=main`, `head=hotfix/*` (머지 직후 `main → develop` merge-back PR 생성 의무)
- [ ] **Hotfix merge-back**: `base=develop`, `head=main` (hotfix 직후 동기화 전용)

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (이슈 #790 완료 조건 3항)
- [x] 모든 완료 기준 충족 — (1) `?focus=sun` 최대 줌인 표면 밖 유지 + 암전 0 (lum 231.8), (2) jupiter/saturn 동일 검증 (r/visualR 2.34/2.96, lum 35.5/42.4), (3) 가드 6종 무회귀 전수 PASS

### 테스트
- [x] 단위 테스트 추가/수정 (신규 15 — focus-lower-radius-floor.test.ts)
- [x] 기존 테스트 통과 확인 (core 736/736 + web 481/481)
- [x] 모노레포: 신규/변경 워크스페이스에 `scripts.test` 존재 확인 (신규 워크스페이스 없음 — 기존 core/web 만 변경)

### ADR 호환성 체크 (docs/decisions/ 변경 시 필수, reviewer.md §절차 5 정합)
적용 비대상이면 자명 PASS. 적용 대상이면 grep 1차 (`Amendment` / `폐기` / `Supersedes` / `§재검토 조건`) + LLM 2차 의미론적 검증.
- [x] **적용 비대상**: 본 PR 은 `docs/decisions/` 미변경
- [ ] **적용 대상**: `docs/decisions/` 변경 포함. 변경 ADR + 검증 결과 박제:
  - 변경 ADR:
  - 검증 결과: 호환 / 비호환 (이유):

### 브라우저 3단계 검증 (UI 변경 포함 시 필수)
빌드 통과 ≠ 동작 통과. 아래 증거를 첨부한다 (최소 1가지).
- [x] **[1/3] 정적**: 렌더링 OK, 콘솔 에러 0 — 스크린샷 경로: `docs/reports/790-focus-zoom/after/790-sun-max-zoom.png` (max zoom 표면 렌더, 전 시나리오 콘솔 에러 0)
- [x] **[2/3] 인터랙션**: 버튼/폼/토글 동작 — 스크린샷 경로: `docs/reports/790-focus-zoom/after/790-jupiter-max-zoom.png` (focus 버튼 경로 setSelectedBody + 실 휠 줌인 반복 → clamp 수렴)
- [x] **[3/3] 흐름**: URL↔상태, 네비게이션 — 스크린샷 경로: `docs/reports/790-focus-zoom/before/790-sun-max-zoom.png` vs `after/` (URL `?focus=sun` → focus 상태 → 최대 줌인 전/후 쌍, `docs/reports/790-focus-zoom/after/790-saturn-max-zoom.png` 포함)
- [x] verify 스크립트(있는 경우) 경로: `apps/web/scripts/browser-verify-790-focus-zoom.mjs`

### 마일스톤 회고 (마일스톤 종료 PR만)
- [x] N/A — 마일스톤 종료 PR 아님 (단일 버그 fix)

### Release PR 전용 (base=main, head=develop)
- [x] N/A — 일반 fix PR

### Hotfix PR 전용 (base=main, head=hotfix/*)
- [x] N/A — 일반 fix PR

### 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 불필요한 변경 없음
- [x] 보안 취약점 없음
- [x] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145) — 해당 없음 (스키마 미수정)
- [x] **정책·규약·ADR·CRITICAL DIRECTIVE 박제 변경 포함 시** (CLAUDE.md / `.claude/agents/*.md` / `.claude/skills/*/SKILL.md` 행동 규칙 신규·수정): cross-validate 박제 직후 1회 루틴 (volt #23) 수행 + outcome 박제 (위치 우선순위 — CHANGELOG Notes > ADR 각주 > 커밋 > PR 코멘트, 중복 금지). API 429 폴백 시 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 명시 (#240 가드) — 해당 없음 (정책·규약 파일 미변경)

### 관련 이슈
Closes #790
